### PR TITLE
fix(antigravity): fix Use in IDE hanging on macOS 15.5+

### DIFF
--- a/Quotio/Services/AntigravityAccountSwitcher.swift
+++ b/Quotio/Services/AntigravityAccountSwitcher.swift
@@ -128,6 +128,10 @@ final class AntigravityAccountSwitcher {
             if wasIDERunning {
                 switchState = .switching(progress: .closingIDE)
                 _ = await processManager.terminate()
+                
+                // Clean up WAL files to release database locks
+                await databaseService.cleanupWALFiles()
+                
                 // Wait for SQLite WAL to flush and release database lock
                 // 500ms is often not enough on slower machines
                 try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds

--- a/Quotio/Services/AntigravityDatabaseService.swift
+++ b/Quotio/Services/AntigravityDatabaseService.swift
@@ -19,6 +19,12 @@ actor AntigravityDatabaseService {
     private static let backupPath = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Library/Application Support/Antigravity/User/globalStorage/state.vscdb.quotio.backup")
     
+    private static let walPath = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/Application Support/Antigravity/User/globalStorage/state.vscdb-wal")
+    
+    private static let shmPath = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/Application Support/Antigravity/User/globalStorage/state.vscdb-shm")
+    
     private static let stateKey = "jetskiStateSync.agentManagerInitState"
     
     // MARK: - Errors
@@ -209,6 +215,13 @@ actor AntigravityDatabaseService {
     /// Check if backup exists
     func backupExists() -> Bool {
         FileManager.default.fileExists(atPath: Self.backupPath.path)
+    }
+    
+    /// Remove WAL and SHM files to release database locks
+    /// Should be called after IDE termination
+    func cleanupWALFiles() async {
+        try? FileManager.default.removeItem(at: Self.walPath)
+        try? FileManager.default.removeItem(at: Self.shmPath)
     }
     
     // MARK: - Auth Status Operations


### PR DESCRIPTION
## Summary

Fixes the "Use in IDE" feature hanging at the "Inject token" step on macOS 15.5+.

## Root Cause

1. **Helper processes not killed properly**: `pkill -f` wasn't reliably killing all Electron helper processes on macOS 15.5+
2. **SQLite WAL lock**: WAL and SHM files were holding database locks even after IDE termination

## Changes

- **AntigravityProcessManager**: Use `killall -9` for each specific Electron helper pattern + `pkill` as fallback
- **AntigravityDatabaseService**: Add `cleanupWALFiles()` to delete `-wal` and `-shm` files
- **AntigravityAccountSwitcher**: Call WAL cleanup after IDE termination
- Increase post-kill delay from 200ms to 500ms

## Compatibility

Tested on macOS 26.1, uses standard BSD utilities (`killall`, `pkill`) available on macOS 14+, 15+, 26+.

## Testing

1. Open Antigravity IDE with an account
2. In Quotio, click "Use in IDE" on a different account
3. Should complete without hanging