### PR TITLE
fix(dashboard): hide +Cursor button for non-manual-auth providers

### DIFF
--- a/Quotio/Views/Screens/DashboardScreen.swift
+++ b/Quotio/Views/Screens/DashboardScreen.swift
@@ -480,7 +480,7 @@ struct DashboardScreen: View {
                         ProviderChip(provider: provider, count: viewModel.authFilesByProvider[provider]?.count ?? 0)
                     }
                     
-                    ForEach(viewModel.disconnectedProviders) { provider in
+                    ForEach(viewModel.disconnectedProviders.filter { $0.supportsManualAuth }) { provider in
                         Button {
                             if provider == .vertex {
                                 isImporterPresented = true


### PR DESCRIPTION
## Summary
- Filter `disconnectedProviders` in Dashboard to only show providers that support manual auth
- Consistent with existing behavior in ProvidersScreen

## Changes
- Added `.filter { $0.supportsManualAuth }` to the ForEach loop displaying add provider buttons

This fixes the issue where +Cursor button was showing in Dashboard even though Cursor doesn't support manual authentication (it's auto-detected from local database).