### PR TITLE
fix: always route traffic through Quotio proxy endpoint

### DIFF
--- a/Quotio/ViewModels/AgentSetupViewModel.swift
+++ b/Quotio/ViewModels/AgentSetupViewModel.swift
@@ -73,9 +73,8 @@ final class AgentSetupViewModel {
 
         selectedAgent = agent
 
-        // Use ProxyBridge endpoint when Fallback is enabled, otherwise use direct CLIProxyAPI endpoint
-        let fallbackEnabled = FallbackSettingsManager.shared.isEnabled
-        let endpoint = fallbackEnabled ? proxyManager.clientEndpoint : proxyManager.baseURL
+        // Always use client endpoint - all traffic should go through Quotio's proxy
+        let endpoint = proxyManager.clientEndpoint
 
         currentConfiguration = AgentConfiguration(
             agent: agent,

--- a/Quotio/Views/Screens/DashboardScreen.swift
+++ b/Quotio/Views/Screens/DashboardScreen.swift
@@ -675,16 +675,10 @@ struct DashboardScreen: View {
     
     // MARK: - Endpoint Section
 
-    /// Compute the display endpoint based on Fallback status
+    /// The display endpoint for clients to connect to
     private var displayEndpoint: String {
-        let fallbackEnabled = FallbackSettingsManager.shared.isEnabled
-        if fallbackEnabled {
-            // When Fallback is enabled, use ProxyBridge endpoint (user port)
-            return viewModel.proxyManager.clientEndpoint + "/v1"
-        } else {
-            // When Fallback is disabled, use CLIProxyAPI endpoint directly (internal port in bridge mode)
-            return viewModel.proxyManager.baseURL + "/v1"
-        }
+        // Always use client endpoint - all traffic should go through Quotio's proxy
+        return viewModel.proxyManager.clientEndpoint + "/v1"
     }
 
     private var endpointSection: some View {


### PR DESCRIPTION
## Summary

- Remove incorrect fallback-based endpoint logic in `AgentSetupViewModel` and `DashboardScreen`
- All external clients should always connect through `clientEndpoint` (user port) regardless of Fallback status
- This ensures proper connection management and request logging through ProxyBridge

## Problem

Previously, when Fallback was disabled:
- Agent configuration used `baseURL` (internal port) instead of `clientEndpoint`
- This caused agents to bypass ProxyBridge entirely
- Connection management and request logging were skipped

## Changes

| File | Change |
|------|--------|
| `AgentSetupViewModel.swift` | Always use `proxyManager.clientEndpoint` |
| `DashboardScreen.swift` | Always display `clientEndpoint` |

## Test plan

- [x] Verify agent setup generates correct endpoint URL with Fallback disabled
- [x] Verify agent setup generates correct endpoint URL with Fallback enabled
- [x] Verify Dashboard shows correct endpoint URL in both cases
- [x] Confirm requests go through ProxyBridge in both scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)