### PR TITLE
feat: add upstream proxy support for quota fetchers and managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ plans/
 # Local AI agent context (not shared)
 .context/
 .wallpaper-cache/
+
+.DS_Store

--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -582,7 +582,9 @@ actor AgentConfigurationService {
         request.addValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
         request.timeoutInterval = 10
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let proxyConfig = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 10)
+        let session = URLSession(configuration: proxyConfig)
+        let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             throw URLError(.badServerResponse)
@@ -643,9 +645,11 @@ actor AgentConfigurationService {
         request.timeoutInterval = 10
         
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let proxyConfig = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 10)
+            let session = URLSession(configuration: proxyConfig)
+            let (data, response) = try await session.data(for: request)
             let latencyMs = Int(Date().timeIntervalSince(startTime) * 1000)
-            
+
             guard let httpResponse = response as? HTTPURLResponse else {
                 return ConnectionTestResult(
                     success: false,

--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -413,14 +413,19 @@ actor AntigravityQuotaFetcher {
     private let clientSecret = "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"
     private let userAgent = "antigravity/1.11.3 Darwin/arm64"
     
-    private let session: URLSession
+    private var session: URLSession
     
     // Cache subscription info to avoid duplicate API calls within same refresh cycle
     private var subscriptionCache: [String: SubscriptionInfo] = [:]
     
     init() {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 15
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
+        self.session = URLSession(configuration: config)
+    }
+
+    /// Update the URLSession with current proxy settings
+    func updateProxyConfiguration() {
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
         self.session = URLSession(configuration: config)
     }
     

--- a/Quotio/Services/GLMQuotaFetcher.swift
+++ b/Quotio/Services/GLMQuotaFetcher.swift
@@ -56,11 +56,16 @@ struct GLMUsageDetail: Codable, Sendable {
 actor GLMQuotaFetcher {
     private let quotaAPIURL = "https://bigmodel.cn/api/monitor/usage/quota/limit"
 
-    private let session: URLSession
+    private var session: URLSession
 
     init() {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 15
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
+        self.session = URLSession(configuration: config)
+    }
+
+    /// Update the URLSession with current proxy settings
+    func updateProxyConfiguration() {
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
         self.session = URLSession(configuration: config)
     }
 

--- a/Quotio/Services/Proxy/CLIProxyManager.swift
+++ b/Quotio/Services/Proxy/CLIProxyManager.swift
@@ -421,17 +421,19 @@ final class CLIProxyManager {
         guard let url = URL(string: urlString) else {
             throw ProxyError.networkError("Invalid URL")
         }
-        
+
         var request = URLRequest(url: url)
         request.addValue("application/vnd.github.v3+json", forHTTPHeaderField: "Accept")
         request.addValue("Quotio/1.0", forHTTPHeaderField: "User-Agent")
-        
-        let (data, response) = try await URLSession.shared.data(for: request)
-        
+
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 30)
+        let session = URLSession(configuration: config)
+        let (data, response) = try await session.data(for: request)
+
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             throw ProxyError.networkError("Failed to fetch release info")
         }
-        
+
         return try JSONDecoder().decode(ReleaseInfo.self, from: data)
     }
     
@@ -464,16 +466,18 @@ final class CLIProxyManager {
         guard let downloadURL = URL(string: url) else {
             throw ProxyError.networkError("Invalid download URL")
         }
-        
+
         var request = URLRequest(url: downloadURL)
         request.addValue("Quotio/1.0", forHTTPHeaderField: "User-Agent")
-        
-        let (data, response) = try await URLSession.shared.data(for: request)
-        
+
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 300) // 5 minutes timeout for large downloads
+        let session = URLSession(configuration: config)
+        let (data, response) = try await session.data(for: request)
+
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             throw ProxyError.networkError("Failed to download binary")
         }
-        
+
         return data
     }
     
@@ -1266,17 +1270,19 @@ extension CLIProxyManager {
         guard let url = URL(string: urlString) else {
             throw ProxyError.networkError("Invalid URL")
         }
-        
+
         var request = URLRequest(url: url)
         request.addValue("application/vnd.github.v3+json", forHTTPHeaderField: "Accept")
         request.addValue("Quotio/1.0", forHTTPHeaderField: "User-Agent")
-        
-        let (data, response) = try await URLSession.shared.data(for: request)
-        
+
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 30)
+        let session = URLSession(configuration: config)
+        let (data, response) = try await session.data(for: request)
+
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             throw ProxyError.networkError("Failed to fetch releases")
         }
