### PR TITLE
fix(proxy): use effectiveBinaryPath for auth commands and Finder reveal

### DIFF
--- a/Quotio/Services/Proxy/CLIProxyManager.swift
+++ b/Quotio/Services/Proxy/CLIProxyManager.swift
@@ -996,7 +996,8 @@ final class CLIProxyManager {
     }
     
     func revealInFinder() {
-        NSWorkspace.shared.selectFile(binaryPath, inFileViewerRootedAtPath: (binaryPath as NSString).deletingLastPathComponent)
+        let path = effectiveBinaryPath
+        NSWorkspace.shared.selectFile(path, inFileViewerRootedAtPath: (path as NSString).deletingLastPathComponent)
     }
 }
 
@@ -1086,7 +1087,7 @@ extension CLIProxyManager {
         
         return await withCheckedContinuation { continuation in
             let newAuthProcess = Process()
-            newAuthProcess.executableURL = URL(fileURLWithPath: binaryPath)
+            newAuthProcess.executableURL = URL(fileURLWithPath: effectiveBinaryPath)
             newAuthProcess.arguments = ["-config", configPath] + command.arguments
             
             let outputPipe = Pipe()


### PR DESCRIPTION
## Summary
- Fix authentication failure ("CLIProxyAPI does not exist") when using versioned storage
- Fix Finder reveal showing wrong location

## Problem
When versioned storage was added in 176a3a1, `runAuthCommand()` and `revealInFinder()` were not updated to use `effectiveBinaryPath`. They still used the legacy `binaryPath` which doesn't exist when using versioned storage.

## Changes
- `runAuthCommand`: use `effectiveBinaryPath` instead of `binaryPath`
- `revealInFinder`: use `effectiveBinaryPath` to show correct location