### PR TITLE
Fix factoryDroid URL to correct docs site

### DIFF
--- a/Quotio/Models/AgentModels.swift
+++ b/Quotio/Models/AgentModels.swift
@@ -80,7 +80,7 @@ nonisolated enum CLIAgent: String, CaseIterable, Identifiable, Codable, Sendable
         case .geminiCLI: return URL(string: "https://github.com/google-gemini/gemini-cli")
         case .ampCLI: return URL(string: "https://ampcode.com/manual")
         case .openCode: return URL(string: "https://github.com/sst/opencode")
-        case .factoryDroid: return URL(string: "https://github.com/github/github-spark")
+        case .factoryDroid: return URL(string: "https://docs.factory.ai/welcome")
         }
     }
 


### PR DESCRIPTION
Fix factoryDroid URL which previously pointed to a deprecated GitHub Spark repository, and update it to the new official documentation at https://docs.factory.ai/welcome.