### PR TITLE
fix(quota): correct Codex plan display and account scoping (#194 #111)

### DIFF
--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -180,7 +180,7 @@ final class StatusBarMenuBuilder {
         data: ProviderQuotaData,
         provider: AIProvider
     ) -> NSMenuItem {
-        let subscriptionInfo = viewModel.subscriptionInfos[email]
+        let subscriptionInfo = viewModel.subscriptionInfos[provider]?[email]
         let isActiveInIDE = provider == .antigravity && viewModel.isAntigravityAccountActive(email: email)
 
         let cardView = MenuAccountCardView(
@@ -620,22 +620,53 @@ private struct MenuAccountCardView: View {
     
     // Modern Tier Badge Config
     private var tierConfig: (name: String, bgColor: Color, textColor: Color)? {
-        guard let info = subscriptionInfo else { return nil }
+        if let info = subscriptionInfo {
+            let tierId = info.tierId.lowercased()
+            let tierName = info.tierDisplayName.lowercased()
+            
+            if tierId.contains("ultra") || tierName.contains("ultra") {
+                return ("Ultra", .orange.opacity(0.15), .orange)
+            }
+            if tierId.contains("pro") || tierName.contains("pro") {
+                return ("Pro", .blue.opacity(0.15), .blue)
+            }
+            if tierId.contains("standard") || tierId.contains("free") ||
+               tierName.contains("standard") || tierName.contains("free") {
+                return ("Free", .secondary.opacity(0.1), .secondary)
+            }
+            return (info.tierDisplayName, .secondary.opacity(0.1), .secondary)
+        }
         
-        let tierId = info.tierId.lowercased()
-        let tierName = info.tierDisplayName.lowercased()
+        guard let planName = data.planDisplayName else { return nil }
+        return planConfig(for: planName)
+    }
+    
+    private func planConfig(for planName: String) -> (name: String, bgColor: Color, textColor: Color) {
+        let lowercased = planName.lowercased()
         
-        if tierId.contains("ultra") || tierName.contains("ultra") {
+        if lowercased.contains("ultra") {
             return ("Ultra", .orange.opacity(0.15), .orange)
         }
-        if tierId.contains("pro") || tierName.contains("pro") {
+        if lowercased.contains("pro") {
             return ("Pro", .blue.opacity(0.15), .blue)
         }
-        if tierId.contains("standard") || tierId.contains("free") ||
-           tierName.contains("standard") || tierName.contains("free") {
+        if lowercased.contains("plus") {
+            return ("Plus", .blue.opacity(0.15), .blue)
+        }
+        if lowercased.contains("team") {
+            return ("Team", .orange.opacity(0.15), .orange)
+        }
+        if lowercased.contains("enterprise") {
+            return ("Enterprise", .red.opacity(0.15), .red)
+        }
+        if lowercased.contains("business") {
+            return ("Business", .red.opacity(0.15), .red)
+        }
+        if lowercased.contains("free") || lowercased.contains("standard") {
             return ("Free", .secondary.opacity(0.1), .secondary)
         }
-        return (info.tierDisplayName, .secondary.opacity(0.1), .secondary)
+        
+        return (planName, .secondary.opacity(0.1), .secondary)
     }
     
     private var isAntigravity: Bool {

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -80,8 +80,8 @@ final class QuotaViewModel {
     /// Quota data per provider per account (email -> QuotaData)
     var providerQuotas: [AIProvider: [String: ProviderQuotaData]] = [:]
     
-    /// Subscription info per account (email -> SubscriptionInfo)
-    var subscriptionInfos: [String: SubscriptionInfo] = [:]
+    /// Subscription info per provider per account (provider -> email -> SubscriptionInfo)
+    var subscriptionInfos: [AIProvider: [String: SubscriptionInfo]] = [:]
     
     /// Antigravity account switcher (for IDE token injection)
     let antigravitySwitcher = AntigravityAccountSwitcher.shared
@@ -1137,9 +1137,11 @@ final class QuotaViewModel {
         providerQuotas[.antigravity] = quotas
         
         // Merge instead of replace to preserve data if API fails
+        var providerInfos = subscriptionInfos[.antigravity] ?? [:]
         for (email, info) in subscriptions {
-            subscriptionInfos[email] = info
+            providerInfos[email] = info
         }
+        subscriptionInfos[.antigravity] = providerInfos
         
         // Detect active account in IDE (reads email directly from database)
         await antigravitySwitcher.detectActiveAccount()
@@ -1152,9 +1154,11 @@ final class QuotaViewModel {
         
         providerQuotas[.antigravity] = quotas
         
+        var providerInfos = subscriptionInfos[.antigravity] ?? [:]
         for (email, info) in subscriptions {
-            subscriptionInfos[email] = info
+            providerInfos[email] = info
         }
+        subscriptionInfos[.antigravity] = providerInfos
         // Note: Don't call detectActiveAccount() here - already set by switch operation
     }
     

--- a/Quotio/Views/Screens/QuotaScreen.swift
+++ b/Quotio/Views/Screens/QuotaScreen.swift
@@ -167,7 +167,7 @@ struct QuotaScreen: View {
                         provider: provider,
                         authFiles: viewModel.authFiles.filter { $0.providerType == provider },
                         quotaData: viewModel.providerQuotas[provider] ?? [:],
-                        subscriptionInfos: viewModel.subscriptionInfos,
+                        subscriptionInfos: viewModel.subscriptionInfos[provider] ?? [:],
                         isLoading: viewModel.isLoadingQuotas
                     )
                     .padding(.horizontal, 24)


### PR DESCRIPTION
## What
- Scope subscription info by provider to avoid cross-provider overrides
- Show plan badge in menubar using planDisplayName fallback
- Ensure Codex usage request includes ChatGPT-Account-Id (via account_id / id_token)

## Why
Fixes incorrect plan type and quota display when the same email is used across providers and ensures Codex team accounts show the correct plan.

Closes #194, actually fix #111

## Testing
before: I used the Codex account on Teamplan, and since it uses the same email as Antigravity, the plan type was overwritten.

<img width="2414" height="1850" alt="CleanShot 2026-01-16 at 17 22 58@2x" src="https://github.com/user-attachments/assets/53d2ad9d-6f45-4ed0-9018-3d242cd3d1ef" />
<img width="2414" height="1850" alt="CleanShot 2026-01-16 at 17 23 09@2x" src="https://github.com/user-attachments/assets/5940d2f7-8cb1-407e-b666-9f0115f67006" />

after: showing the correct plan type as team and quota updating normally

<img width="2414" height="1850" alt="CleanShot 2026-01-17 at 13 22 02@2x" src="https://github.com/user-attachments/assets/4986f2ba-190a-481d-8318-6a72aa94b19e" />
<img width="2414" height="1850" alt="CleanShot 2026-01-17 at 13 22 06@2x" src="https://github.com/user-attachments/assets/22f66dbf-df63-488e-8058-aea7d1644590" />


