### PR TITLE
fix(agent): remove fd from Factory Droid binary detection

### DIFF
--- a/Quotio/Models/AgentModels.swift
+++ b/Quotio/Models/AgentModels.swift
@@ -58,7 +58,7 @@ nonisolated enum CLIAgent: String, CaseIterable, Identifiable, Codable, Sendable
         case .geminiCLI: return ["gemini"]
         case .ampCLI: return ["amp"]
         case .openCode: return ["opencode", "oc"]
-        case .factoryDroid: return ["droid", "factory-droid", "fd"]
+        case .factoryDroid: return ["droid", "factory-droid"]
         }
     }
 


### PR DESCRIPTION
## Problem

`fd` was incorrectly listed as a binary name for Factory Droid detection. However, `fd` is actually [sharkdp/fd](https://github.com/sharkdp/fd) - a popular file-finding tool (alternative to `find`).

This caused false positive detection:
- When `/opt/homebrew/bin/fd` (fd-find) is installed, it was incorrectly identified as Factory Droid

## Solution

Remove `fd` from Factory Droid's binary names list. The official Factory Droid CLI command is `droid`, not `fd`.

Reference: https://docs.factory.ai/reference/cli-reference

## Changes

- Remove `fd` from `binaryNames` for `.factoryDroid` case
- Keep `droid` and `factory-droid` as valid detection names