### PR TITLE
fix(kiro): Use case-insensitive authMethod comparison for token refresh

### DIFF
--- a/Quotio/Services/DirectAuthFileService.swift
+++ b/Quotio/Services/DirectAuthFileService.swift
@@ -339,7 +339,8 @@ actor DirectAuthFileService {
 
                 // For IdC auth, if clientId/clientSecret are missing, try to load from AWS SSO cache
                 // Social auth (Google) doesn't need these credentials
-                if authMethod == "IdC" && (clientId == nil || clientSecret == nil) {
+                // Use case-insensitive comparison since CLIProxyAPI stores as "idc" (lowercase)
+                if authMethod.lowercased() == "idc" && (clientId == nil || clientSecret == nil) {
                     let (loadedClientId, loadedClientSecret) = loadKiroDeviceRegistration()
                     if let cid = loadedClientId, let csec = loadedClientSecret {
                         clientId = cid

--- a/Quotio/Services/QuotaFetchers/KiroQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/KiroQuotaFetcher.swift
@@ -316,9 +316,10 @@ actor KiroQuotaFetcher {
         }
 
         // Determine auth method: "Social" (Google) or "IdC" (AWS Builder ID)
-        let authMethod = tokenData.authMethod ?? "IdC"
+        // Use case-insensitive comparison since CLIProxyAPI may store as "idc" or "social" (lowercase)
+        let authMethod = (tokenData.authMethod ?? "IdC").lowercased()
 
-        if authMethod == "Social" {
+        if authMethod == "social" {
             let region = tokenData.extras?["region"] ?? defaultRegion
             return await refreshSocialTokenWithExpiry(refreshToken: refreshToken, region: region, filePath: filePath)
         } else {


### PR DESCRIPTION
## Background

This is a follow-up fix to PR #241 which I submitted to add dynamic region support for Enterprise/IdC authentication.

While #241 successfully fixed the hardcoded `us-east-1` region issue, I discovered that **"Import from Kiro IDE" users still experienced 403/500 errors after ~1 hour** due to token refresh failures.

After investigating the auth file structures, I found a case-sensitivity bug in the `authMethod` comparison.

## Problem

### Auth File Comparison

| Source | Field | Value |
|--------|-------|-------|
| **Kiro IDE** (`~/.aws/sso/cache/kiro-auth-token.json`) | `authMethod` | `"IdC"` (mixed case) |
| **CLIProxyAPI** (`~/.cli-proxy-api/kiro-*.json`) | `auth_method` | `"idc"` (lowercase) |

### Root Cause

```swift
// DirectAuthFileService.swift:342 - BEFORE
if authMethod == "IdC" && (clientId == nil || clientSecret == nil) {
    // This condition is FALSE when authMethod is "idc" (lowercase)
    // loadKiroDeviceRegistration() is never called!
}
```

When CLIProxyAPI imports from Kiro IDE via `-kiro-import`, it stores `auth_method: "idc"` (lowercase). However, the code compared with `"IdC"` (mixed case), causing:

1. `loadKiroDeviceRegistration()` was never called
2. `client_id` and `client_secret` were not loaded from `~/.aws/sso/cache/{clientIdHash}.json`
3. Token refresh failed due to missing credentials
4. Users got 403/500 errors after ~1 hour when the access token expired

## Solution

Use case-insensitive comparison for `authMethod`:

```swift
// AFTER
if authMethod.lowercased() == "idc" && (clientId == nil || clientSecret == nil) {
```

## Changes

| File | Change |
|------|--------|
| `DirectAuthFileService.swift` | Fix IdC auth method comparison (line 342) |
| `KiroQuotaFetcher.swift` | Fix Social/IdC auth method comparison (line 319-321) |

## Testing

- ✅ Verified with Enterprise account (ap-northeast-2 region)
- ✅ Confirmed `loadKiroDeviceRegistration()` is called when `auth_method: "idc"`
- ✅ Confirmed token refresh works correctly after "Import from Kiro IDE"
- ✅ Confirmed no regression for `--kiro-aws-login` flow

## Related Issues

- Fixes remaining issue from #237 (Kiro usage issues)
- Follow-up to #241 (Dynamic region support)