### PR TITLE
fix: prevent Quotio from killing itself during port cleanup

### DIFF
--- a/Quotio/Services/Proxy/CLIProxyManager.swift
+++ b/Quotio/Services/Proxy/CLIProxyManager.swift
@@ -1061,25 +1061,34 @@ final class CLIProxyManager {
     
     /// Synchronous port cleanup for use in detached tasks.
     /// This method is `nonisolated` to allow calling from background threads.
+    /// IMPORTANT: Excludes own PID to prevent killing Quotio itself when ProxyBridge is running.
     nonisolated private static func killProcessOnPortSync(_ port: UInt16) {
         let lsofProcess = Process()
         lsofProcess.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
         lsofProcess.arguments = ["-ti", "tcp:\(port)"]
-        
+
         let pipe = Pipe()
         lsofProcess.standardOutput = pipe
         lsofProcess.standardError = FileHandle.nullDevice
-        
+
+        // Get own PID to avoid killing ourselves (ProxyBridge runs in our process)
+        let ownPid = ProcessInfo.processInfo.processIdentifier
+
         do {
             try lsofProcess.run()
             lsofProcess.waitUntilExit()
-            
+
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
             guard let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
                   !output.isEmpty else { return }
-            
+
             for pidString in output.components(separatedBy: .newlines) {
                 if let pid = Int32(pidString.trimmingCharacters(in: .whitespaces)) {
+                    // Never kill our own process - ProxyBridge uses NWListener in-process
+                    if pid == ownPid {
+                        NSLog("[CLIProxyManager] Skipping kill of own PID \(pid) on port \(port)")
+                        continue
+                    }
                     kill(pid, SIGKILL)
                 }
             }


### PR DESCRIPTION
## Summary
- Fixes crash when clicking "Apply Workaround (Backup & Force URL)" in Settings > Troubleshooting
- The app would silently disappear because `killProcessOnPortSync()` was killing Quotio's own process
- When ProxyBridge is enabled (default), Quotio owns the proxy port via in-process `NWListener`
- Added check to skip own PID to prevent self-termination

## Root Cause
When restarting the proxy, `killProcessOnPortSync()` uses `lsof` to find PIDs on the port, then kills them. Due to a race condition where ProxyBridge stops but port release is asynchronous, `lsof` would return Quotio's own PID. The subsequent `kill(pid, SIGKILL)` terminated Quotio itself (SIGKILL doesn't generate crash reports, hence "silent disappearance").

## Test plan
- [ ] Launch Quotio
- [ ] Go to Settings > Troubleshooting
- [ ] Click "Apply Workaround (Backup & Force URL)"
- [ ] Verify app remains running and proxy restarts successfully