### PR TITLE
fix: prevent proxy-start UI reentrancy crash

### DIFF
--- a/Quotio/Services/Proxy/CLIProxyManager.swift
+++ b/Quotio/Services/Proxy/CLIProxyManager.swift
@@ -955,10 +955,6 @@ final class CLIProxyManager {
             }
         }
         
-        // Small buffer to allow detached task to start killing before state update.
-        // This reduces the race condition window when start() is called immediately after.
-        Thread.sleep(forTimeInterval: 0.15)
-        
         process = nil
         proxyStatus.running = false
     }

--- a/Quotio/Services/StatusBarManager.swift
+++ b/Quotio/Services/StatusBarManager.swift
@@ -136,12 +136,6 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
         menu?.cancelTracking()
     }
 
-    private func populateMenu() {
-        guard let menu = menu else { return }
-
-        performMenuRebuild(using: menu)
-    }
-
     private func performMenuRebuild(using menu: NSMenu) {
         if isRebuildingMenu {
             hasPendingMenuRebuild = true

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -92,6 +92,7 @@ final class QuotaViewModel {
     
     @ObservationIgnored private var refreshTask: Task<Void, Never>?
     @ObservationIgnored private var warmupTask: Task<Void, Never>?
+    @ObservationIgnored private var isStartingProxyFlow = false
     @ObservationIgnored private var lastLogTimestamp: Int?
     @ObservationIgnored private var isWarmupRunning = false
     @ObservationIgnored private var warmupRunningAccounts: Set<WarmupAccountKey> = []
@@ -964,6 +965,13 @@ final class QuotaViewModel {
     var readyAccounts: Int { authFiles.filter { $0.isReady }.count }
     
     func startProxy() async {
+        guard !isStartingProxyFlow else { return }
+        isStartingProxyFlow = true
+
+        defer {
+            isStartingProxyFlow = false
+        }
+
         do {
             // Wire up ProxyBridge callback to RequestTracker before starting
             proxyManager.proxyBridge.onRequestCompleted = { [weak self] metadata in


### PR DESCRIPTION
## Summary
- Prevent concurrent proxy-start flows by adding an in-flight guard in `QuotaViewModel.startProxy()`.
- Harden status bar menu rebuilding with re-entrancy/pending guards and avoid direct status button frame mutation to reduce AppKit/SwiftUI layout recursion risk.
- Remove blocking `Thread.sleep(0.15)` from `CLIProxyManager.stop()` to avoid main-thread stalls during rapid stop/start cycles.

## Verification
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build` (succeeded)