### PR TITLE
feat(proxy): add workaround to force primary API URL

### DIFF
--- a/Quotio/Views/Screens/SettingsScreen.swift
+++ b/Quotio/Views/Screens/SettingsScreen.swift
@@ -51,6 +51,21 @@ struct SettingsScreen: View {
                 Label("settings.language".localized(), systemImage: "globe")
             }
 
+            // Troubleshooting
+            Section {
+                Button("Apply Workaround (Backup & Force URL)") {
+                    CLIProxyManager.shared.applyBaseURLWorkaround()
+                }
+
+                Button("Restore Original Settings") {
+                    CLIProxyManager.shared.removeBaseURLWorkaround()
+                }
+            } header: {
+                Label("Troubleshooting", systemImage: "hammer.fill")
+            } footer: {
+                Text("Forces the proxy to use the primary Google API URL to fix slowness. Original settings are backed up and can be restored.")
+            }
+
             // Appearance
             AppearanceSettingsSection()
             


### PR DESCRIPTION
## Summary
- Adds a mechanism to force the proxy to use the primary Google API URL, bypassing the slow "sandbox" fallback.
- Implements a "Backup & Restore" system for auth files to ensure safety.
- Adds UI controls in **Settings > Troubleshooting** to apply and revert this workaround.

## Detailed Problem Analysis
The `CLIProxyAPI` binary contains internal logic to handle rate limits from the upstream Google Gemini API. When a request receives a `429 Too Many Requests` error, the binary attempts to recover by retrying the request against a "sandbox" endpoint (`daily-cloudcode-pa.sandbox.googleapis.com`).

**The Issue:**
1. **High Latency:** This sandbox endpoint is significantly slower than the production API or introduces a long timeout before failing. Logs show requests taking 15-20 seconds during this fallback phase, compared to 6-8 seconds normally.
2. **Delayed Rotation:** Because the binary spends time retrying on the slow sandbox URL, it delays reporting the failure back to the proxy manager. This prevents the "Round-Robin" strategy from quickly rotating to the next available account.
3. **User Experience:** The user perceives this as the app "freezing" or being extremely slow, even though valid accounts might be available in the pool.

**The Fix:**
By injecting `"base_url": "https://daily-cloudcode-pa.googleapis.com"` into the `metadata` of the authentication JSON files, we force the binary to stick to the primary production endpoint. This effectively disables the automatic fallback to the sandbox URL. When a rate limit is hit, the request fails faster, allowing the proxy manager to catch the error and rotate to a fresh account immediately.

## Changes
- `CLIProxyManager.swift`: Added `applyBaseURLWorkaround()` and `removeBaseURLWorkaround()` with backup logic.
- `SettingsScreen.swift`: Added "Troubleshooting" section with action buttons.

## Test Plan
1. Go to Settings > Troubleshooting.
2. Click "Apply Workaround".
3. Check `~/.cli-proxy-api/antigravity-*.json` files to verify `base_url` is added and `.bak` files are created.
4. Click "Restore Original Settings".
5. Verify files are restored to original state.