### PR TITLE
fix(detection): check XDG_DATA_HOME for fnm path detection

### DIFF
--- a/Quotio/Services/AgentDetectionService.swift
+++ b/Quotio/Services/AgentDetectionService.swift
@@ -127,11 +127,24 @@ actor AgentDetectionService {
             }
         }
         
-        // fnm: ~/.fnm/node-versions/v*/installation/bin/
-        let fnmBase = "\(home)/.fnm/node-versions"
-        if let versions = try? fileManager.contentsOfDirectory(atPath: fnmBase) {
-            for version in versions.sorted().reversed() {
-                paths.append("\(fnmBase)/\(version)/installation/bin/\(name)")
+        // fnm: $XDG_DATA_HOME/fnm (defaults to ~/.local/share/fnm), then legacy ~/.fnm
+        let xdgDataHome: String
+        if let envValue = ProcessInfo.processInfo.environment["XDG_DATA_HOME"], !envValue.isEmpty {
+            xdgDataHome = envValue
+        } else {
+            xdgDataHome = "\(home)/.local/share"
+        }
+        let fnmPaths = [
+            "\(xdgDataHome)/fnm/node-versions",
+            "\(home)/.fnm/node-versions"  // legacy path
+        ]
+
+        for fnmBase in fnmPaths {
+            if let versions = try? fileManager.contentsOfDirectory(atPath: fnmBase), !versions.isEmpty {
+                for version in versions.sorted().reversed() {
+                    paths.append("\(fnmBase)/\(version)/installation/bin/\(name)")
+                }
+                break  // found fnm installation, skip legacy path
             }
         }
         


### PR DESCRIPTION
Fixes #101 

Previously only checked ~/.fnm which was incorrect. Now checks paths in priority order: $XDG_DATA_HOME/fnm, ~/.local/share/fnm, and ~/.fnm (legacy).

Note: I'm not a swift dev, feel free to modify this PR, Thank you!

---
**Parts of this PR were drafted with assistance from Claude Code (with claude opus 4.5) and fully reviewed and edited by me. I take full responsibility for all changes.**