### PR TITLE
Adjust menu bar item padding to match native spacing

### DIFF
--- a/Quotio/Services/StatusBarManager.swift
+++ b/Quotio/Services/StatusBarManager.swift
@@ -75,12 +75,26 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
         let hostingView = NSHostingView(rootView: contentView)
         hostingView.setFrameSize(hostingView.intrinsicContentSize)
         
-        let containerView = StatusBarContainerView(frame: NSRect(origin: .zero, size: hostingView.intrinsicContentSize))
+        // Add horizontal padding to align with native status bar spacing
+        let horizontalPadding: CGFloat = 4
+        let contentSize = hostingView.intrinsicContentSize
+        let containerSize = NSSize(
+            width: contentSize.width + horizontalPadding * 2,
+            height: max(22, contentSize.height)
+        )
+        
+        let containerView = StatusBarContainerView(frame: NSRect(origin: .zero, size: containerSize))
         containerView.addSubview(hostingView)
-        hostingView.frame = containerView.bounds
+        hostingView.frame = NSRect(
+            x: horizontalPadding,
+            y: (containerSize.height - contentSize.height) / 2,
+            width: contentSize.width,
+            height: contentSize.height
+        )
         
         button.addSubview(containerView)
-        button.frame = NSRect(origin: .zero, size: hostingView.intrinsicContentSize)
+        button.frame = NSRect(origin: .zero, size: containerSize)
+        statusItem?.length = containerSize.width
     }
     
     // MARK: - NSMenuDelegate


### PR DESCRIPTION
* Added explicit horizontal padding around the status bar hosting view so the custom icon aligns with native spacing
* Tuned padding to 4pt per side and kept vertical centering for consistent appearance across menu bar items

<img width="479" height="139" alt="image" src="https://github.com/user-attachments/assets/08d44bb1-6b2a-498d-9016-6f1e504aee14" />
