### PR TITLE
fix: prevent infinite loading when checking updates without network

### DIFF
--- a/Quotio/Views/Screens/SettingsScreen.swift
+++ b/Quotio/Views/Screens/SettingsScreen.swift
@@ -1154,10 +1154,14 @@ struct ProxyUpdateSettingsSection: View {
     private func checkForUpdate() {
         isCheckingForUpdate = true
         upgradeError = nil
-        
+
         Task { @MainActor in
+            defer {
+                // Always reset loading state
+                isCheckingForUpdate = false
+            }
+
             await proxyManager.checkForUpgrade()
-            isCheckingForUpdate = false
         }
     }
     
@@ -2276,10 +2280,14 @@ struct AboutProxyUpdateSection: View {
     private func checkForUpdate() {
         isCheckingForUpdate = true
         upgradeError = nil
-        
+
         Task { @MainActor in
+            defer {
+                // Always reset loading state
+                isCheckingForUpdate = false
+            }
+
             await proxyManager.checkForUpgrade()
-            isCheckingForUpdate = false
         }
     }
     
@@ -2605,10 +2613,14 @@ struct AboutProxyUpdateCard: View {
     private func checkForUpdate() {
         isCheckingForUpdate = true
         upgradeError = nil
-        
+
         Task { @MainActor in
+            defer {
+                // Always reset loading state
+                isCheckingForUpdate = false
+            }
+
             await proxyManager.checkForUpgrade()
-            isCheckingForUpdate = false
         }
     }
     


### PR DESCRIPTION
## Summary
Fixes the issue where clicking "Check for Updates" with no network connection causes an infinite loading spinner.

## Problem
When the user clicks "Check for Updates" in settings and there's no network connection, the loading indicator spins indefinitely because `isCheckingForUpdate` is only reset after the async task completes. When network is unavailable, the URLSession can hang beyond the configured timeout.

## Solution
Added a `defer` block to ensure `isCheckingForUpdate` is always reset, even when network requests timeout or hang.

## Changes
- Added `defer` block to `checkForUpdate()` function in 3 locations:
  - `ProxyUpdateSettingsSection` (line 1154)
  - `AboutProxyUpdateSection` (line 2276)
  - `AboutProxyUpdateCard` (line 2605)

## Testing
- ✅ Build succeeds with no warnings
- ✅ Code compiles without errors
- Manual testing needed: Disable network and click "Check for Updates" - spinner should stop after timeout (~30s)

## Related
Reported issue: "when there is no network check update the app is loading infinity"