### PR TITLE
feat(agents setup): add OpenCode model slots configuration

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -1367,6 +1367,64 @@
         }
       }
     },
+    "agents.opencode.primaryModel": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primary Model (Main)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modèle principal"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mô hình chính"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主模型"
+          }
+        }
+      }
+    },
+    "agents.opencode.smallModel": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Small Model (Fast)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Petit modèle (Rapide)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mô hình nhỏ (Nhanh)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小模型 (快速)"
+          }
+        }
+      }
+    },
     "agents.proxyURL": {
       "extractionState": "stale",
       "localizations": {
@@ -1450,6 +1508,122 @@
           "stringUnit": {
             "state": "translated",
             "value": "重新配置"
+          }
+        }
+      }
+    },
+    "agents.restoreDefault": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore Default"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurer par défaut"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Khôi phục mặc định"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复默认"
+          }
+        }
+      }
+    },
+    "agents.restoreDefault.confirm": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurer"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Khôi phục"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复"
+          }
+        }
+      }
+    },
+    "agents.restoreDefault.message": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This will remove model and small_model settings from opencode.json. OpenCode will use its default model selection."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cela supprimera les paramètres model et small_model de opencode.json. OpenCode utilisera sa sélection de modèle par défaut."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thao tác này sẽ xóa cài đặt model và small_model khỏi opencode.json. OpenCode sẽ sử dụng lựa chọn mô hình mặc định."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这将从 opencode.json 中删除 model 和 small_model 设置。OpenCode 将使用其默认模型选择。"
+          }
+        }
+      }
+    },
+    "agents.restoreDefault.title": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore Default Settings?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurer les paramètres par défaut ?"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Khôi phục cài đặt mặc định?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复默认设置？"
           }
         }
       }

--- a/Quotio/Models/AgentModels.swift
+++ b/Quotio/Models/AgentModels.swift
@@ -183,6 +183,29 @@ nonisolated enum ModelSlot: String, CaseIterable, Identifiable, Codable, Sendabl
     }
 }
 
+// MARK: - OpenCode Model Slots
+
+nonisolated enum OpenCodeModelSlot: String, CaseIterable, Identifiable, Codable, Sendable {
+    case primary = "primary"
+    case small = "small"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .primary: return "agents.opencode.primaryModel".localizedStatic()
+        case .small: return "agents.opencode.smallModel".localizedStatic()
+        }
+    }
+
+    var configKey: String {
+        switch self {
+        case .primary: return "model"
+        case .small: return "small_model"
+        }
+    }
+}
+
 // MARK: - Available Models for Routing
 
 nonisolated struct AvailableModel: Identifiable, Codable, Hashable, Sendable {
@@ -201,6 +224,11 @@ nonisolated struct AvailableModel: Identifiable, Codable, Hashable, Sendable {
         .opus: AvailableModel(id: "opus", name: "gemini-claude-opus-4-5-thinking", provider: "openai", isDefault: true),
         .sonnet: AvailableModel(id: "sonnet", name: "gemini-claude-sonnet-4-5", provider: "openai", isDefault: true),
         .haiku: AvailableModel(id: "haiku", name: "gemini-3-flash-preview", provider: "openai", isDefault: true)
+    ]
+
+    static let openCodeDefaultModels: [OpenCodeModelSlot: AvailableModel] = [
+        .primary: AvailableModel(id: "primary", name: "gemini-claude-opus-4-5-thinking", provider: "anthropic", isDefault: true),
+        .small: AvailableModel(id: "small", name: "gemini-3-flash-preview", provider: "google", isDefault: true)
     ]
 
     static let allModels: [AvailableModel] = [
@@ -267,6 +295,7 @@ nonisolated struct AgentStatus: Identifiable, Sendable {
 nonisolated struct AgentConfiguration: Codable, Sendable {
     let agent: CLIAgent
     var modelSlots: [ModelSlot: String]
+    var openCodeModelSlots: [OpenCodeModelSlot: String]
     var proxyURL: String
     var apiKey: String
     var useOAuth: Bool
@@ -280,6 +309,10 @@ nonisolated struct AgentConfiguration: Codable, Sendable {
             .opus: AvailableModel.defaultModels[.opus]!.name,
             .sonnet: AvailableModel.defaultModels[.sonnet]!.name,
             .haiku: AvailableModel.defaultModels[.haiku]!.name
+        ]
+        self.openCodeModelSlots = [
+            .primary: AvailableModel.openCodeDefaultModels[.primary]!.name,
+            .small: AvailableModel.openCodeDefaultModels[.small]!.name
         ]
     }
 }

--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -413,6 +413,11 @@ actor AgentConfigurationService {
                 existingConfig["$schema"] = "https://opencode.ai/config.json"
             }
 
+            let primaryModel = config.openCodeModelSlots[.primary] ?? AvailableModel.openCodeDefaultModels[.primary]!.name
+            let smallModel = config.openCodeModelSlots[.small] ?? AvailableModel.openCodeDefaultModels[.small]!.name
+            existingConfig["model"] = "quotio/\(primaryModel)"
+            existingConfig["small_model"] = "quotio/\(smallModel)"
+
             var providers = existingConfig["provider"] as? [String: Any] ?? [:]
             providers["quotio"] = quotioProvider
             existingConfig["provider"] = providers
@@ -446,8 +451,8 @@ actor AgentConfigurationService {
                     mode: mode,
                     configPath: configPath,
                     rawConfigs: rawConfigs,
-                    instructions: "Configuration updated. Run 'opencode' and use /models to select a model (e.g., quotio/\(modelsToUse.first?.name ?? "model")).",
-                    modelsConfigured: quotioModels.count,
+                    instructions: "Configuration updated. Model: quotio/\(primaryModel), Small: quotio/\(smallModel)",
+                    modelsConfigured: quotioModels.count + 2,
                     backupPath: backupPath
                 )
             } else {
@@ -456,8 +461,8 @@ actor AgentConfigurationService {
                     mode: mode,
                     configPath: configPath,
                     rawConfigs: rawConfigs,
-                    instructions: "Merge provider.quotio section into your existing ~/.config/opencode/opencode.json:",
-                    modelsConfigured: quotioModels.count
+                    instructions: "Merge into ~/.config/opencode/opencode.json. Model: quotio/\(primaryModel), Small: quotio/\(smallModel)",
+                    modelsConfigured: quotioModels.count + 2
                 )
             }
         } catch {


### PR DESCRIPTION
 Summary
- Add Primary Model and Small Model dropdowns for OpenCode in AgentConfigSheet
- Read existing `model`/`small_model` from `~/.config/opencode/opencode.json` on load
- Write `quotio/model-name` format to config on Apply
- Add "Restore Default" button to remove model slots from config (with confirmation dialog)
- Full localization support (EN/FR/VI/ZH-Hans)

 Changes
| File | Description |
|------|-------------|
| `AgentModels.swift` | Added `OpenCodeModelSlot` enum and `openCodeDefaultModels` |
| `AgentSetupViewModel.swift` | Added load/save/restore logic for model slots |
| `AgentConfigurationService.swift` | Modified JSON generation with `quotio/` prefix |
| `AgentConfigSheet.swift` | Added UI dropdowns + restore button with confirmation |
| `Localizable.xcstrings` | Added i18n strings for new UI elements |

![PixPin_2026-01-13_23-37-43](https://github.com/user-attachments/assets/283b729b-4140-4e40-85f2-99b25b621c8d)
![PixPin_2026-01-13_23-38-30](https://github.com/user-attachments/assets/2b2b0902-22ea-4c4f-ac73-bd6433f1eb9d)

