### PR TITLE
fix(quota): handle ISO8601 dates with and without fractional seconds

### DIFF
--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -874,7 +874,16 @@ private struct MenuAccountCardView: View {
     }
     
     private func formatLocalTime(_ isoString: String) -> String {
-        guard let date = ISO8601DateFormatter().date(from: isoString) else { return "" }
+        // Try parsing with fractional seconds first, then standard format
+        let isoFormatterWithFractional = ISO8601DateFormatter()
+        isoFormatterWithFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        let isoFormatterStandard = ISO8601DateFormatter()
+        isoFormatterStandard.formatOptions = [.withInternetDateTime]
+
+        guard let date = isoFormatterWithFractional.date(from: isoString)
+              ?? isoFormatterStandard.date(from: isoString) else { return "" }
+
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
@@ -890,8 +899,17 @@ private struct ModelBadgeData: Identifiable {
     var id: String { name }
 
     var formattedResetTime: String? {
-        guard let resetTime = resetTime,
-              let date = ISO8601DateFormatter().date(from: resetTime) else { return nil }
+        guard let resetTime = resetTime else { return nil }
+
+        // Try parsing with fractional seconds first, then standard format
+        let isoFormatterWithFractional = ISO8601DateFormatter()
+        isoFormatterWithFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        let isoFormatterStandard = ISO8601DateFormatter()
+        isoFormatterStandard.formatOptions = [.withInternetDateTime]
+
+        guard let date = isoFormatterWithFractional.date(from: resetTime)
+              ?? isoFormatterStandard.date(from: resetTime) else { return nil }
 
         let now = Date()
         let diff = date.timeIntervalSince(now)


### PR DESCRIPTION
## Summary
- Update `formattedResetTime` to try parsing ISO8601 dates with fractional seconds first, then fall back to standard format
- Apply fix to:
  - `ModelQuota.formattedResetTime` in AntigravityQuotaFetcher.swift
  - `GroupedModelQuota.formattedResetTime` in AntigravityQuotaFetcher.swift
  - `ModelBadgeData.formattedResetTime` in StatusBarMenuBuilder.swift
  - `formatLocalTime()` in StatusBarMenuBuilder.swift

## Problem
Reset time would not display for some providers (showing "—" instead of the actual time). This happened because:
- `ModelQuota.formattedResetTime` used `.withFractionalSeconds` option which requires fractional seconds in the input
- `CodexCLIQuotaFetcher` and some other providers return ISO8601 timestamps without fractional seconds
- When one provider had fractional seconds and another didn't, only one would display correctly

## Solution
Try parsing with fractional seconds first (for providers like Claude Code that include them), then fall back to standard format (for providers like Codex that don't).

## Test Plan
1. Set up accounts for both Claude Code and Codex
2. Refresh quota data
3. Verify that reset time displays correctly for both providers in the Quota view
4. Check menu bar tooltip also shows reset time correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
