### PR TITLE
Show warning icon for forbidden accounts instead of --%

### DIFF
--- a/Quotio/Models/MenuBarSettings.swift
+++ b/Quotio/Models/MenuBarSettings.swift
@@ -407,8 +407,10 @@ struct MenuBarQuotaDisplayItem: Identifiable {
     let accountShort: String
     let percentage: Double
     let provider: AIProvider
+    var isForbidden: Bool = false
     
     var statusColor: Color {
+        if isForbidden { return .orange }
         if percentage > 50 { return .green }
         if percentage > 20 { return .orange }
         return .red

--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -106,6 +106,7 @@ final class AppBootstrap {
             guard let provider = selectedItem.aiProvider else { continue }
 
             var displayPercent: Double = -1
+            var isForbidden = false
 
             if let accountQuotas = viewModel.providerQuotas[provider] {
                 // Robust key lookup: Try exact match first, then clean key (no .json)
@@ -115,9 +116,12 @@ final class AppBootstrap {
                     quotaData = accountQuotas[cleanKey]
                 }
 
-                if let quotaData = quotaData, !quotaData.models.isEmpty {
-                    let models = quotaData.models.map { (name: $0.name, percentage: $0.percentage) }
-                    displayPercent = menuBarSettings.totalUsagePercent(models: models)
+                if let quotaData = quotaData {
+                    isForbidden = quotaData.isForbidden
+                    if !quotaData.models.isEmpty {
+                        let models = quotaData.models.map { (name: $0.name, percentage: $0.percentage) }
+                        displayPercent = menuBarSettings.totalUsagePercent(models: models)
+                    }
                 }
             }
 
@@ -126,7 +130,8 @@ final class AppBootstrap {
                 providerSymbol: provider.menuBarSymbol,
                 accountShort: selectedItem.accountKey,
                 percentage: displayPercent,
-                provider: provider
+                provider: provider,
+                isForbidden: isForbidden
             ))
         }
 

--- a/Quotio/Services/StatusBarManager.swift
+++ b/Quotio/Services/StatusBarManager.swift
@@ -223,10 +223,16 @@ struct StatusBarQuotaItemView: View {
                     .fixedSize()
             }
             
-            Text(formatPercentage(displayPercent))
-                .font(.system(size: 11, weight: .medium, design: .monospaced))
-                .foregroundStyle(colorMode == .colored ? item.statusColor : .primary)
-                .fixedSize()
+            if item.isForbidden {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.orange)
+            } else if item.percentage >= 0 {
+                Text(formatPercentage(displayPercent))
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(colorMode == .colored ? item.statusColor : .primary)
+                    .fixedSize()
+            }
         }
         .fixedSize()
     }


### PR DESCRIPTION
When an account returns HTTP 403 (expired subscription, forbidden access, etc.), the menu bar currently shows "--%" which doesn't really tell you what's wrong.

This PR shows a ⚠ warning icon instead, making it immediately clear that something needs attention with that account.

**Changes:**
- Added `isForbidden` flag to `MenuBarQuotaDisplayItem`
- Updated `QuotioApp.swift` to pass through the forbidden state from quota data
- Modified `StatusBarQuotaItemView` to show orange warning triangle for forbidden accounts

The warning icon uses the same orange color that's already used for low quota states, so it fits with the existing visual language.