### PR TITLE
Fix duplicate glm-api-key entries in config file (#148)

### DIFF
--- a/Quotio/Services/CustomProviderService.swift
+++ b/Quotio/Services/CustomProviderService.swift
@@ -186,13 +186,15 @@ final class CustomProviderService {
     private func removeCustomProviderSections(from content: String) -> String {
         var result = content
         
+        // Dynamically derive custom provider keys from CustomProviderType enum
+        // This ensures new provider types are automatically handled
+        let customProviderKeys = CustomProviderType.allCases.map { "\($0.rawValue):" }
+        
         // Remove marker comment and everything after it that belongs to custom providers
         if let markerRange = result.range(of: "# Custom Providers (managed by Quotio)") {
             // Find the end of custom providers section (next top-level key or end of file)
             let afterMarker = result[markerRange.upperBound...]
             
-            // Find next top-level key that's NOT a custom provider type
-            let customProviderKeys = ["openai-compatibility:", "claude-api-key:", "gemini-api-key:", "codex-api-key:"]
             var endIndex = result.endIndex
             
             // Look for any non-custom-provider top-level key
@@ -217,7 +219,7 @@ final class CustomProviderService {
         }
         
         // Also remove standalone custom provider sections that might exist without marker
-        for key in ["openai-compatibility:", "claude-api-key:", "gemini-api-key:", "codex-api-key:"] {
+        for key in customProviderKeys {
             result = removeYAMLSection(key, from: result)
         }
         


### PR DESCRIPTION
## Summary
based on my issue: https://github.com/nguyenphutrong/quotio/issues/148 - Proxy fails to start due to duplicate `glm-api-key` entries accumulating in the config file.
## Problem
The `removeCustomProviderSections()` function used a hardcoded list of custom provider keys that did not include `glm-api-key:`. This caused GLM provider configurations to accumulate rather than being replaced on each sync, resulting in invalid YAML that CLIProxyAPI could not parse.
## Solution
Replace the hardcoded list with a dynamically derived list from `CustomProviderType.allCases`. This ensures all provider types (including `glm-api-key` and any future types) are properly cleaned up before syncing.
## Changes
- `CustomProviderService.swift`: Use `CustomProviderType.allCases.map { "\($0.rawValue):" }` instead of hardcoded array
## Testing
- Built and verified the fix compiles successfully
- Users with corrupted configs should manually clean up duplicate entries or delete and recreate their config