### PR TITLE
fix: preserve prefix, project_id, and proxy_url fields when refreshing auth tokens

### DIFF
--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -415,6 +415,10 @@ nonisolated struct AntigravityAuthFile: Codable, Sendable {
     let refreshToken: String?
     let timestamp: Int?
     let type: String?
+    // Fields preserved during token refresh (used by CLIProxyAPI)
+    var prefix: String?
+    var projectId: String?
+    var proxyUrl: String?
     
     enum CodingKeys: String, CodingKey {
         case accessToken = "access_token"
@@ -424,6 +428,9 @@ nonisolated struct AntigravityAuthFile: Codable, Sendable {
         case refreshToken = "refresh_token"
         case timestamp
         case type
+        case prefix
+        case projectId = "project_id"
+        case proxyUrl = "proxy_url"
     }
     
     nonisolated var isExpired: Bool {

--- a/Quotio/Services/QuotaFetchers/OpenAIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/OpenAIQuotaFetcher.swift
@@ -293,6 +293,9 @@ nonisolated struct CodexAuthFile: Codable, Sendable {
     let idToken: String?
     let refreshToken: String?
     let type: String?
+    // Fields preserved during token refresh (used by CLIProxyAPI)
+    var prefix: String?
+    var proxyUrl: String?
     
     enum CodingKeys: String, CodingKey {
         case accessToken = "access_token"
@@ -302,6 +305,8 @@ nonisolated struct CodexAuthFile: Codable, Sendable {
         case idToken = "id_token"
         case refreshToken = "refresh_token"
         case type
+        case prefix
+        case proxyUrl = "proxy_url"
     }
     
     nonisolated var isExpired: Bool {


### PR DESCRIPTION
## Problem

When Quotio refreshes expired auth tokens and saves them back to disk, the `JSONEncoder` only serializes fields explicitly defined in the `Codable` struct. This causes user-defined fields in the auth JSON file to be lost.

Specifically, CLIProxyAPI supports a `prefix` field in auth files (e.g., `~/.cli-proxy-api/antigravity-xxx.json`) to route requests to specific credentials. After Quotio refreshes the token, this field is deleted.

**Steps to reproduce:**
1. Add `"prefix": "myprefix"` to an Antigravity auth file
2. Verify CLIProxyAPI recognizes the prefix (e.g., models show as `myprefix/gemini-...`)
3. Launch Quotio (which triggers token refresh if expired)
4. The `prefix` field is removed from the auth file

## Solution

Added the following optional fields to auth file structs so they are preserved during encode/decode:

**AntigravityAuthFile:**
- `prefix` - Used by CLIProxyAPI for model routing
- `projectId` - Google Cloud project ID
- `proxyUrl` - Per-auth proxy override

**CodexAuthFile:**
- `prefix` - Used by CLIProxyAPI for model routing
- `proxyUrl` - Per-auth proxy override
