### PR TITLE
Fix image attachment support for OpenCode

### DIFF
--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -1162,16 +1162,32 @@ actor AgentConfigurationService {
 
         var modelConfig: [String: Any] = ["name": displayName]
 
-        // Determine limits based on model family
+        // Determine limits and capabilities based on model family
         if modelName.contains("claude") {
             modelConfig["limit"] = ["context": 200000, "output": 64000]
+            // Claude models support vision
+            modelConfig["attachment"] = true
+            modelConfig["modalities"] = ["input": ["text", "image"], "output": ["text"]]
         } else if modelName.contains("gemini") {
             modelConfig["limit"] = ["context": 1048576, "output": 65536]
+            // Gemini models support vision
+            modelConfig["attachment"] = true
+            modelConfig["modalities"] = ["input": ["text", "image"], "output": ["text"]]
         } else if modelName.contains("gpt") {
             modelConfig["limit"] = ["context": 400000, "output": 32768]
-        } else {
-            // Default limits
+            // GPT-4+ models support vision
+            modelConfig["attachment"] = true
+            modelConfig["modalities"] = ["input": ["text", "image"], "output": ["text"]]
+        } else if modelName.contains("qwen") && modelName.contains("vl") {
+            // Qwen VL (vision-language) models
             modelConfig["limit"] = ["context": 128000, "output": 16384]
+            modelConfig["attachment"] = true
+            modelConfig["modalities"] = ["input": ["text", "image"], "output": ["text"]]
+        } else {
+            // Default: text-only models
+            modelConfig["limit"] = ["context": 128000, "output": 16384]
+            modelConfig["attachment"] = false
+            modelConfig["modalities"] = ["input": ["text"], "output": ["text"]]
         }
 
         // Add reasoning options for thinking/reasoning models


### PR DESCRIPTION
## Summary

OpenCode requires both `attachment: true` and `modalities` fields to enable image uploads for vision-capable models. The config generator was only setting `limit` - missing these two critical fields.

## Changes

- Added `attachment` and `modalities` fields to `buildOpenCodeModelConfig()` for Claude, Gemini, GPT, and Qwen VL models
- Text-only models now explicitly set `attachment: false` with text-only modalities

## Root Cause

OpenCode's provider resolution (in `provider.ts`) checks capabilities like this:

```typescript
attachment: configModel?.attachment ?? existingModel?.capabilities?.attachment ?? false
input.image: configModel?.modalities?.input?.includes("image") ?? existingModel?.capabilities?.input?.image ?? false
```

For custom providers like Quotio that aren't in the models.dev database, both fields must be explicitly set - there's no fallback.

## Testing

Verified by checking the generated config:
- Before: `attachment: undefined, modalities: undefined` → images disabled
- After: `attachment: true, modalities: {input: ["text", "image"], ...}` → images work

Closes #272