### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2025-12-30
+
+### Added
+
+- **Chinese Localization**: Full Simplified Chinese translation for all UI strings (#39)
+
+### Fixed
+
+- **Sparkle Update Loop**: Sync build number to match released version, preventing false update notifications
+
 ## [0.3.1] - 2025-12-30
 
 ### Added


### PR DESCRIPTION
## Summary

Release version 0.3.2 with the following changes:

### Added
- **Chinese Localization**: Full Simplified Chinese translation for all UI strings (#39)

### Fixed
- **Sparkle Update Loop**: Sync build number to match released version, preventing false update notifications
  - Build number mismatch (0.3.1 build 12 vs released build 13) caused users to see update prompts for the same version

## Checklist
- [x] Version bumped to 0.3.2 (build 14)
- [x] CHANGELOG.md updated
- [x] Build succeeds
- [x] GitHub Release created