### PR TITLE
fix: prevent spurious proxy restart when navigating to Settings

### DIFF
--- a/Quotio/Services/Proxy/CLIProxyManager.swift
+++ b/Quotio/Services/Proxy/CLIProxyManager.swift
@@ -28,6 +28,7 @@ final class CLIProxyManager {
     var allowNetworkAccess: Bool {
         get { UserDefaults.standard.bool(forKey: "allowNetworkAccess") }
         set {
+            guard newValue != UserDefaults.standard.bool(forKey: "allowNetworkAccess") else { return }
             UserDefaults.standard.set(newValue, forKey: "allowNetworkAccess")
             ensureConfigExists()
             if newValue {
@@ -163,6 +164,7 @@ final class CLIProxyManager {
     var port: UInt16 {
         get { proxyStatus.port }
         set {
+            guard newValue != proxyStatus.port else { return }
             proxyStatus.port = newValue
             UserDefaults.standard.set(Int(newValue), forKey: "proxyPort")
             updateConfigPort(newValue)


### PR DESCRIPTION
## Summary

Fixes #291 — Clicking Settings consistently causes the running gateway to restart and dashboard statistics to be lost, even when no configuration changes are made.

## Root Cause

When navigating to Settings in `localProxy` mode, `LocalProxyServerSection` is rendered with `@State portText = ""`. The `.onAppear` modifier sets `portText` to the current port (e.g. `"8080"`), which triggers `.onChange(of: portText)`, which calls `proxyManager.port = 8080`. The `port` setter had no same-value guard, so it unconditionally called `restartProxyIfRunning()` — restarting the proxy every time Settings was opened.

This happens on **every** navigation to Settings because SwiftUI destroys and recreates `LocalProxyServerSection` (conditionally rendered via `if modeManager.isLocalProxyMode`), resetting `@State` each time.

## Changes

**Defense in depth — fixes at both model and view layers:**

### `CLIProxyManager.swift` (model layer)
- **`port` setter**: Added `guard newValue != proxyStatus.port else { return }` — skip restart when value unchanged
- **`allowNetworkAccess` setter**: Added same-value guard — skip restart when value unchanged

### `SettingsScreen.swift` (view layer)
- **`LocalProxyServerSection`**: Added `isLoadingConfig` flag (same pattern already used by `UnifiedProxySettingsSection`)
  - Set `true` before `.onAppear` populates `portText`, cleared after via `DispatchQueue.main.async`
  - `.onChange(of: portText)` and `.onChange(of: allowNetworkAccess)` guarded with `!isLoadingConfig`

## Testing

- [x] `xcodebuild` build succeeds
- [ ] Manual: Navigate to Settings multiple times — proxy should NOT restart
- [ ] Manual: Change port in Settings — proxy should restart as expected
- [ ] Manual: Toggle network access — proxy should restart only when value actually changes