### PR TITLE
feat(settings): add restart notice for routing strategy changes

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -10685,25 +10685,25 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Restart proxy after changing port"
+            "value" : "Restart proxy for changes to take effect"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Redémarrer le proxy après changement de port"
+            "value" : "Redémarrer le proxy pour appliquer les modifications"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Khởi động lại proxy sau khi đổi cổng"
+            "value" : "Khởi động lại proxy để áp dụng thay đổi"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "更改端口后重启代理"
+            "value" : "重启代理以使更改生效"
           }
         }
       }

--- a/Quotio/Views/Screens/SettingsScreen.swift
+++ b/Quotio/Views/Screens/SettingsScreen.swift
@@ -155,10 +155,13 @@ struct SettingsScreen: View {
                 } header: {
                     Label("settings.routingStrategy".localized(), systemImage: "arrow.triangle.branch")
                 } footer: {
-                    Text(routingStrategy == "round-robin"
-                         ? "settings.roundRobinDesc".localized()
-                         : "settings.fillFirstDesc".localized())
-                        .font(.caption)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(routingStrategy == "round-robin"
+                             ? "settings.roundRobinDesc".localized()
+                             : "settings.fillFirstDesc".localized())
+                        Text("settings.restartProxy".localized())
+                    }
+                    .font(.caption)
                 }
                 
                 // Quota Exceeded Behavior


### PR DESCRIPTION
## Summary

- Added restart notice to Routing Strategy section footer to inform users that proxy restart is required after changing routing strategy
- Updated localization strings from "Restart proxy after changing port" to "Restart proxy for changes to take effect" in 4 languages (EN, FR, VI, ZH)

## Changes

| File | Change |
|------|--------|
| `SettingsScreen.swift` | Added `settings.restartProxy` text to routing strategy footer using VStack layout |
| `Localizable.xcstrings` | Updated translations to be more generic (applies to both port and routing changes) |

## Screenshots

N/A - Minor text addition to existing UI

## Testing

- [x] Verified UI displays correctly in Settings > Routing Strategy section
- [x] Translations available for all supported languages