### PR TITLE
fix: prevent routing strategy reset when leaving settings view

### DIFF
--- a/Quotio/Views/Screens/SettingsScreen.swift
+++ b/Quotio/Views/Screens/SettingsScreen.swift
@@ -336,6 +336,7 @@ struct UnifiedProxySettingsSection: View {
     
     @State private var isLoading = true
     @State private var loadError: String?
+    @State private var isLoadingConfig = false  // Prevents onChange from firing during load
     
     @State private var proxyURL = ""
     @State private var routingStrategy = "round-robin"
@@ -469,6 +470,7 @@ struct UnifiedProxySettingsSection: View {
             }
             .pickerStyle(.segmented)
             .onChange(of: routingStrategy) { _, newValue in
+                guard !isLoadingConfig else { return }
                 Task { await saveRoutingStrategy(newValue) }
             }
         } header: {
@@ -485,10 +487,12 @@ struct UnifiedProxySettingsSection: View {
         Section {
             Toggle("settings.autoSwitchAccount".localized(), isOn: $switchProject)
                 .onChange(of: switchProject) { _, newValue in
+                    guard !isLoadingConfig else { return }
                     Task { await saveSwitchProject(newValue) }
                 }
             Toggle("settings.autoSwitchPreview".localized(), isOn: $switchPreviewModel)
                 .onChange(of: switchPreviewModel) { _, newValue in
+                    guard !isLoadingConfig else { return }
                     Task { await saveSwitchPreviewModel(newValue) }
                 }
         } header: {
@@ -503,11 +507,13 @@ struct UnifiedProxySettingsSection: View {
         Section {
             Stepper("settings.maxRetries".localized() + ": \(requestRetry)", value: $requestRetry, in: 0...10)
                 .onChange(of: requestRetry) { _, newValue in
+                    guard !isLoadingConfig else { return }
                     Task { await saveRequestRetry(newValue) }
                 }
             
             Stepper("settings.maxRetryInterval".localized() + ": \(maxRetryInterval)s", value: $maxRetryInterval, in: 5...300, step: 5)
                 .onChange(of: maxRetryInterval) { _, newValue in
+                    guard !isLoadingConfig else { return }
                     Task { await saveMaxRetryInterval(newValue) }
                 }
         } header: {
@@ -522,16 +528,19 @@ struct UnifiedProxySettingsSection: View {
         Section {
             Toggle("settings.loggingToFile".localized(), isOn: $loggingToFile)
                 .onChange(of: loggingToFile) { _, newValue in
+                    guard !isLoadingConfig else { return }
                     Task { await saveLoggingToFile(newValue) }
                 }
             
             Toggle("settings.requestLog".localized(), isOn: $requestLog)
                 .onChange(of: requestLog) { _, newValue in
+                    guard !isLoadingConfig else { return }
                     Task { await saveRequestLog(newValue) }
                 }
             
             Toggle("settings.debugMode".localized(), isOn: $debugMode)
                 .onChange(of: debugMode) { _, newValue in
+                    guard !isLoadingConfig else { return }
                     Task { await saveDebugMode(newValue) }
                 }
         } header: {
@@ -544,6 +553,7 @@ struct UnifiedProxySettingsSection: View {
     
     private func loadConfig() async {
         isLoading = true
+        isLoadingConfig = true
         loadError = nil
         
         guard let apiClient = viewModel.apiClient else {
@@ -551,6 +561,7 @@ struct UnifiedProxySettingsSection: View {
                 ? "settings.proxy.startToConfigureAdvanced".localized()
                 : "settings.remote.noConnection".localized()
             isLoading = false
+            isLoadingConfig = false
             return
         }
         
@@ -567,9 +578,11 @@ struct UnifiedProxySettingsSection: View {
             switchPreviewModel = config.quotaExceeded?.switchPreviewModel ?? true
             proxyURLValidation = ProxyURLValidator.validate(proxyURL)
             isLoading = false
+            isLoadingConfig = false
         } catch {
             loadError = error.localizedDescription
             isLoading = false
+            isLoadingConfig = false
         }
     }
     


### PR DESCRIPTION
## Summary

Fixes the bug where selecting "fill first" routing strategy would reset to "round-robin" when leaving and returning to the settings view.

## Root Cause

When the settings view appears, `loadConfig()` fetches configuration from the API and updates `@State` variables. This triggers `.onChange` handlers which would immediately call save functions with the loaded value, causing a race condition that reset settings.

## Solution

Added an `isLoadingConfig` flag that:
1. Is set to `true` at the start of `loadConfig()`
2. Is set to `false` after all state updates complete
3. All `.onChange` handlers check `guard !isLoadingConfig else { return }` to prevent saving during initial load

This prevents the save functions from being called when values are being loaded from the API, only triggering them on actual user interactions.

## Changes

- Added `@State private var isLoadingConfig = false` flag
- Added guard clauses to all 8 relevant `onChange` handlers in `UnifiedProxySettingsSection`
- Wrapped state updates in `loadConfig()` with the flag

## Testing

- Build succeeds
- Manual testing: routing strategy now persists correctly when navigating away and back to settings