### PR TITLE
Clamp quota percentages to 0-100 in all fetchers

### DIFF
--- a/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
@@ -24,11 +24,11 @@ nonisolated struct CopilotQuotaSnapshot: Codable, Sendable {
     
     nonisolated func calculatePercent(defaultTotal: Int) -> Double {
         if let percent = percentRemaining {
-            return percent
+            return min(100, max(0, percent))
         }
         let remaining = remaining ?? 0
         let total = entitlement ?? defaultTotal
-        return total > 0 ? (Double(remaining) / Double(total)) * 100 : 0
+        return total > 0 ? min(100, max(0, (Double(remaining) / Double(total)) * 100)) : 0
     }
 }
 
@@ -331,7 +331,7 @@ actor CopilotQuotaFetcher {
            let total = entitlement.monthlyQuotas {
             // Chat quota
             if let chatRemaining = remaining.chat, let chatTotal = total.chat, chatTotal > 0 {
-                let percentage = (Double(chatRemaining) / Double(chatTotal)) * 100.0
+                let percentage = min(100, max(0, (Double(chatRemaining) / Double(chatTotal)) * 100.0))
                 models.append(ModelQuota(
                     name: "copilot-chat",
                     percentage: percentage,
@@ -341,7 +341,7 @@ actor CopilotQuotaFetcher {
 
             // Completions quota
             if let compRemaining = remaining.completions, let compTotal = total.completions, compTotal > 0 {
-                let percentage = (Double(compRemaining) / Double(compTotal)) * 100.0
+                let percentage = min(100, max(0, (Double(compRemaining) / Double(compTotal)) * 100.0))
                 models.append(ModelQuota(
                     name: "copilot-completions",
                     percentage: percentage,

--- a/Quotio/Services/QuotaFetchers/CursorQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CursorQuotaFetcher.swift
@@ -34,7 +34,7 @@ nonisolated struct CursorQuotaInfo: Sendable {
         
         var remainingPercentage: Double {
             guard limit > 0 else { return 100 }
-            return Double(remaining) / Double(limit) * 100
+            return min(100, max(0, Double(remaining) / Double(limit) * 100))
         }
     }
     
@@ -357,7 +357,7 @@ actor CursorQuotaFetcher {
             // For on-demand, show used count (no limit typically)
             let percentage: Double
             if let limit = onDemand.limit, limit > 0, let remaining = onDemand.remaining {
-                percentage = Double(remaining) / Double(limit) * 100
+                percentage = min(100, max(0, Double(remaining) / Double(limit) * 100))
             } else {
                 percentage = 100 // Unlimited or no limit set
             }

--- a/Quotio/Services/QuotaFetchers/KiroQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/KiroQuotaFetcher.swift
@@ -538,7 +538,7 @@ actor KiroQuotaFetcher {
 
                     var percentage: Double = 0
                     if total > 0 {
-                        percentage = max(0, (total - used) / total * 100)
+                        percentage = min(100, max(0, (total - used) / total * 100))
                     }
 
                     // Calculate free trial expiry time
@@ -564,7 +564,7 @@ actor KiroQuotaFetcher {
                 // Add regular quota if it has meaningful limits
                 if regularTotal > 0 {
                     var percentage: Double = 0
-                    percentage = max(0, (regularTotal - regularUsed) / regularTotal * 100)
+                    percentage = min(100, max(0, (regularTotal - regularUsed) / regularTotal * 100))
 
                     // Use different name based on whether trial is active
                     let quotaName = hasActiveTrial ? "\(displayName) (Base)" : displayName

--- a/Quotio/Services/QuotaFetchers/TraeQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/TraeQuotaFetcher.swift
@@ -284,7 +284,7 @@ actor TraeQuotaFetcher {
         // Add Premium Fast quota (most important for users)
         if info.premiumFastLimit > 0 {
             let remaining = max(0, info.premiumFastLimit - info.premiumFastUsed)
-            let percentage = Double(remaining) / Double(info.premiumFastLimit) * 100
+            let percentage = min(100, max(0, Double(remaining) / Double(info.premiumFastLimit) * 100))
             
             var quotaModel = ModelQuota(
                 name: "premium-fast",
@@ -300,7 +300,7 @@ actor TraeQuotaFetcher {
         // Add Premium Slow quota
         if info.premiumSlowLimit > 0 {
             let remaining = max(0, info.premiumSlowLimit - info.premiumSlowUsed)
-            let percentage = Double(remaining) / Double(info.premiumSlowLimit) * 100
+            let percentage = min(100, max(0, Double(remaining) / Double(info.premiumSlowLimit) * 100))
             
             var quotaModel = ModelQuota(
                 name: "premium-slow",
@@ -316,7 +316,7 @@ actor TraeQuotaFetcher {
         // Add Advanced Model quota
         if info.advancedModelLimit > 0 {
             let remaining = max(0, info.advancedModelLimit - info.advancedModelUsed)
-            let percentage = Double(remaining) / Double(info.advancedModelLimit) * 100
+            let percentage = min(100, max(0, Double(remaining) / Double(info.advancedModelLimit) * 100))
             
             var quotaModel = ModelQuota(
                 name: "advanced-model",
@@ -332,7 +332,7 @@ actor TraeQuotaFetcher {
         // Add Auto Completion quota
         if info.autoCompletionLimit > 0 {
             let remaining = max(0, info.autoCompletionLimit - info.autoCompletionUsed)
-            let percentage = Double(remaining) / Double(info.autoCompletionLimit) * 100
+            let percentage = min(100, max(0, Double(remaining) / Double(info.autoCompletionLimit) * 100))
             
             var quotaModel = ModelQuota(
                 name: "auto-completion",

--- a/Quotio/Services/QuotaFetchers/WarpQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/WarpQuotaFetcher.swift
@@ -183,7 +183,7 @@ actor WarpQuotaFetcher {
             if isUnlimited {
                 percentage = 100
             } else if limit > 0 {
-                percentage = Double(remaining) / Double(limit) * 100
+                percentage = min(100, max(0, Double(remaining) / Double(limit) * 100))
             } else {
                 percentage = 0
             }
@@ -219,7 +219,7 @@ actor WarpQuotaFetcher {
 
                 let bonusPercentage: Double
                 if granted > 0 {
-                    bonusPercentage = Double(remainingCredits) / Double(granted) * 100
+                    bonusPercentage = min(100, max(0, Double(remainingCredits) / Double(granted) * 100))
                 } else {
                     bonusPercentage = 0
                 }

--- a/Quotio/Services/StatusBarManager.swift
+++ b/Quotio/Services/StatusBarManager.swift
@@ -233,6 +233,8 @@ struct StatusBarQuotaItemView: View {
     
     private func formatPercentage(_ value: Double) -> String {
         if value < 0 { return "--%"}
-        return String(format: "%.0f%%", value.rounded())
+        // Defensive clamp to valid 0-100 range
+        let clamped = min(100, max(0, value))
+        return String(format: "%.0f%%", clamped.rounded())
     }
 }


### PR DESCRIPTION
## Summary

Comprehensive fix to prevent invalid quota percentages (>100% or <0%) from appearing in the UI.

Companion to #274 which fixes the same issue in AntigravityQuotaFetcher.

## Changes

Added `min(100, max(0, ...))` clamping to percentage calculations in:

| Fetcher | Fixed Functions |
|---------|-----------------|
| CursorQuotaFetcher | `remainingPercentage`, on-demand calculation |
| CopilotQuotaFetcher | `calculatePercent`, chat/completions |
| WarpQuotaFetcher | main usage, bonus percentages |
| TraeQuotaFetcher | premium-fast, premium-slow, advanced-model, auto-completion |
| KiroQuotaFetcher | free trial and regular quota |
| StatusBarManager | defensive clamp in `formatPercentage` display |

## Root Cause

APIs can return values where `remaining > limit` due to timing issues, stale data, or edge cases. The calculation `remaining / limit * 100` then produces values >100%.

## Testing

This is a defensive fix - the UI should now never display percentages outside 0-100 range regardless of API response values.