-        
+
         return try JSONDecoder().decode([GitHubRelease].self, from: data)
     }
     
@@ -1292,17 +1298,19 @@ extension CLIProxyManager {
         guard let url = URL(string: urlString) else {
             throw ProxyError.networkError("Invalid URL")
         }
-        
+
         var request = URLRequest(url: url)
         request.addValue("application/vnd.github.v3+json", forHTTPHeaderField: "Accept")
         request.addValue("Quotio/1.0", forHTTPHeaderField: "User-Agent")
-        
-        let (data, response) = try await URLSession.shared.data(for: request)
-        
+
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 30)
+        let session = URLSession(configuration: config)
+        let (data, response) = try await session.data(for: request)
+
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             throw ProxyError.networkError("Failed to fetch release info")
         }
-        
+
         return try JSONDecoder().decode(GitHubRelease.self, from: data)
     }
     

--- a/Quotio/Services/ProxyConfigurationService.swift
+++ b/Quotio/Services/ProxyConfigurationService.swift
@@ -1,0 +1,96 @@
+//
+//  ProxyConfigurationService.swift
+//  Quotio
+//
+//  Created by Antigravity on 2026/01/11.
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ProxyConfigurationService {
+    static let shared = ProxyConfigurationService()
+
+    /// Current upstream proxy URL (validated and sanitized)
+    var upstreamProxyURL: String? {
+        guard let savedURL = UserDefaults.standard.string(forKey: "proxyURL"),
+              !savedURL.isEmpty else {
+            return nil
+        }
+
+        let sanitized = ProxyURLValidator.sanitize(savedURL)
+        guard ProxyURLValidator.validate(sanitized) == .valid else {
+            return nil
+        }
+
+        return sanitized
+    }
+
+    /// Create a URLSessionConfiguration with proxy settings applied
+    func createProxiedConfiguration(timeout: TimeInterval = 15) -> URLSessionConfiguration {
+        Self.createProxiedConfigurationStatic(timeout: timeout)
+    }
+    
+    /// Static nonisolated method to create proxied configuration
+    /// Can be called from any actor context
+    nonisolated static func createProxiedConfigurationStatic(timeout: TimeInterval = 15) -> URLSessionConfiguration {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = timeout
+
+        // Read proxy URL from UserDefaults directly (thread-safe)
+        if let proxyURLString = UserDefaults.standard.string(forKey: "proxyURL"),
+           !proxyURLString.isEmpty {
+            let sanitized = ProxyURLValidator.sanitize(proxyURLString)
+            if ProxyURLValidator.validate(sanitized) == .valid,
+               let url = URL(string: sanitized) {
+                config.connectionProxyDictionary = proxyDictionary(from: url)
+            }
+        }
+
+        return config
+    }
+
+    nonisolated static private func proxyDictionary(from url: URL) -> [AnyHashable: Any]? {
+        guard let host = url.host else { return nil }
+        let port = url.port ?? (url.scheme == "https" ? 443 : 8080)
+
+        var dict: [AnyHashable: Any] = [:]
+
+        switch url.scheme?.lowercased() {
+        case "http":
+            dict[kCFNetworkProxiesHTTPEnable] = true
+            dict[kCFNetworkProxiesHTTPProxy] = host
+            dict[kCFNetworkProxiesHTTPPort] = port
+
+            // Also enable for HTTPS using the same proxy
+            dict[kCFNetworkProxiesHTTPSEnable] = true
+            dict[kCFNetworkProxiesHTTPSProxy] = host
+            dict[kCFNetworkProxiesHTTPSPort] = port
+
+        case "https":
+            dict[kCFNetworkProxiesHTTPSEnable] = true
+            dict[kCFNetworkProxiesHTTPSProxy] = host
+            dict[kCFNetworkProxiesHTTPSPort] = port
+
+        case "socks5":
+            dict[kCFStreamPropertySOCKSProxyHost] = host
+            dict[kCFStreamPropertySOCKSProxyPort] = port
+            dict[kCFStreamPropertySOCKSVersion] = kCFStreamSocketSOCKSVersion5
+
+            // Add authentication if present
+            if let user = url.user {
+                dict[kCFStreamPropertySOCKSUser] = user
+            }
+            if let password = url.password {
+                dict[kCFStreamPropertySOCKSPassword] = password
+            }
+
+        default:
+            return nil
+        }
+
+        return dict
+    }
+}

