### PR TITLE
fix(menu-bar): support full-screen mode with NSPanel

### DIFF
--- a/Quotio/Services/StatusBarManager.swift
+++ b/Quotio/Services/StatusBarManager.swift
@@ -205,6 +205,15 @@ final class StatusBarPanel: NSPanel {
     
     override var canBecomeKey: Bool { true }
     
+    // Prevent auto-focus on first responder when panel opens
+    override func makeFirstResponder(_ responder: NSResponder?) -> Bool {
+        // Only allow the panel itself or nil as first responder, not buttons
+        if responder == nil || responder === self.contentView {
+            return super.makeFirstResponder(responder)
+        }
+        return super.makeFirstResponder(self.contentView)
+    }
+    
     override func resignKey() {
         super.resignKey()
         // Close panel when it loses key status (user clicked elsewhere in app)


### PR DESCRIPTION
## Summary

- Replace `NSPopover` with custom `NSPanel` to fix menu bar not displaying when app is in full-screen mode
- Add proper panel positioning below status bar button
- Implement click-outside and escape key dismiss behavior
- Prevent auto-focus on buttons when panel opens

## Technical Changes

- `StatusBarPanel` uses `.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]` to work across all Spaces
- Panel level set to `.statusBar` for proper visibility
- Uses `NSVisualEffectView` with `.popover` material for native appearance
- Override `makeFirstResponder` to prevent button auto-focus

Closes #10