### PR TITLE
Remove menu bar account cap and flatten account list

### DIFF
--- a/Quotio/Models/Constants.swift
+++ b/Quotio/Models/Constants.swift
@@ -21,8 +21,4 @@ enum AppConstants {
     /// Default proxy port
     static let defaultProxyPort: UInt16 = 17080
     
-    // MARK: - UI
-    
-    /// Maximum number of items to display in menu bar
-    static let maxMenuBarItems = 3
 }

--- a/Quotio/Models/MenuBarSettings.swift
+++ b/Quotio/Models/MenuBarSettings.swift
@@ -430,17 +430,12 @@ final class MenuBarSettingsManager {
     private let colorModeKey = "menuBarColorMode"
     private let showMenuBarIconKey = "showMenuBarIcon"
     private let showQuotaKey = "menuBarShowQuota"
-    private let menuBarMaxItemsKey = "menuBarMaxItems"
     private let quotaDisplayModeKey = "quotaDisplayMode"
     private let quotaDisplayStyleKey = "quotaDisplayStyle"
     private let hideSensitiveInfoKey = "hideSensitiveInfo"
     private let totalUsageModeKey = "totalUsageMode"
     private let modelAggregationModeKey = "modelAggregationMode"
     private let hasUserModifiedMenuBarKey = "hasUserModifiedMenuBar"
-
-    static let minMenuBarItems = 1
-    static let maxMenuBarItems = 10
-    static let defaultMenuBarMaxItems = 3
 
     /// Whether to show menu bar icon at all
     var showMenuBarIcon: Bool {
@@ -452,14 +447,6 @@ final class MenuBarSettingsManager {
         didSet { defaults.set(showQuotaInMenuBar, forKey: showQuotaKey) }
     }
 
-    /// Maximum number of items to display in menu bar
-    var menuBarMaxItems: Int {
-        didSet {
-            defaults.set(menuBarMaxItems, forKey: menuBarMaxItemsKey)
-            enforceMaxItems()
-        }
-    }
-    
     /// Selected items to display
     var selectedItems: [MenuBarQuotaItem] {
         didSet { saveSelectedItems() }
@@ -501,18 +488,6 @@ final class MenuBarSettingsManager {
         didSet { defaults.set(hasUserModifiedMenuBar, forKey: hasUserModifiedMenuBarKey) }
     }
 
-    /// Check if adding another item would exceed the warning threshold
-    /// Warning shows when approaching the limit (at maxItems - 1)
-    var shouldWarnOnAdd: Bool {
-        let threshold = max(menuBarMaxItems - 1, 1)
-        return selectedItems.count >= threshold && selectedItems.count < menuBarMaxItems
-    }
-
-    /// Check if selection has reached the maximum items
-    var isAtMaxItems: Bool {
-        selectedItems.count >= menuBarMaxItems
-    }
-    
     private init() {
         // Show menu bar icon - default true if not set
         if defaults.object(forKey: showMenuBarIconKey) == nil {
@@ -526,29 +501,15 @@ final class MenuBarSettingsManager {
         }
         self.showQuotaInMenuBar = defaults.bool(forKey: showQuotaKey)
         
-        if defaults.object(forKey: menuBarMaxItemsKey) == nil {
-            defaults.set(Self.defaultMenuBarMaxItems, forKey: menuBarMaxItemsKey)
-        }
-
         self.colorMode = MenuBarColorMode(rawValue: defaults.string(forKey: colorModeKey) ?? "") ?? .colored
         self.quotaDisplayMode = QuotaDisplayMode(rawValue: defaults.string(forKey: quotaDisplayModeKey) ?? "") ?? .used
         self.quotaDisplayStyle = QuotaDisplayStyle(rawValue: defaults.string(forKey: quotaDisplayStyleKey) ?? "") ?? .card
         self.selectedItems = Self.loadSelectedItems(from: defaults, key: selectedItemsKey)
 
-        // Load and clamp menuBarMaxItems, then persist the clamped value
-        let loadedMax = defaults.integer(forKey: menuBarMaxItemsKey)
-        let clampedMax = Self.clampedMenuBarMax(loadedMax)
-        self.menuBarMaxItems = clampedMax
-        if loadedMax != clampedMax {
-            defaults.set(clampedMax, forKey: menuBarMaxItemsKey)
-        }
-
         self.hideSensitiveInfo = defaults.bool(forKey: hideSensitiveInfoKey)
         self.totalUsageMode = TotalUsageMode(rawValue: defaults.string(forKey: totalUsageModeKey) ?? "") ?? .sessionOnly
         self.modelAggregationMode = ModelAggregationMode(rawValue: defaults.string(forKey: modelAggregationModeKey) ?? "") ?? .lowest
         self.hasUserModifiedMenuBar = defaults.bool(forKey: hasUserModifiedMenuBarKey)
-
-        enforceMaxItems()
     }
     
     private func saveSelectedItems() {
@@ -567,7 +528,6 @@ final class MenuBarSettingsManager {
     
     func addItem(_ item: MenuBarQuotaItem) {
         guard !selectedItems.contains(item) else { return }
-        guard selectedItems.count < menuBarMaxItems else { return }
         if !showQuotaInMenuBar {
             showQuotaInMenuBar = true
         }
@@ -608,25 +568,9 @@ final class MenuBarSettingsManager {
         // Don't auto-add if user has manually modified the menu bar selection
         guard !hasUserModifiedMenuBar else { return }
 
-        enforceMaxItems()
         let existingIds = Set(selectedItems.map(\.id))
         let newItems = availableItems.filter { !existingIds.contains($0.id) }
-
-        let remainingSlots = menuBarMaxItems - selectedItems.count
-        if remainingSlots > 0 {
-            let itemsToAdd = Array(newItems.prefix(remainingSlots))
-            selectedItems.append(contentsOf: itemsToAdd)
-        }
+        selectedItems.append(contentsOf: newItems)
     }
 
-    @discardableResult
-    private func enforceMaxItems() -> Bool {
-        guard selectedItems.count > menuBarMaxItems else { return false }
-        selectedItems = Array(selectedItems.prefix(menuBarMaxItems))
-        return true
-    }
-
-    private static func clampedMenuBarMax(_ value: Int) -> Int {
-        min(max(value, minMenuBarItems), maxMenuBarItems)
-    }
 }

--- a/Quotio/Views/Components/AccountRow.swift
+++ b/Quotio/Views/Components/AccountRow.swift
@@ -142,8 +142,6 @@ struct AccountRow: View {
     var isActiveInIDE: Bool = false
     
     @State private var settings = MenuBarSettingsManager.shared
-    @State private var showWarning = false
-    @State private var showMaxItemsAlert = false
     @State private var showDeleteConfirmation = false
     
     private var isMenuBarSelected: Bool {
@@ -353,34 +351,10 @@ struct AccountRow: View {
         } message: {
             Text("providers.deleteMessage".localized())
         }
-        .alert("menubar.warning.title".localized(), isPresented: $showWarning) {
-            Button("menubar.warning.confirm".localized()) {
-                settings.toggleItem(account.menuBarItem)
-            }
-            Button("menubar.warning.cancel".localized(), role: .cancel) {}
-        } message: {
-            Text("menubar.warning.message".localized())
-        }
-        .alert("menubar.maxItems.title".localized(), isPresented: $showMaxItemsAlert) {
-            Button("action.ok".localized(), role: .cancel) {}
-        } message: {
-            Text(String(
-                format: "menubar.maxItems.message".localized(),
-                settings.menuBarMaxItems
-            ))
-        }
     }
     
     private func handleMenuBarToggle() {
-        if isMenuBarSelected {
-            settings.toggleItem(account.menuBarItem)
-        } else if settings.isAtMaxItems {
-            showMaxItemsAlert = true
-        } else if settings.shouldWarnOnAdd {
-            showWarning = true
-        } else {
-            settings.toggleItem(account.menuBarItem)
-        }
+        settings.toggleItem(account.menuBarItem)
     }
 }
 

--- a/Quotio/Views/Screens/SettingsScreen.swift
+++ b/Quotio/Views/Screens/SettingsScreen.swift
@@ -1670,8 +1670,6 @@ struct MenuBarSettingsSection: View {
     @Environment(QuotaViewModel.self) private var viewModel
     private let settings = MenuBarSettingsManager.shared
     @AppStorage("showInDock") private var showInDock = true
-    @State private var showTruncationAlert = false
-    @State private var pendingMaxItems: Int?
     
     private var showMenuBarIconBinding: Binding<Bool> {
         Binding(
@@ -1723,24 +1721,6 @@ struct MenuBarSettingsSection: View {
         )
     }
     
-    private var maxItemsBinding: Binding<Int> {
-        Binding(
-            get: { settings.menuBarMaxItems },
-            set: { newValue in
-                let clamped = min(max(newValue, MenuBarSettingsManager.minMenuBarItems), MenuBarSettingsManager.maxMenuBarItems)
-
-                // Check if reducing max items would truncate current selection
-                if clamped < settings.menuBarMaxItems && settings.selectedItems.count > clamped {
-                    pendingMaxItems = clamped
-                    showTruncationAlert = true
-                } else {
-                    settings.menuBarMaxItems = clamped
-                    viewModel.syncMenuBarSelection()
-                }
-            }
-        )
-    }
-    
     var body: some View {
         Section {
             Toggle("settings.showInDock".localized(), isOn: showInDockBinding)
@@ -1751,21 +1731,6 @@ struct MenuBarSettingsSection: View {
                 Toggle("settings.menubar.showQuota".localized(), isOn: showQuotaBinding)
                 
                 if settings.showQuotaInMenuBar {
-                    HStack {
-                        Text("settings.menubar.maxItems".localized())
-                        Spacer()
-                        Text("\(settings.menuBarMaxItems)")
-                            .monospacedDigit()
-                            .foregroundStyle(.primary)
-                        Stepper(
-                            "",
-                            value: maxItemsBinding,
-                            in: MenuBarSettingsManager.minMenuBarItems...MenuBarSettingsManager.maxMenuBarItems,
-                            step: 1
-                        )
-                        .labelsHidden()
-                    }
-                    
                     Picker("settings.menubar.colorMode".localized(), selection: colorModeBinding) {
                         Text("settings.menubar.colored".localized()).tag(MenuBarColorMode.colored)
                         Text("settings.menubar.monochrome".localized()).tag(MenuBarColorMode.monochrome)
@@ -1775,32 +1740,6 @@ struct MenuBarSettingsSection: View {
             }
         } header: {
             Label("settings.menubar".localized(), systemImage: "menubar.rectangle")
-        } footer: {
-            Text(String(
-                format: "settings.menubar.help".localized(),
-                settings.menuBarMaxItems
-            ))
-            .font(.caption)
-        }
-        .alert("menubar.truncation.title".localized(), isPresented: $showTruncationAlert) {
-            Button("action.cancel".localized(), role: .cancel) {
-                pendingMaxItems = nil
-            }
-            Button("action.ok".localized(), role: .destructive) {
-                if let newMax = pendingMaxItems {
-                    settings.menuBarMaxItems = newMax
-                    viewModel.syncMenuBarSelection()
-                    pendingMaxItems = nil
-                }
-            }
-        } message: {
-            if let newMax = pendingMaxItems {
-                Text(String(
-                    format: "menubar.truncation.message".localized(),
-                    settings.selectedItems.count,
-                    newMax
-                ))
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove the hard limit (max 10, default 3) on how many accounts can be displayed in the menu bar
- Flatten the providers screen from per-provider disclosure groups into a single sorted list of all accounts
- Remove the "Max Items" stepper from settings and all related enforcement/warning logic

## Test plan
- [ ] Add more than 3 accounts to menu bar — no limit alert should appear
- [ ] Verify all accounts show in a single flat list on the providers screen
- [ ] Verify menu bar displays all selected accounts correctly
- [ ] Quit and relaunch — selections should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)