### PR TITLE
Fix 101% quota display in menu bar

### DIFF
--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -577,7 +577,8 @@ actor AntigravityQuotaFetcher {
                     guard name.contains("gemini") || name.contains("claude") else { continue }
                     
                     if let quotaInfo = info.quotaInfo {
-                        let percentage = (quotaInfo.remainingFraction ?? 0) * 100
+                        // Clamp to 0-100 range (API can return remainingFraction > 1.0)
+                        let percentage = min(100, max(0, (quotaInfo.remainingFraction ?? 0) * 100))
                         let resetTime = quotaInfo.resetTime ?? ""
                         models.append(ModelQuota(name: name, percentage: percentage, resetTime: resetTime))
                     }


### PR DESCRIPTION
## Problem

Menu bar sometimes shows 101% for quota instead of valid percentage.

## Cause

The Antigravity API can return `remainingFraction` values slightly above 1.0. The code multiplies this by 100 without clamping:

```swift
let percentage = (quotaInfo.remainingFraction ?? 0) * 100
// If remainingFraction = 1.01, percentage = 101
```

## Fix

Clamp the value to 0-100 range:

```swift
let percentage = min(100, max(0, (quotaInfo.remainingFraction ?? 0) * 100))
```