### PR TITLE
fix(quota): filter out unknown percentages when calculating lowest quota

### DIFF
--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -42,7 +42,9 @@ struct QuotioApp: App {
             if let accountQuotas = viewModel.providerQuotas[provider],
                let quotaData = accountQuotas[selectedItem.accountKey],
                !quotaData.models.isEmpty {
-                let lowestPercent = quotaData.models.map(\.percentage).min() ?? 0
+                // Filter out -1 (unknown) percentages when calculating lowest
+                let validPercentages = quotaData.models.map(\.percentage).filter { $0 >= 0 }
+                let lowestPercent = validPercentages.min() ?? (quotaData.models.first?.percentage ?? -1)
                 items.append(MenuBarQuotaDisplayItem(
                     id: selectedItem.id,
                     providerSymbol: provider.menuBarSymbol,

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -683,7 +683,11 @@ final class QuotaViewModel {
             for (account, quotaData) in accountQuotas {
                 guard !quotaData.models.isEmpty else { continue }
                 
-                let minRemainingPercent = quotaData.models.map(\.percentage).min() ?? 100.0
+                // Filter out models with unknown percentage (-1 means unavailable/unknown)
+                let validPercentages = quotaData.models.map(\.percentage).filter { $0 >= 0 }
+                guard !validPercentages.isEmpty else { continue }
+                
+                let minRemainingPercent = validPercentages.min() ?? 100.0
                 
                 if minRemainingPercent <= notificationManager.quotaAlertThreshold {
                     notificationManager.notifyQuotaLow(
@@ -721,7 +725,9 @@ final class QuotaViewModel {
             if let accountQuotas = providerQuotas[provider],
                let quotaData = accountQuotas[selectedItem.accountKey],
                !quotaData.models.isEmpty {
-                let lowestPercent = quotaData.models.map(\.percentage).min() ?? 0
+                // Filter out -1 (unknown) percentages when calculating lowest
+                let validPercentages = quotaData.models.map(\.percentage).filter { $0 >= 0 }
+                let lowestPercent = validPercentages.min() ?? (quotaData.models.first?.percentage ?? -1)
                 items.append(MenuBarQuotaDisplayItem(
                     id: selectedItem.id,
                     providerSymbol: provider.menuBarSymbol,


### PR DESCRIPTION
## Summary
- Fix incorrect quota notifications triggered when percentage is -1 (unknown)
- Filter out invalid percentages (-1) when calculating lowest quota for menu bar display
- Affects Cursor and Gemini CLI providers which use -1 for unknown/unavailable quota

## Problem
When providers like Cursor or Gemini CLI don't have quota data, `percentage` is set to `-1` (unknown). The old logic used `.min()` to get the lowest value, causing `-1` to be selected and triggering false quota alerts (since `-1 <= 20` is true).

## Changes
- `QuotaViewModel.swift` - `checkQuotaNotifications()`: Filter `{ $0 >= 0 }` to exclude unknown percentages
- `QuotaViewModel.swift` - `menuBarQuotaItems`: Same filter for menu bar display
- `QuotioApp.swift` - `quotaItems`: Same filter for menu bar display

## Testing
- Build succeeded ✅