### PR TITLE
feat: add gpt-5.3-codex model

### DIFF
--- a/Quotio/Models/AgentModels.swift
+++ b/Quotio/Models/AgentModels.swift
@@ -248,6 +248,7 @@ nonisolated struct AvailableModel: Identifiable, Codable, Hashable, Sendable {
         AvailableModel(id: "gemini-2.5-flash-lite", name: "gemini-2.5-flash-lite", provider: "google", isDefault: false),
         AvailableModel(id: "gemini-2.5-computer-use-preview-10-2025", name: "gemini-2.5-computer-use-preview-10-2025", provider: "google", isDefault: false),
         // GPT models
+        AvailableModel(id: "gpt-5.3-codex", name: "gpt-5.3-codex", provider: "openai", isDefault: false),
         AvailableModel(id: "gpt-5.2", name: "gpt-5.2", provider: "openai", isDefault: false),
         AvailableModel(id: "gpt-5.2-codex", name: "gpt-5.2-codex", provider: "openai", isDefault: false),
         AvailableModel(id: "gpt-5.1", name: "gpt-5.1", provider: "openai", isDefault: false),


### PR DESCRIPTION
Summary
- Add gpt-5.3-codex to the available model list for routing.

Impact
- Enables selecting gpt-5.3-codex in model slots.

Notes
- No other logic changes.

References / Links
- N/A
