### PR TITLE
feat(client): improve error handling for upstream proxy failures

### DIFF
--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -1366,9 +1366,18 @@ actor AgentConfigurationService {
                     modelResponded: nil
                 )
             } else {
+                var errorMessage = "HTTP \(httpResponse.statusCode)"
+                
+                // Try to parse detailed error message from proxy response (OpenAI format)
+                if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let errorObj = json["error"] as? [String: Any],
+                   let detailedMessage = errorObj["message"] as? String {
+                    errorMessage = detailedMessage
+                }
+                
                 return ConnectionTestResult(
                     success: false,
-                    message: "HTTP \(httpResponse.statusCode)",
+                    message: errorMessage,
                     latencyMs: latencyMs,
                     modelResponded: nil
                 )


### PR DESCRIPTION
This PR updates the AgentConfigurationService in Quotio to properly parse the JSON error body returned by the proxy when the upstream provider fails (returning a 500). Instead of showing 'HTTP 500', it will now display the detailed error message (e.g., 'Upstream quota exceeded').