### PR TITLE
fix: add missing plan types to planDisplayName

### DIFF
--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -250,11 +250,19 @@ nonisolated struct ProviderQuotaData: Codable, Sendable {
     var planDisplayName: String? {
         guard let plan = planType?.lowercased() else { return nil }
         switch plan {
+        case "guest": return "Guest"
+        case "free": return "Free"
+        case "go": return "Go"
         case "plus": return "Plus"
         case "pro": return "Pro"
+        case "free_workspace": return "Free Workspace"
         case "team": return "Team"
+        case "business": return "Business"
+        case "education": return "Education"
+        case "quorum": return "Quorum"
+        case "k12": return "K-12"
         case "enterprise": return "Enterprise"
-        case "free": return "Free"
+        case "edu": return "Edu"
         default: return planType?.capitalized
         }
     }


### PR DESCRIPTION
## Summary
- Add 8 additional plan types to `planDisplayName` in `ProviderQuotaData` to match CodexBar's implementation
- New plan types: `guest`, `go`, `free_workspace`, `business`, `education`, `quorum`, `k12`, `edu`

## Changes
- Updated `Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift`

## Context
Fixes #111 - Quotio was missing several plan types that CodexBar supports, causing some plans to display incorrectly or fall back to capitalized raw values.

## Testing
- Build verified: ✅ `** BUILD SUCCEEDED **`