### PR TITLE
fix: Swift 6 strict concurrency errors

### DIFF
--- a/Quotio/Models/AppMode.swift
+++ b/Quotio/Models/AppMode.swift
@@ -87,7 +87,7 @@ enum AppMode: String, Codable, CaseIterable, Identifiable {
 // MARK: - App Mode Manager (DEPRECATED)
 
 @available(*, deprecated, message: "Use OperatingModeManager instead. AppModeManager will be removed in a future version.")
-@Observable
+@MainActor @Observable
 final class AppModeManager {
     static let shared = AppModeManager()
     

--- a/Quotio/Services/NotificationManager.swift
+++ b/Quotio/Services/NotificationManager.swift
@@ -86,10 +86,13 @@ final class NotificationManager {
         }
     }
     
-    func checkAuthorizationStatus() async {
+    nonisolated func checkAuthorizationStatus() async {
         let center = UNUserNotificationCenter.current()
         let settings = await center.notificationSettings()
-        isAuthorized = settings.authorizationStatus == .authorized
+        let authorized = settings.authorizationStatus == .authorized
+        await MainActor.run {
+            self.isAuthorized = authorized
+        }
     }
     
     // MARK: - Notification Sending


### PR DESCRIPTION
Fix Swift 6 strict concurrency errors

- Add @MainActor to AppModeManager for thread-safe singleton access
- Capture NSCache directly in ImageCacheService event handlers
- Make NotificationManager.checkAuthorizationStatus() non-isolated to avoid sending non-Sendable UNNotificationSettings across actor boundaries