### PR TITLE
fix: align service identifiers with bundle ID and add keychain migration

### DIFF
--- a/Quotio/Services/ImageCacheService.swift
+++ b/Quotio/Services/ImageCacheService.swift
@@ -12,26 +12,26 @@ import Foundation
 /// Thread-safe image cache with automatic memory pressure eviction
 final class ImageCacheService: @unchecked Sendable {
     static let shared = ImageCacheService()
-    
+
     private let cache = NSCache<NSString, NSImage>()
-    private let queue = DispatchQueue(label: "com.quotio.imagecache", attributes: .concurrent)
-    
+    private let queue = DispatchQueue(label: "proseek.io.vn.Quotio.imagecache", attributes: .concurrent)
+
     /// Retained memory pressure source to prevent deallocation
     private var memoryPressureSource: DispatchSourceMemoryPressure?
-    
+
     private init() {
         cache.countLimit = 50
         cache.totalCostLimit = 10 * 1024 * 1024
         setupMemoryPressureHandler()
     }
-    
+
     deinit {
         memoryPressureSource?.cancel()
         memoryPressureSource = nil
     }
-    
+
     // MARK: - Public API
-    
+
     /// Get a cached image or load and cache it
     /// - Parameters:
     ///   - name: Asset catalog image name
@@ -39,17 +39,17 @@ final class ImageCacheService: @unchecked Sendable {
     /// - Returns: The image, or nil if not found
     func image(named name: String, size: CGFloat? = nil) -> NSImage? {
         let cacheKey = makeCacheKey(name: name, size: size)
-        
+
         // Check cache first
         if let cached = cache.object(forKey: cacheKey as NSString) {
             return cached
         }
-        
+
         // Load from asset catalog
         guard let original = NSImage(named: name) else {
             return nil
         }
-        
+
         // Resize if needed and cache
         let imageToCache: NSImage
         if let targetSize = size, targetSize < min(original.size.width, original.size.height) {
@@ -57,32 +57,32 @@ final class ImageCacheService: @unchecked Sendable {
         } else {
             imageToCache = original
         }
-        
+
         // Estimate cost (bytes)
         let cost = estimateCost(for: imageToCache)
         cache.setObject(imageToCache, forKey: cacheKey as NSString, cost: cost)
-        
+
         return imageToCache
     }
-    
+
     /// Clear all cached images (called on memory pressure)
     func clearCache() {
         cache.removeAllObjects()
     }
-    
+
     // MARK: - Private Helpers
-    
+
     private func makeCacheKey(name: String, size: CGFloat?) -> String {
         if let size = size {
             return "\(name)_\(Int(size))"
         }
         return name
     }
-    
+
     private func resized(image: NSImage, to targetSize: CGFloat) -> NSImage {
         let newSize = NSSize(width: targetSize, height: targetSize)
         let newImage = NSImage(size: newSize)
-        
+
         newImage.lockFocus()
         image.draw(
             in: NSRect(origin: .zero, size: newSize),
@@ -91,17 +91,17 @@ final class ImageCacheService: @unchecked Sendable {
             fraction: 1.0
         )
         newImage.unlockFocus()
-        
+
         return newImage
     }
-    
+
     private func estimateCost(for image: NSImage) -> Int {
         // Estimate: width * height * 4 bytes per pixel (RGBA)
         let width = Int(image.size.width)
         let height = Int(image.size.height)
         return width * height * 4
     }
-    
+
     private func setupMemoryPressureHandler() {
         let source = DispatchSource.makeMemoryPressureSource(eventMask: [.warning, .critical], queue: .main)
         // Capture cache directly since NSCache is thread-safe
@@ -111,7 +111,7 @@ final class ImageCacheService: @unchecked Sendable {
         }
         memoryPressureSource = source
         source.resume()
-        
+
         NotificationCenter.default.addObserver(
             forName: NSApplication.didResignActiveNotification,
             object: nil,
@@ -119,7 +119,7 @@ final class ImageCacheService: @unchecked Sendable {
         ) { [weak self] _ in
             self?.cache.countLimit = 20
         }
-        
+
         NotificationCenter.default.addObserver(
             forName: NSApplication.didBecomeActiveNotification,
             object: nil,

--- a/Quotio/Services/KeychainHelper.swift
+++ b/Quotio/Services/KeychainHelper.swift
@@ -11,14 +11,19 @@ import Security
 // MARK: - Keychain Helper
 
 enum KeychainHelper {
-    private static let remoteService = "com.quotio.remote-management"
-    private static let localService = "com.quotio.local-management"
-    private static let warpService = "com.quotio.warp"
+    private static let remoteService = "proseek.io.vn.Quotio.remote-management"
+    private static let localService = "proseek.io.vn.Quotio.local-management"
+    private static let warpService = "proseek.io.vn.Quotio.warp"
     private static let localManagementAccount = "local-management-key"
     private static let warpTokensAccount = "warp-tokens"
     private static let localManagementDefaultsKey = "managementKey"
     private static let warpTokensDefaultsKey = "warpTokens"
-    
+
+    // Legacy service names for keychain migration (pre-0.12.0)
+    private static let legacyRemoteService = "com.quotio.remote-management"
+    private static let legacyLocalService = "com.quotio.local-management"
+    private static let legacyWarpService = "com.quotio.warp"
+
     static func saveManagementKey(_ key: String, for configId: String) {
         let account = "management-key-\(configId)"
         guard let data = key.data(using: .utf8) else { return }
@@ -26,21 +31,25 @@ enum KeychainHelper {
             Log.keychain("Failed to save management key for config \(configId)")
         }
     }
-    
+
     static func getManagementKey(for configId: String) -> String? {
         let account = "management-key-\(configId)"
-        return readString(service: remoteService, account: account)
+        if let key = readString(service: remoteService, account: account) {
+            return key
+        }
+        return migrateString(from: legacyRemoteService, to: remoteService, account: account)
     }
-    
+
     static func deleteManagementKey(for configId: String) {
         let account = "management-key-\(configId)"
         deleteData(service: remoteService, account: account)
+        deleteData(service: legacyRemoteService, account: account)
     }
-    
+
     static func hasManagementKey(for configId: String) -> Bool {
         getManagementKey(for: configId) != nil
     }
-    
+
     static func saveLocalManagementKey(_ key: String) -> Bool {
         guard let data = key.data(using: .utf8) else { return false }
         let saved = saveData(data, service: localService, account: localManagementAccount)
@@ -49,29 +58,35 @@ enum KeychainHelper {
         }
         return saved
     }
-    
+
     static func getLocalManagementKey() -> String? {
         if let key = readString(service: localService, account: localManagementAccount) {
             return key
         }
-        
+
+        // Migrate from legacy keychain service name
+        if let legacyKey = migrateString(from: legacyLocalService, to: localService, account: localManagementAccount) {
+            return legacyKey
+        }
+
         guard let legacyKey = UserDefaults.standard.string(forKey: localManagementDefaultsKey),
               !legacyKey.hasPrefix("$2a$") else {
             return nil
         }
-        
+
         if saveLocalManagementKey(legacyKey) {
             UserDefaults.standard.removeObject(forKey: localManagementDefaultsKey)
         }
-        
+
         return legacyKey
     }
-    
+
     static func deleteLocalManagementKey() {
         deleteData(service: localService, account: localManagementAccount)
+        deleteData(service: legacyLocalService, account: localManagementAccount)
         UserDefaults.standard.removeObject(forKey: localManagementDefaultsKey)
     }
-    
+
     static func saveWarpTokens(_ data: Data) -> Bool {
         let saved = saveData(data, service: warpService, account: warpTokensAccount)
         if !saved {
@@ -79,31 +94,53 @@ enum KeychainHelper {
         }
         return saved
     }
-    
+
     static func getWarpTokens() -> Data? {
         if let data = readData(service: warpService, account: warpTokensAccount) {
             return data
         }
-        
+
+        if let legacyData = migrateData(from: legacyWarpService, to: warpService, account: warpTokensAccount) {
+            return legacyData
+        }
+
         guard let legacyData = UserDefaults.standard.data(forKey: warpTokensDefaultsKey) else {
             return nil
         }
-        
+
         if saveWarpTokens(legacyData) {
             UserDefaults.standard.removeObject(forKey: warpTokensDefaultsKey)
         }
-        
+
         return legacyData
     }
-    
+
     static func deleteWarpTokens() {
         deleteData(service: warpService, account: warpTokensAccount)
+        deleteData(service: legacyWarpService, account: warpTokensAccount)
         UserDefaults.standard.removeObject(forKey: warpTokensDefaultsKey)
     }
-    
+
+    private static func migrateData(from oldService: String, to newService: String, account: String) -> Data? {
+        guard let data = readData(service: oldService, account: account) else {
+            return nil
+        }
+        if saveData(data, service: newService, account: account) {
+            deleteData(service: oldService, account: account)
+        }
+        return data
+    }
+
+    private static func migrateString(from oldService: String, to newService: String, account: String) -> String? {
+        guard let data = migrateData(from: oldService, to: newService, account: account) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
     private static func saveData(_ data: Data, service: String, account: String) -> Bool {
         deleteData(service: service, account: account)
-        
+
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -111,16 +148,16 @@ enum KeychainHelper {
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         ]
-        
+
         let status = SecItemAdd(query as CFDictionary, nil)
         if status == errSecSuccess {
             return true
         }
-        
+
         Log.keychain("Keychain save failed (service: \(service), account: \(account)): \(status)")
         return false
     }
-    
+
     private static func readData(service: String, account: String) -> Data? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -129,36 +166,36 @@ enum KeychainHelper {
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
-        
+
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
-        
+
         if status == errSecSuccess {
             return result as? Data
         }
-        
+
         if status != errSecItemNotFound {
             Log.keychain("Keychain read failed (service: \(service), account: \(account)): \(status)")
         }
-        
+
         return nil
     }
-    
+
     private static func readString(service: String, account: String) -> String? {
         guard let data = readData(service: service, account: account) else {
             return nil
         }
-        
+
         return String(data: data, encoding: .utf8)
     }
-    
+
     private static func deleteData(service: String, account: String) {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account
         ]
-        
+
         let status = SecItemDelete(query as CFDictionary)
         if status != errSecSuccess && status != errSecItemNotFound {
             Log.keychain("Keychain delete failed (service: \(service), account: \(account)): \(status)")

--- a/Quotio/Services/Logger.swift
+++ b/Quotio/Services/Logger.swift
@@ -13,11 +13,11 @@ import os.log
 /// All logging is disabled in Release builds to prevent sensitive data leakage.
 /// Marked nonisolated to be callable from any actor context.
 nonisolated enum Log {
-    private static let subsystem = Bundle.main.bundleIdentifier ?? "com.quotio"
-    
+    private static let subsystem = Bundle.main.bundleIdentifier ?? "proseek.io.vn.Quotio"
+
     // MARK: - Log Categories
     // os.Logger is thread-safe and can be called from any context
-    
+
     private static let apiLogger = Logger(subsystem: subsystem, category: "API")
     private static let quotaLogger = Logger(subsystem: subsystem, category: "Quota")
     private static let proxyLogger = Logger(subsystem: subsystem, category: "Proxy")
@@ -26,9 +26,9 @@ nonisolated enum Log {
     private static let keychainLogger = Logger(subsystem: subsystem, category: "Keychain")
     private static let warmupLogger = Logger(subsystem: subsystem, category: "Warmup")
     private static let updateLogger = Logger(subsystem: subsystem, category: "Update")
-    
+
     // MARK: - Public Logging Methods
-    
+
     /// Log API-related debug messages
     static func api(_ message: String, file: String = #file, function: String = #function) {
         #if DEBUG
@@ -36,7 +36,7 @@ nonisolated enum Log {
         apiLogger.debug("[\(filename)] \(message)")
         #endif
     }
-    
+
     /// Log quota fetching debug messages
     static func quota(_ message: String, file: String = #file) {
         #if DEBUG
@@ -44,7 +44,7 @@ nonisolated enum Log {
         quotaLogger.debug("[\(filename)] \(message)")
         #endif
     }
-    
+
     /// Log proxy-related debug messages
     static func proxy(_ message: String, file: String = #file) {
         #if DEBUG
@@ -52,7 +52,7 @@ nonisolated enum Log {
         proxyLogger.debug("[\(filename)] \(message)")
         #endif
     }
-    
+
     /// Log authentication-related debug messages
     static func auth(_ message: String, file: String = #file) {
         #if DEBUG
@@ -60,7 +60,7 @@ nonisolated enum Log {
         authLogger.debug("[\(filename)] \(message)")
         #endif
     }
-    
+
     /// Log keychain-related debug messages
     static func keychain(_ message: String, file: String = #file) {
         #if DEBUG
@@ -68,7 +68,7 @@ nonisolated enum Log {
         keychainLogger.debug("[\(filename)] \(message)")
         #endif
     }
-    
+
     /// Log warmup-related debug messages
     static func warmup(_ message: String, file: String = #file) {
         #if DEBUG
@@ -76,7 +76,7 @@ nonisolated enum Log {
         warmupLogger.debug("[\(filename)] \(message)")
         #endif
     }
-    
+
     /// Log update-related debug messages
     static func update(_ message: String, file: String = #file) {
         #if DEBUG
@@ -84,7 +84,7 @@ nonisolated enum Log {
         updateLogger.debug("[\(filename)] \(message)")
         #endif
     }
-    
+
     /// Log general debug messages
     static func debug(_ message: String, file: String = #file) {
         #if DEBUG
@@ -92,28 +92,28 @@ nonisolated enum Log {
         generalLogger.debug("[\(filename)] \(message)")
         #endif
     }
-    
+
     /// Log warning messages (also logged in Release for important warnings)
     static func warning(_ message: String, file: String = #file) {
         let filename = URL(fileURLWithPath: file).deletingPathExtension().lastPathComponent
         generalLogger.warning("[\(filename)] ⚠️ \(message)")
     }
-    
+
     /// Log error messages (always logged)
     static func error(_ message: String, file: String = #file) {
         let filename = URL(fileURLWithPath: file).deletingPathExtension().lastPathComponent
         generalLogger.error("[\(filename)] ❌ \(message)")
     }
-    
+
     // MARK: - Privacy Helpers
-    
+
     /// Mask sensitive data for logging (e.g., account IDs, emails)
     static func mask(_ value: String, visibleChars: Int = 4) -> String {
         guard value.count > visibleChars else { return String(repeating: "*", count: value.count) }
         let prefix = String(value.prefix(visibleChars))
         return prefix + String(repeating: "*", count: max(0, value.count - visibleChars))
     }
-    
+
     /// Mask email for logging (shows first part before @)
     static func maskEmail(_ email: String) -> String {
         guard let atIndex = email.firstIndex(of: "@") else { return mask(email) }

--- a/Quotio/Services/Proxy/ProxyBridge.swift
+++ b/Quotio/Services/Proxy/ProxyBridge.swift
@@ -100,7 +100,7 @@ final class ProxyBridge {
     // MARK: - Properties
     
     private var listener: NWListener?
-    private let stateQueue = DispatchQueue(label: "io.quotio.proxy-bridge-state")
+    private let stateQueue = DispatchQueue(label: "proseek.io.vn.Quotio.proxy-bridge-state")
     
     /// The port this proxy listens on (user-facing port)
     private(set) var listenPort: UInt16 = 8080

--- a/Quotio/Services/RequestTracker.swift
+++ b/Quotio/Services/RequestTracker.swift
@@ -38,7 +38,7 @@ final class RequestTracker {
     private var store: RequestHistoryStore = .empty
     
     /// Queue for file operations
-    private let fileQueue = DispatchQueue(label: "io.quotio.request-tracker-file")
+    private let fileQueue = DispatchQueue(label: "proseek.io.vn.Quotio.request-tracker-file")
     
     /// Storage file URL
     private var storageURL: URL {


### PR DESCRIPTION
## Summary

- Align all hardcoded service identifiers (`DispatchQueue` labels, Keychain service names, Logger subsystem) to match the actual `PRODUCT_BUNDLE_IDENTIFIER` (`proseek.io.vn.Quotio`)
- Add transparent keychain migration so existing users don't lose stored credentials after the service name change
- Fix inconsistent identifier prefixes: `com.quotio.*` and `io.quotio.*` → `proseek.io.vn.Quotio.*`

## Problem

Hardcoded identifiers used inconsistent prefixes that didn't match the bundle ID:

| File | Old | New |
|------|-----|-----|
| `KeychainHelper` | `com.quotio.{remote,local,warp}` | `proseek.io.vn.Quotio.{…}` |
| `ImageCacheService` | `com.quotio.imagecache` | `proseek.io.vn.Quotio.imagecache` |
| `Logger` | `com.quotio` (fallback) | `proseek.io.vn.Quotio` |
| `RequestTracker` | `io.quotio.request-tracker-file` | `proseek.io.vn.Quotio.request-tracker-file` |
| `ProxyBridge` | `io.quotio.proxy-bridge-state` | `proseek.io.vn.Quotio.proxy-bridge-state` |

Changing Keychain service names without migration would orphan existing stored credentials (management keys, warp tokens).

## Solution

**Keychain migration** (same pattern as existing UserDefaults → Keychain migration):
- `migrateData` / `migrateString` helpers: read from old service → save under new service → delete old entry
- Getters waterfall: new service → legacy keychain → legacy UserDefaults
- Deleters clean up both old and new service entries

**No migration needed** for DispatchQueue labels and Logger subsystem (debug-only, non-persistent).

## Files Changed

| File | Change |
|------|--------|
| `KeychainHelper.swift` | Migration logic + aligned service names |
| `ImageCacheService.swift` | Aligned queue label (already in working tree) |
| `Logger.swift` | Aligned fallback subsystem (already in working tree) |
| `RequestTracker.swift` | Aligned queue label |
| `ProxyBridge.swift` | Aligned queue label |

## Not Changed (intentional)

| Location | Value | Reason |
|----------|-------|--------|
| `QuotaViewModel` | `quotio.authFiles.lastChanged` | UserDefaults key, not a bundle ID |
| `AntigravityDatabaseService` | `.quotio.backup` | File suffix |
| `SettingsScreen` | `quotio.dev` | Website URL |