### PR TITLE
feat: Support Claude Code 2.0+ Keychain authentication

### DIFF
--- a/Quotio/Services/ClaudeCodeQuotaFetcher.swift
+++ b/Quotio/Services/ClaudeCodeQuotaFetcher.swift
@@ -2,292 +2,208 @@
 //  ClaudeCodeQuotaFetcher.swift
 //  Quotio - CLIProxyAPI GUI Wrapper
 //
-//  Fetches quota from Claude Code CLI by running /usage and /status commands
+//  Fetches quota from Claude Code using Anthropic OAuth API
 //  Used in Quota-Only mode
 //
 
 import Foundation
 
-/// Quota data from Claude Code CLI
+/// Quota data from Claude Code OAuth API
 struct ClaudeCodeQuotaInfo: Sendable {
-    let email: String?
-    let organizationName: String?
-    let loginMethod: String?
-    let planType: String?
-    
-    /// Weekly usage info
-    let weeklyUsage: WeeklyUsage?
-    let sonnetOnlyUsage: WeeklyUsage?
-    
-    struct WeeklyUsage: Sendable {
-        let used: Int
-        let limit: Int
-        let remaining: Int
-        let resetTime: Date?
-        
-        var percentage: Double {
-            guard limit > 0 else { return 100 }
-            return Double(remaining) / Double(limit) * 100
+    let accessToken: String?
+
+    /// Usage quotas from OAuth API
+    let fiveHour: QuotaUsage?
+    let sevenDay: QuotaUsage?
+    let sevenDaySonnet: QuotaUsage?
+    let sevenDayOpus: QuotaUsage?
+
+    struct QuotaUsage: Sendable {
+        let utilization: Double  // Percentage used (0-100)
+        let resetsAt: String     // ISO8601 date string
+
+        /// Remaining percentage (100 - utilization)
+        var remaining: Double {
+            max(0, 100 - utilization)
         }
     }
 }
 
-/// Fetches quota from Claude Code CLI
+/// Fetches quota from Claude Code using OAuth API
 actor ClaudeCodeQuotaFetcher {
-    private let executor = CLIExecutor.shared
-    
-    /// Check if Claude CLI is installed
-    func isInstalled() async -> Bool {
-        return await executor.isCLIInstalled(name: "claude")
+
+    /// Keychain service names to try (Claude Code may use different names)
+    private let keychainServiceNames = [
+        "Claude Code-credentials",
+        "claude-credentials",
+        "Claude-credentials",
+        "claudecode-credentials"
+    ]
+
+    /// Check if Claude Code credentials exist in Keychain
+    func hasCredentials() async -> Bool {
+        return getAccessToken() != nil
     }
-    
-    /// Fetch quota info from Claude CLI
+
+    /// Get OAuth access token from macOS Keychain
+    private func getAccessToken() -> String? {
+        for serviceName in keychainServiceNames {
+            if let token = getTokenFromKeychain(serviceName: serviceName) {
+                return token
+            }
+        }
+        return nil
+    }
+
+    /// Extract token from Keychain for a specific service name
+    private func getTokenFromKeychain(serviceName: String) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        process.arguments = ["find-generic-password", "-s", serviceName, "-w"]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+
+            guard process.terminationStatus == 0 else { return nil }
+
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            guard let jsonString = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !jsonString.isEmpty,
+                  let jsonData = jsonString.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+                  let claudeAiOauth = json["claudeAiOauth"] as? [String: Any],
+                  let accessToken = claudeAiOauth["accessToken"] as? String else {
+                return nil
+            }
+
+            return accessToken
+        } catch {
+            return nil
+        }
+    }
+
+    /// Fetch quota info from Anthropic OAuth API
     func fetchQuota() async -> ClaudeCodeQuotaInfo? {
-        guard await isInstalled() else { return nil }
-        
-        // Try to get status info first
-        let statusResult = await executor.executeCLI(name: "claude", arguments: ["/status"], timeout: 15)
-        
-        // Then get usage info
-        let usageResult = await executor.executeCLI(name: "claude", arguments: ["/usage"], timeout: 15)
-        
-        // Parse both outputs
-        return parseClaudeOutput(statusOutput: statusResult.combinedOutput, usageOutput: usageResult.combinedOutput)
-    }
-    
-    /// Parse Claude CLI output
-    private func parseClaudeOutput(statusOutput: String, usageOutput: String) -> ClaudeCodeQuotaInfo? {
-        var email: String? = nil
-        var orgName: String? = nil
-        var loginMethod: String? = nil
-        var planType: String? = nil
-        var weeklyUsage: ClaudeCodeQuotaInfo.WeeklyUsage? = nil
-        var sonnetOnlyUsage: ClaudeCodeQuotaInfo.WeeklyUsage? = nil
-        
-        // Parse status output for account info
-        // Expected format:
-        // Email: user@example.com
-        // Organization: My Org
-        // Login Method: OAuth
-        // Plan: Pro
-        
-        for line in statusOutput.components(separatedBy: "\n") {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            
-            if trimmed.lowercased().hasPrefix("email:") {
-                email = extractValue(from: trimmed, key: "email")
-            } else if trimmed.lowercased().hasPrefix("organization:") || trimmed.lowercased().hasPrefix("org:") {
-                orgName = extractValue(from: trimmed, key: "organization") ?? extractValue(from: trimmed, key: "org")
-            } else if trimmed.lowercased().hasPrefix("login method:") || trimmed.lowercased().hasPrefix("auth:") {
-                loginMethod = extractValue(from: trimmed, key: "login method") ?? extractValue(from: trimmed, key: "auth")
-            } else if trimmed.lowercased().hasPrefix("plan:") {
-                planType = extractValue(from: trimmed, key: "plan")
-            }
-        }
-        
-        // Parse usage output
-        // Expected format varies, but typically:
-        // Weekly usage: 150/500 (30%)
-        // Sonnet-only: 50/100 (50%)
-        // Resets in: 3d 5h
-        
-        weeklyUsage = parseUsageSection(from: usageOutput, sectionName: "weekly")
-        sonnetOnlyUsage = parseUsageSection(from: usageOutput, sectionName: "sonnet")
-        
-        // If we couldn't parse structured data, try alternative patterns
-        if weeklyUsage == nil {
-            weeklyUsage = parseAlternativeUsageFormat(from: usageOutput)
-        }
-        
-        // Return nil if we got nothing useful
-        guard email != nil || weeklyUsage != nil else {
+        guard let accessToken = getAccessToken() else {
             return nil
         }
-        
-        return ClaudeCodeQuotaInfo(
-            email: email,
-            organizationName: orgName,
-            loginMethod: loginMethod,
-            planType: planType,
-            weeklyUsage: weeklyUsage,
-            sonnetOnlyUsage: sonnetOnlyUsage
-        )
+
+        // Call Anthropic OAuth usage API
+        return await fetchUsageFromAPI(accessToken: accessToken)
     }
-    
-    private func extractValue(from line: String, key: String) -> String? {
-        let pattern = "\(key):\\s*(.+)"
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+
+    /// Parse a quota usage object from JSON
+    private func parseQuotaUsage(from json: [String: Any]?) -> ClaudeCodeQuotaInfo.QuotaUsage? {
+        guard let json = json,
+              let utilization = json["utilization"] as? Double,
+              let resetsAt = json["resets_at"] as? String else {
             return nil
         }
-        
-        let range = NSRange(line.startIndex..<line.endIndex, in: line)
-        if let match = regex.firstMatch(in: line, options: [], range: range) {
-            if let valueRange = Range(match.range(at: 1), in: line) {
-                return String(line[valueRange]).trimmingCharacters(in: .whitespaces)
-            }
-        }
-        
-        return nil
+        return ClaudeCodeQuotaInfo.QuotaUsage(utilization: utilization, resetsAt: resetsAt)
     }
-    
-    private func parseUsageSection(from output: String, sectionName: String) -> ClaudeCodeQuotaInfo.WeeklyUsage? {
-        // Look for patterns like:
-        // "Weekly: 150/500" or "Weekly usage: 150 of 500" or "150/500 (30%)"
-        
-        let lines = output.lowercased().components(separatedBy: "\n")
-        
-        for line in lines {
-            if line.contains(sectionName) || (sectionName == "weekly" && line.contains("usage")) {
-                return parseUsageLine(line)
-            }
-        }
-        
-        return nil
-    }
-    
-    private func parseUsageLine(_ line: String) -> ClaudeCodeQuotaInfo.WeeklyUsage? {
-        // Pattern 1: "150/500" or "150 / 500"
-        let slashPattern = #"(\d+)\s*/\s*(\d+)"#
-        if let regex = try? NSRegularExpression(pattern: slashPattern),
-           let match = regex.firstMatch(in: line, range: NSRange(line.startIndex..<line.endIndex, in: line)) {
-            if let usedRange = Range(match.range(at: 1), in: line),
-               let limitRange = Range(match.range(at: 2), in: line),
-               let used = Int(line[usedRange]),
-               let limit = Int(line[limitRange]) {
-                return ClaudeCodeQuotaInfo.WeeklyUsage(
-                    used: used,
-                    limit: limit,
-                    remaining: limit - used,
-                    resetTime: parseResetTime(from: line)
-                )
-            }
-        }
-        
-        // Pattern 2: "150 of 500" or "150 out of 500"
-        let ofPattern = #"(\d+)\s*(?:of|out of)\s*(\d+)"#
-        if let regex = try? NSRegularExpression(pattern: ofPattern, options: .caseInsensitive),
-           let match = regex.firstMatch(in: line, range: NSRange(line.startIndex..<line.endIndex, in: line)) {
-            if let usedRange = Range(match.range(at: 1), in: line),
-               let limitRange = Range(match.range(at: 2), in: line),
-               let used = Int(line[usedRange]),
-               let limit = Int(line[limitRange]) {
-                return ClaudeCodeQuotaInfo.WeeklyUsage(
-                    used: used,
-                    limit: limit,
-                    remaining: limit - used,
-                    resetTime: nil
-                )
-            }
-        }
-        
-        return nil
-    }
-    
-    private func parseAlternativeUsageFormat(from output: String) -> ClaudeCodeQuotaInfo.WeeklyUsage? {
-        // Try to find any usage pattern in the entire output
-        let fullText = output.lowercased()
-        
-        // Look for percentage patterns like "70% remaining" or "30% used"
-        let percentPattern = #"(\d+)%\s*(remaining|left|used|consumed)"#
-        if let regex = try? NSRegularExpression(pattern: percentPattern, options: .caseInsensitive),
-           let match = regex.firstMatch(in: fullText, range: NSRange(fullText.startIndex..<fullText.endIndex, in: fullText)) {
-            if let percentRange = Range(match.range(at: 1), in: fullText),
-               let typeRange = Range(match.range(at: 2), in: fullText),
-               let percent = Int(fullText[percentRange]) {
-                let type = String(fullText[typeRange])
-                let remaining = type.contains("remaining") || type.contains("left") ? percent : 100 - percent
-                
-                // Assume a limit of 100 for percentage-based display
-                return ClaudeCodeQuotaInfo.WeeklyUsage(
-                    used: 100 - remaining,
-                    limit: 100,
-                    remaining: remaining,
-                    resetTime: parseResetTime(from: output)
-                )
-            }
-        }
-        
-        return nil
-    }
-    
-    private func parseResetTime(from text: String) -> Date? {
-        // Look for patterns like "resets in 3d 5h" or "reset in 2 hours"
-        let resetPatterns = [
-            #"resets?\s+in\s+(\d+)d\s*(\d+)?h?"#,
-            #"resets?\s+in\s+(\d+)\s*hours?"#,
-            #"resets?\s+in\s+(\d+)\s*days?"#
+
+    /// Fetch usage data from Anthropic OAuth API
+    private func fetchUsageFromAPI(accessToken: String) async -> ClaudeCodeQuotaInfo? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/curl")
+        process.arguments = [
+            "-s",
+            "-H", "Accept: application/json",
+            "-H", "Authorization: Bearer \(accessToken)",
+            "-H", "anthropic-beta: oauth-2025-04-20",
+            "https://api.anthropic.com/api/oauth/usage"
         ]
-        
-        for pattern in resetPatterns {
-            if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
-               let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..<text.endIndex, in: text)) {
-                // Parse days and hours
-                if match.numberOfRanges >= 2,
-                   let daysRange = Range(match.range(at: 1), in: text),
-                   let days = Int(text[daysRange]) {
-                    var totalHours = days * 24
-                    
-                    if match.numberOfRanges >= 3,
-                       let hoursRange = Range(match.range(at: 2), in: text),
-                       let hours = Int(text[hoursRange]) {
-                        totalHours += hours
-                    }
-                    
-                    return Date().addingTimeInterval(TimeInterval(totalHours * 3600))
-                }
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+
+            guard process.terminationStatus == 0 else { return nil }
+
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
             }
+
+            // Parse the usage response
+            // Format: { "five_hour": { "utilization": 74.0, "resets_at": "..." }, ... }
+            let fiveHour = parseQuotaUsage(from: json["five_hour"] as? [String: Any])
+            let sevenDay = parseQuotaUsage(from: json["seven_day"] as? [String: Any])
+            let sevenDaySonnet = parseQuotaUsage(from: json["seven_day_sonnet"] as? [String: Any])
+            let sevenDayOpus = parseQuotaUsage(from: json["seven_day_opus"] as? [String: Any])
+
+            return ClaudeCodeQuotaInfo(
+                accessToken: accessToken,
+                fiveHour: fiveHour,
+                sevenDay: sevenDay,
+                sevenDaySonnet: sevenDaySonnet,
+                sevenDayOpus: sevenDayOpus
+            )
+        } catch {
+            return nil
         }
-        
-        return nil
     }
-    
+
     /// Convert ClaudeCodeQuotaInfo to ProviderQuotaData for unified display
     func fetchAsProviderQuota() async -> [String: ProviderQuotaData] {
         guard let info = await fetchQuota() else { return [:] }
-        
+
         var models: [ModelQuota] = []
-        
-        if let weekly = info.weeklyUsage {
-            // Convert reset time to ISO8601 string
-            let resetTimeStr: String
-            if let resetTime = weekly.resetTime {
-                resetTimeStr = ISO8601DateFormatter().string(from: resetTime)
-            } else {
-                resetTimeStr = ""
-            }
-            
+
+        // Add 5-hour quota
+        if let fiveHour = info.fiveHour {
             models.append(ModelQuota(
-                name: "weekly-usage",
-                percentage: weekly.percentage,
-                resetTime: resetTimeStr
+                name: "5-hour",
+                percentage: fiveHour.remaining,
+                resetTime: fiveHour.resetsAt
             ))
         }
-        
-        if let sonnet = info.sonnetOnlyUsage {
-            let resetTimeStr: String
-            if let resetTime = sonnet.resetTime {
-                resetTimeStr = ISO8601DateFormatter().string(from: resetTime)
-            } else {
-                resetTimeStr = ""
-            }
-            
+
+        // Add 7-day quota (main quota)
+        if let sevenDay = info.sevenDay {
             models.append(ModelQuota(
-                name: "sonnet-only",
-                percentage: sonnet.percentage,
-                resetTime: resetTimeStr
+                name: "7-day",
+                percentage: sevenDay.remaining,
+                resetTime: sevenDay.resetsAt
             ))
         }
-        
+
+        // Add Sonnet-specific quota if available
+        if let sonnet = info.sevenDaySonnet {
+            models.append(ModelQuota(
+                name: "sonnet",
+                percentage: sonnet.remaining,
+                resetTime: sonnet.resetsAt
+            ))
+        }
+
+        // Add Opus-specific quota if available
+        if let opus = info.sevenDayOpus {
+            models.append(ModelQuota(
+                name: "opus",
+                percentage: opus.remaining,
+                resetTime: opus.resetsAt
+            ))
+        }
+
         guard !models.isEmpty else { return [:] }
-        
-        let email = info.email ?? "Claude Code User"
+
         let quotaData = ProviderQuotaData(
             models: models,
             lastUpdated: Date(),
             isForbidden: false,
-            planType: info.planType
+            planType: nil
         )
-        
-        return [email: quotaData]
+
+        return ["Claude Code User": quotaData]
     }
 }

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -539,12 +539,12 @@ final class QuotaViewModel {
             await startKiroAuth(method: authMethod ?? .kiroGoogleLogin)
             return
         }
-        
+
         guard let client = apiClient else {
-            errorMessage = "Proxy not running"
+            oauthState = OAuthState(provider: provider, status: .error, error: "Proxy not running. Please start the proxy first.")
             return
         }
-        
+
         oauthState = OAuthState(provider: provider, status: .waiting)
         
         do {


### PR DESCRIPTION
## Summary

- Add support for Claude Code 2.0+ which stores credentials in macOS Keychain instead of `~/.claude/.credentials.json`
- Use Anthropic OAuth API to fetch real-time quota data (5-hour, 7-day, sonnet limits)
- Fix OAuth error feedback when proxy is not running

## Changes

### `DirectAuthFileService.swift`
- Add `getClaudeAuthFromKeychain()` to read credentials from macOS Keychain
- Try multiple service names: `Claude Code-credentials`, `claude-credentials`, etc.
- Keep fallback to legacy file location for older Claude Code versions

### `ClaudeCodeQuotaFetcher.swift`
- Replace CLI-based approach with Anthropic OAuth API
- API endpoint: `https://api.anthropic.com/api/oauth/usage`
- Parse quota response: `five_hour`, `seven_day`, `seven_day_sonnet`, `seven_day_opus`

### `QuotaViewModel.swift`
- Fix OAuth error to show in UI instead of silently failing

## Test plan

- [x] Verify Claude Code 2.0+ credentials are detected from Keychain
- [x] Verify quota data is fetched from Anthropic OAuth API
- [x] Verify 5-hour, 7-day, and sonnet quotas display correctly
- [x] Verify Full Mode is not affected

Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)