### PR TITLE
fix: treat educational quota as Pro for GitHub Copilot

### DIFF
--- a/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
@@ -88,24 +88,33 @@ nonisolated struct CopilotEntitlement: Codable, Sendable {
         let sku = accessTypeSku?.lowercased() ?? ""
         let plan = copilotPlan?.lowercased() ?? ""
 
-        // Check free first - sku takes priority as it's more specific
-        if sku.contains("free") {
-            return "Free"
-        }
+        // Enterprise/Business check first (highest tiers)
         if sku.contains("enterprise") || plan == "enterprise" {
             return "Enterprise"
         }
         if sku.contains("business") || plan == "business" {
             return "Business"
         }
+        
+        // Educational quota is treated as Pro (unlimited chat/completions)
+        if sku.contains("educational") {
+            return "Pro"
+        }
+        
+        // Pro checks
         if sku.contains("pro") || plan.contains("pro") {
             return "Pro"
         }
-        // individual without free sku means paid Pro
-        if plan == "individual" || sku.contains("individual") {
+        
+        // Individual plan without "free_limited" sku means paid Pro
+        if plan == "individual" && !sku.contains("free_limited") {
             return "Pro"
         }
-        // Fallback for other free plans
+        
+        // Free tier: only "free_limited_user" or explicit free plan
+        if sku.contains("free_limited") || sku == "free" {
+            return "Free"
+        }
         if plan.contains("free") {
             return "Free"
         }


### PR DESCRIPTION
## Summary
- Fix incorrect plan display for GitHub Copilot educational accounts
- `free_educational_quota` SKU now shows as "Pro" instead of "Free"

## Problem
The previous logic checked `sku.contains("free")` first, which incorrectly matched `free_educational_quota` as a Free tier account. However, educational accounts have Pro-level features (unlimited chat/completions).

## Solution
Reorder the plan detection logic:
1. Enterprise/Business (highest tiers)
2. **Educational** → Pro (new)
3. Pro
4. Free (only `free_limited` SKU)

## Test Case
```json
{
  "access_type_sku": "free_educational_quota",
  "copilot_plan": "individual"
}
```
- Before: "Free"
- After: "Pro" ✅