### PR TITLE
fix(shell): support XDG Base Directory for zsh config path

### DIFF
--- a/Quotio/Models/AgentModels.swift
+++ b/Quotio/Models/AgentModels.swift
@@ -418,7 +418,16 @@ nonisolated enum ShellType: String, CaseIterable, Sendable {
     var profilePath: String {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         switch self {
-        case .zsh: return "\(home)/.zshrc"
+        case .zsh:
+            if let zdotdir = ProcessInfo.processInfo.environment["ZDOTDIR"], !zdotdir.isEmpty {
+                return "\(zdotdir)/.zshrc"
+            }
+            let xdgConfigHome = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"] ?? "\(home)/.config"
+            let xdgZshDir = "\(xdgConfigHome)/zsh"
+            if FileManager.default.fileExists(atPath: xdgZshDir) {
+                return "\(xdgZshDir)/.zshrc"
+            }
+            return "\(home)/.zshrc"
         case .bash: return "\(home)/.bashrc"
         case .fish: return "\(home)/.config/fish/config.fish"
         }

--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -190,8 +190,7 @@ actor AgentConfigurationService {
     
     private func readGeminiCLIConfig() -> SavedAgentConfig? {
         // Gemini CLI uses environment variables, check shell profile
-        let home = fileManager.homeDirectoryForCurrentUser.path
-        let shellPaths = ["\(home)/.zshrc", "\(home)/.bashrc"]
+        let shellPaths = ShellType.allCases.map { $0.profilePath }
         
         for shellPath in shellPaths {
             guard let content = try? String(contentsOfFile: shellPath, encoding: .utf8) else { continue }
@@ -793,6 +792,7 @@ actor AgentConfigurationService {
             let jsonData = try JSONSerialization.data(withJSONObject: existingConfig, options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
             let jsonString = String(data: jsonData, encoding: .utf8) ?? "{}"
             
+            let shellProfilePath = ShellType.zsh.profilePath
             let rawConfigs = [
                 RawConfigOutput(
                     format: .json,
@@ -805,7 +805,7 @@ actor AgentConfigurationService {
                     format: .shellExport,
                     content: shellExports,
                     filename: nil,
-                    targetPath: "~/.zshrc or ~/.bashrc",
+                    targetPath: shellProfilePath,
                     instructions: "Option 2: Add to your shell profile"
                 )
             ]
@@ -965,7 +965,7 @@ actor AgentConfigurationService {
                 format: .shellExport,
                 content: exports,
                 filename: nil,
-                targetPath: "~/.zshrc or ~/.bashrc",
+                targetPath: ShellType.zsh.profilePath,
                 instructions: instructions
             )
         ]
@@ -1027,7 +1027,7 @@ actor AgentConfigurationService {
                 format: .shellExport,
                 content: envExports,
                 filename: nil,
-                targetPath: "~/.zshrc (alternative)",
+                targetPath: "\(ShellType.zsh.profilePath) (alternative)",
                 instructions: "Or add these environment variables instead"
             )
         ]


### PR DESCRIPTION
## Summary

- Add ZDOTDIR environment variable support for custom zsh config location
- Add XDG_CONFIG_HOME fallback to `~/.config/zsh/.zshrc` if directory exists
- Fall back to traditional `~/.zshrc` when no XDG paths are configured

## Problem

The app hardcoded `~/.zshrc` as the zsh configuration path, which doesn't work for users who follow the XDG Base Directory specification. Users with custom `ZDOTDIR` or `XDG_CONFIG_HOME` configurations would have their shell profiles ignored, causing agent configuration detection and export to fail.

## Changes

- Refactor `AgentConfigurationService` to use `ShellType.profilePath` instead of hardcoded paths
- Update Gemini CLI config reader to check all shell types dynamically
- Replace hardcoded "~/.zshrc or ~/.bashrc" strings with actual resolved paths
