### PR TITLE
fix: prevent crash in String.index(after:) at boundary

### DIFF
--- a/Quotio/Services/CustomProviderService.swift
+++ b/Quotio/Services/CustomProviderService.swift
@@ -235,6 +235,11 @@ final class CustomProviderService {
             return result
         }
         
+        guard startRange.upperBound < result.endIndex else {
+            result.removeSubrange(startRange.lowerBound..<result.endIndex)
+            return result
+        }
+        
         let searchStart = result.index(after: startRange.upperBound)
         guard searchStart < result.endIndex else {
             result.removeSubrange(startRange.lowerBound..<result.endIndex)

--- a/Quotio/Services/ShellProfileManager.swift
+++ b/Quotio/Services/ShellProfileManager.swift
@@ -36,7 +36,11 @@ actor ShellProfileManager {
             
             if let startRange = content.range(of: marker),
                let endRange = content.range(of: endMarker) {
-                let fullRange = startRange.lowerBound..<content.index(after: endRange.upperBound)
+                // Safe bounds check: only advance if not at end
+                let endBound = endRange.upperBound < content.endIndex
+                    ? content.index(after: endRange.upperBound)
+                    : endRange.upperBound
+                let fullRange = startRange.lowerBound..<endBound
                 content.removeSubrange(fullRange)
             }
         } else {


### PR DESCRIPTION
## Summary

- Fix `EXC_BREAKPOINT` crash in `String.index(after:)` when indices are at string boundaries
- Add bounds checking before advancing string indices in two locations

## Root Cause

The app crashed when calling `String.index(after:)` on an index already at `endIndex`. This is a Swift runtime assertion failure that occurs during shell profile manipulation and YAML section removal.

## Changes

| File | Fix |
|------|-----|
| `ShellProfileManager.swift` | Check `endRange.upperBound < content.endIndex` before advancing |
| `CustomProviderService.swift` | Add guard to check bounds before calling `index(after:)` |

## Testing

- [x] Build succeeds
- [x] Code review passed
- [x] Edge cases verified safe

Fixes #103