--- a/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
@@ -61,7 +61,7 @@ actor ClaudeCodeQuotaFetcher {
     private let usageURL = "https://api.anthropic.com/api/oauth/usage"
 
     /// URLSession for network requests
-    private let session: URLSession
+    private var session: URLSession
 
     /// Cache for quota data to reduce API calls
     private var quotaCache: [String: CachedQuota] = [:]
@@ -70,8 +70,13 @@ actor ClaudeCodeQuotaFetcher {
     private let cacheTTL: TimeInterval = 300
 
     init() {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 15
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
+        self.session = URLSession(configuration: config)
+    }
+
+    /// Update the URLSession with current proxy settings
+    func updateProxyConfiguration() {
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
         self.session = URLSession(configuration: config)
     }
 

--- a/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
@@ -70,11 +70,16 @@ actor CodexCLIQuotaFetcher {
     private let usageURL = "https://chatgpt.com/backend-api/wham/usage"
     private let refreshURL = "https://auth.openai.com/oauth/token"
     
-    private let session: URLSession
+    private var session: URLSession
     
     init() {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 15
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
+        self.session = URLSession(configuration: config)
+    }
+
+    /// Update the URLSession with current proxy settings
+    func updateProxyConfiguration() {
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
         self.session = URLSession(configuration: config)
     }
     

--- a/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
@@ -195,15 +195,20 @@ actor CopilotQuotaFetcher {
     private let entitlementURL = "https://api.github.com/copilot_internal/user"
     private let tokenURL = "https://api.github.com/copilot_internal/v2/token"
     private let modelsURL = "https://api.githubcopilot.com/models"
-    private let session: URLSession
+    private var session: URLSession
 
     // Cache for available models (per access token)
     private var modelsCache: [String: (models: [CopilotModelInfo], expiry: Date)] = [:]
     private let modelsCacheTTL: TimeInterval = 300 // 5 minutes
 
     init() {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 15
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
+        self.session = URLSession(configuration: config)
+    }
+
+    /// Update the URLSession with current proxy settings
+    func updateProxyConfiguration() {
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
         self.session = URLSession(configuration: config)
     }
     

--- a/Quotio/Services/QuotaFetchers/CursorQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CursorQuotaFetcher.swift
@@ -58,13 +58,21 @@ nonisolated struct CursorAuthData: Sendable {
 
 /// Fetches quota from Cursor using stored auth
 actor CursorQuotaFetcher {
-    private let session: URLSession
+    private var session: URLSession
     private let cursorAPIBase = "https://api2.cursor.sh"
     private let stateDBPath = "~/Library/Application Support/Cursor/User/globalStorage/state.vscdb"
     
     init() {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 15
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
+        config.httpAdditionalHeaders = [
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+        ]
+        self.session = URLSession(configuration: config)
+    }
+
+    /// Update the URLSession with current proxy settings
+    func updateProxyConfiguration() {
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
         config.httpAdditionalHeaders = [
             "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
         ]

--- a/Quotio/Services/QuotaFetchers/GeminiCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/GeminiCLIQuotaFetcher.swift
@@ -57,7 +57,18 @@ actor GeminiCLIQuotaFetcher {
     private let authFilePath = "~/.gemini/oauth_creds.json"
     private let accountsFilePath = "~/.gemini/google_accounts.json"
     private let executor = CLIExecutor.shared
-    
+
+    // Note: Gemini CLI interactions are handled by the executor, which spawns processes.
+    // The current CLIExecutor implementation does not seem to support explicit proxy configuration
+    // for the executed commands.
+    // However, if we were making HTTP requests here, we would use ProxyConfigurationService.
+
+    /// Update the URLSession with current proxy settings
+    /// (No-op for now as Gemini CLI uses shell commands, but kept for protocol conformance)
+    func updateProxyConfiguration() {
+        // Future: If GeminiFetcher starts making direct HTTP calls, update session here
+    }
+
     /// Check if Gemini CLI is installed
     func isInstalled() async -> Bool {
         return await executor.isCLIInstalled(name: "gemini")

--- a/Quotio/Services/QuotaFetchers/KiroQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/KiroQuotaFetcher.swift
@@ -67,12 +67,17 @@ actor KiroQuotaFetcher {
     private let usageEndpoint = "https://codewhisperer.us-east-1.amazonaws.com/getUsageLimits"
     private let tokenEndpoint = "https://oidc.us-east-1.amazonaws.com/token"
 
-    private let session: URLSession
+    private var session: URLSession
     private let fileManager = FileManager.default
 
     init() {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 20
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 20)
+        self.session = URLSession(configuration: config)
+    }
+
+    /// Update the URLSession with current proxy settings
+    func updateProxyConfiguration() {
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 20)
         self.session = URLSession(configuration: config)
     }
 

--- a/Quotio/Services/QuotaFetchers/OpenAIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/OpenAIQuotaFetcher.swift
@@ -9,11 +9,16 @@ actor OpenAIQuotaFetcher {
     private let usageURL = "https://chatgpt.com/backend-api/wham/usage"
     private let tokenURL = "https://token.oaifree.com/api/auth/refresh"
     
-    private let session: URLSession
+    private var session: URLSession
     
     init() {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 15
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
+        self.session = URLSession(configuration: config)
+    }
+
+    /// Update the URLSession with current proxy settings
+    func updateProxyConfiguration() {
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
         self.session = URLSession(configuration: config)
     }
     

--- a/Quotio/Services/QuotaFetchers/TraeQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/TraeQuotaFetcher.swift
@@ -40,13 +40,21 @@ struct TraeQuotaInfo: Sendable {
 
 /// Fetches quota from Trae using stored auth
 actor TraeQuotaFetcher {
-    private let session: URLSession
+    private var session: URLSession
     private let storageJsonPath = "~/Library/Application Support/Trae/User/globalStorage/storage.json"
     private let authKey = "iCubeAuthInfo://icube.cloudide"
     
     init() {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 15
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
+        config.httpAdditionalHeaders = [
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+        ]
+        self.session = URLSession(configuration: config)
+    }
+
+    /// Update the URLSession with current proxy settings
+    func updateProxyConfiguration() {
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
         config.httpAdditionalHeaders = [
             "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
         ]


### PR DESCRIPTION
Introduce ProxyConfigurationService to centralize proxy settings and update all quota fetchers to route HTTP requests through a user-configurable proxy. This enables users behind corporate proxies or firewalls to use the app.

Changes:
- Add ProxyConfigurationService.swift for centralized proxy configuration
- Update all quota fetchers (Antigravity, Claude Code, Codex CLI, Copilot, Cursor, Gemini CLI, GLM, Kiro, OpenAI, Trae) to use proxied URLSession
- Update AgentConfigurationService to use proxy for API requests
- Update CLIProxyManager to use proxy for GitHub API calls
- Add updateProxyConfiguration() method to all fetchers for dynamic updates
- Add proxy URL observer in QuotaViewModel to refresh configs on changes
- Add .DS_Store to .gitignore