### PR TITLE
feat(privacy): add option to hide sensitive information

### DIFF
--- a/Quotio/Services/LanguageManager.swift
+++ b/Quotio/Services/LanguageManager.swift
@@ -533,6 +533,11 @@ struct LocalizedStrings {
         "settings.proxyUpdate.deleteWarning.title": [.english: "Old Versions Will Be Deleted", .vietnamese: "Phiên bản cũ sẽ bị xóa", .chinese: "旧版本将被删除"],
         "settings.proxyUpdate.deleteWarning.message": [.english: "Installing this version will delete the following old versions to keep only %d most recent: %@", .vietnamese: "Cài đặt phiên bản này sẽ xóa các phiên bản cũ sau để chỉ giữ lại %d phiên bản gần nhất: %@", .chinese: "安装此版本将删除以下旧版本，仅保留最近的 %d 个：%@"],
         "settings.proxyUpdate.deleteWarning.confirm": [.english: "Install Anyway", .vietnamese: "Vẫn cài đặt", .chinese: "仍然安装"],
+        
+        // Privacy Settings
+        "settings.privacy": [.english: "Privacy", .vietnamese: "Riêng tư", .chinese: "隐私"],
+        "settings.privacy.hideSensitive": [.english: "Hide Sensitive Information", .vietnamese: "Ẩn thông tin nhạy cảm", .chinese: "隐藏敏感信息"],
+        "settings.privacy.hideSensitiveHelp": [.english: "Masks emails and account names with ● characters across the app", .vietnamese: "Che email và tên tài khoản bằng ký tự ● trong toàn bộ ứng dụng", .chinese: "在应用中使用 ● 字符隐藏邮箱和账户名称"],
     ]
     
     static func get(_ key: String, language: AppLanguage) -> String {

--- a/Quotio/Views/Components/MenuBarView.swift
+++ b/Quotio/Views/Components/MenuBarView.swift
@@ -377,6 +377,11 @@ private struct MenuBarQuotaCard: View {
     let provider: AIProvider
     
     @State private var isHovered = false
+    @State private var settings = MenuBarSettingsManager.shared
+    
+    private var displayEmail: String {
+        email.masked(if: settings.hideSensitiveInfo)
+    }
     
     // For Antigravity: use grouped models
     private var isAntigravity: Bool {
@@ -443,7 +448,7 @@ private struct MenuBarQuotaCard: View {
     
     private var cardHeader: some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text(email)
+            Text(displayEmail)
                 .font(.system(size: 12, weight: .medium))
                 .lineLimit(1)
             

--- a/Quotio/Views/Components/QuotaCard.swift
+++ b/Quotio/Views/Components/QuotaCard.swift
@@ -286,6 +286,12 @@ private struct StatusBadge: View {
 private struct AccountRow: View {
     let account: AuthFile
     var quotaData: ProviderQuotaData?
+    @State private var settings = MenuBarSettingsManager.shared
+    
+    private var displayName: String {
+        let name = account.email ?? account.name
+        return name.masked(if: settings.hideSensitiveInfo)
+    }
     
     var body: some View {
         HStack(spacing: 8) {
@@ -293,7 +299,7 @@ private struct AccountRow: View {
                 .fill(account.statusColor)
                 .frame(width: 8, height: 8)
             
-            Text(account.email ?? account.name)
+            Text(displayName)
                 .font(.caption)
                 .lineLimit(1)
             

--- a/Quotio/Views/Screens/ProvidersScreen.swift
+++ b/Quotio/Views/Screens/ProvidersScreen.swift
@@ -385,6 +385,11 @@ struct DirectAuthFileRow: View {
         settings.isSelected(menuBarItem)
     }
     
+    private var displayName: String {
+        let name = file.email ?? file.filename
+        return name.masked(if: settings.hideSensitiveInfo)
+    }
+    
     private func handleToggle() {
         if isSelected {
             settings.toggleItem(menuBarItem)
@@ -400,7 +405,7 @@ struct DirectAuthFileRow: View {
             ProviderIcon(provider: file.provider, size: 24)
             
             VStack(alignment: .leading, spacing: 2) {
-                Text(file.email ?? file.filename)
+                Text(displayName)
                     .fontWeight(.medium)
                 
                 HStack(spacing: 6) {
@@ -466,6 +471,11 @@ struct AuthFileRow: View {
         return settings.isSelected(item)
     }
     
+    private var displayName: String {
+        let name = file.email ?? file.name
+        return name.masked(if: settings.hideSensitiveInfo)
+    }
+    
     private func handleToggle() {
         guard let item = menuBarItem else { return }
         if isSelected {
@@ -489,7 +499,7 @@ struct AuthFileRow: View {
             }
             
             VStack(alignment: .leading, spacing: 2) {
-                Text(file.email ?? file.name)
+                Text(displayName)
                     .fontWeight(.medium)
                 
                 HStack(spacing: 6) {
@@ -584,6 +594,10 @@ struct AutoDetectedAccountRow: View {
         settings.isSelected(menuBarItem)
     }
     
+    private var displayAccountKey: String {
+        accountKey.masked(if: settings.hideSensitiveInfo)
+    }
+    
     private func handleToggle() {
         if isSelected {
             settings.toggleItem(menuBarItem)
@@ -599,7 +613,7 @@ struct AutoDetectedAccountRow: View {
             ProviderIcon(provider: provider, size: 24)
             
             VStack(alignment: .leading, spacing: 2) {
-                Text(accountKey)
+                Text(displayAccountKey)
                     .fontWeight(.medium)
                 
                 HStack(spacing: 6) {

--- a/Quotio/Views/Screens/QuotaScreen.swift
+++ b/Quotio/Views/Screens/QuotaScreen.swift
@@ -359,6 +359,7 @@ private struct AccountInfo {
 
 private struct AccountQuotaCardV2: View {
     @Environment(QuotaViewModel.self) private var viewModel
+    @State private var settings = MenuBarSettingsManager.shared
     let provider: AIProvider
     let account: AccountInfo
     let isLoading: Bool
@@ -368,6 +369,10 @@ private struct AccountQuotaCardV2: View {
     private var hasQuotaData: Bool {
         guard let data = account.quotaData else { return false }
         return !data.models.isEmpty
+    }
+    
+    private var displayEmail: String {
+        account.email.masked(if: settings.hideSensitiveInfo)
     }
     
     var body: some View {
@@ -405,7 +410,7 @@ private struct AccountQuotaCardV2: View {
             
             // Email
             VStack(alignment: .leading, spacing: 2) {
-                Text(account.email)
+                Text(displayEmail)
                     .font(.headline)
                     .lineLimit(1)
                 

--- a/Quotio/Views/Screens/SettingsScreen.swift
+++ b/Quotio/Views/Screens/SettingsScreen.swift
@@ -74,6 +74,9 @@ struct SettingsScreen: View {
             // Appearance
             AppearanceSettingsSection()
             
+            // Privacy
+            PrivacySettingsSection()
+            
             // Proxy Server - Only in Full Mode
             if modeManager.isFullMode {
                 Section {
@@ -1173,6 +1176,29 @@ struct AppearanceSettingsSection: View {
             Label("settings.appearance.title".localized(), systemImage: "paintbrush")
         } footer: {
             Text("settings.appearance.help".localized())
+        }
+    }
+}
+
+// MARK: - Privacy Settings Section
+
+struct PrivacySettingsSection: View {
+    @State private var settings = MenuBarSettingsManager.shared
+    
+    private var hideSensitiveBinding: Binding<Bool> {
+        Binding(
+            get: { settings.hideSensitiveInfo },
+            set: { settings.hideSensitiveInfo = $0 }
+        )
+    }
+    
+    var body: some View {
+        Section {
+            Toggle("settings.privacy.hideSensitive".localized(), isOn: hideSensitiveBinding)
+        } header: {
+            Label("settings.privacy".localized(), systemImage: "eye.slash")
+        } footer: {
+            Text("settings.privacy.hideSensitiveHelp".localized())
         }
     }
 }


### PR DESCRIPTION
## Summary
Add privacy feature to hide sensitive information (emails and account names) with asterisks across the app.

## Changes
- **Models**: Add `MenuBarSettings` model with `hideSensitiveInfo` setting and `shouldMask()` helper methods
- **Views**: Update `MenuBarView`, `QuotaCard`, `ProvidersScreen`, `QuotaScreen` to mask sensitive info when enabled
- **Settings**: Add Privacy section in Settings with toggle to enable/disable masking
- **Localization**: Add privacy setting strings for EN, VI, ZH

## Testing
- Manual testing in Xcode
- Verified masking works on menu bar, quota cards, provider screens