### PR TITLE
fix(fallback): fix provider icons, context menu scope, and add model refresh

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -8609,6 +8609,35 @@
         }
       }
     },
+    "menubar.hideAccounts" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hide accounts"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer les comptes"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ẩn tài khoản"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏账户"
+          }
+        }
+      }
+    },
     "menubar.hideFromMenuBar" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -8692,6 +8721,64 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上次更新"
+          }
+        }
+      }
+    },
+    "menubar.maxItems.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can show up to %d accounts in the menu bar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous pouvez afficher jusqu'à %d comptes dans la barre de menus."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bạn có thể hiển thị tối đa %d tài khoản trên Menu Bar."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "菜单栏最多可显示 %d 个账户。"
+          }
+        }
+      }
+    },
+    "menubar.maxItems.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menu Bar Account Limit Reached"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limite de comptes dans la barre de menus atteinte"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã đạt giới hạn tài khoản trên Menu Bar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已达到菜单栏账户上限"
           }
         }
       }
@@ -8841,31 +8928,60 @@
         }
       }
     },
-    "menubar.hideAccounts" : {
+    "menubar.truncation.message" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hide accounts"
+            "value" : "You currently have %d items selected. Reducing the limit to %d will remove some of your selections."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Masquer les comptes"
+            "value" : "Vous avez actuellement %d éléments sélectionnés. Réduire la limite à %d supprimera certaines de vos sélections."
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ẩn tài khoản"
+            "value" : "Bạn hiện có %d mục đã chọn. Giảm giới hạn xuống %d sẽ xóa một số lựa chọn của bạn."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "隐藏账户"
+            "value" : "您当前已选择 %d 项。将限制减少到 %d 将删除部分选择。"
+          }
+        }
+      }
+    },
+    "menubar.truncation.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reduce Menu Bar Items?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réduire les éléments de la barre de menus ?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giảm số mục trên Menu Bar?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "减少菜单栏项目？"
           }
         }
       }
@@ -9011,122 +9127,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "项目过多"
-          }
-        }
-      }
-    },
-    "menubar.maxItems.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menu Bar Account Limit Reached"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limite de comptes dans la barre de menus atteinte"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đã đạt giới hạn tài khoản trên Menu Bar"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已达到菜单栏账户上限"
-          }
-        }
-      }
-    },
-    "menubar.maxItems.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You can show up to %d accounts in the menu bar."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vous pouvez afficher jusqu'à %d comptes dans la barre de menus."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bạn có thể hiển thị tối đa %d tài khoản trên Menu Bar."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "菜单栏最多可显示 %d 个账户。"
-          }
-        }
-      }
-    },
-    "menubar.truncation.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reduce Menu Bar Items?"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réduire les éléments de la barre de menus ?"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giảm số mục trên Menu Bar?"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "减少菜单栏项目？"
-          }
-        }
-      }
-    },
-    "menubar.truncation.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You currently have %d items selected. Reducing the limit to %d will remove some of your selections."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vous avez actuellement %d éléments sélectionnés. Réduire la limite à %d supprimera certaines de vos sélections."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bạn hiện có %d mục đã chọn. Giảm giới hạn xuống %d sẽ xóa một số lựa chọn của bạn."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "您当前已选择 %d 项。将限制减少到 %d 将删除部分选择。"
           }
         }
       }
@@ -11893,6 +11893,7 @@
       }
     },
     "providers.disable" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -11945,34 +11946,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已禁用"
-          }
-        }
-      }
-    },
-    "providers.enable" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activer"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bật"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "启用"
           }
         }
       }
@@ -12031,6 +12004,35 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无账户"
+          }
+        }
+      }
+    },
+    "providers.enable" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bật"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用"
           }
         }
       }

--- a/Quotio/Views/Screens/FallbackScreen.swift
+++ b/Quotio/Views/Screens/FallbackScreen.swift
@@ -26,6 +26,13 @@ struct FallbackScreen: View {
         viewModel.agentSetupViewModel.availableModels
     }
 
+    /// Refresh callback for Add Entry sheet (only available when proxy is running).
+    /// Returns `true` on successful model fetch; models update reactively via `availableModels`.
+    private var addEntryRefreshAction: (() async -> Bool)? {
+        guard viewModel.proxyManager.proxyStatus.running else { return nil }
+        return { await viewModel.agentSetupViewModel.loadModels(forceRefresh: true) }
+    }
+
     var body: some View {
         List {
             // Section 1: Global Settings
@@ -81,7 +88,8 @@ struct FallbackScreen: View {
                 },
                 onDismiss: {
                     addingEntryToModelId = nil
-                }
+                },
+                onRefresh: addEntryRefreshAction
             )
         }
         .task {


### PR DESCRIPTION
## Summary

Two bug fixes and one feature enhancement in the Fallback UI:

### 1. Aggregator provider icons misidentified

- Aggregator providers (Copilot, Antigravity, Kiro) host models from other providers,
  so model IDs carry the underlying provider's prefix (e.g., Copilot's `claude-3.5-sonnet`)
- `providerFromModel()` checked model ID prefix first, causing aggregator-hosted models
  to display the wrong provider icon
- **Fix**: Check the `provider` field (from proxy API `owned_by`) first, fall back to
  model ID prefix matching for unknown provider metadata

| Model ID | Provider field | Before (❌) | After (✅) |
|---|---|---|---|
| `claude-3.5-sonnet` | `github-copilot` | Claude icon | Copilot icon |
| `claude-opus-4-6-thinking` | `antigravity` | Claude icon | Antigravity icon |

<img width="1532" height="492" alt="202602120224568696970" src="https://github.com/user-attachments/assets/6f0d3121-b305-4214-9f09-280b10d8eb7b" />

### 2. Context menu deleting entire virtual model group

- `.contextMenu` was attached to the entire `DisclosureGroup`, covering both the title row
  and expanded fallback entry rows
- Right-clicking a fallback entry triggered group-level context menu instead of entry-level one
- **Fix**: Move `.contextMenu` to the label's `HStack` so only the title row responds to right-click

<img width="1346" height="332" alt="202602120225278727685" src="https://github.com/user-attachments/assets/c5f17bdc-8637-43a6-a033-af4fe46bd24b" />

### 3. Add refresh button to AddFallbackEntry sheet

**Background**: When users open the "Add Fallback Entry" sheet, the model list is loaded once from the proxy on initial screen load. If the proxy starts after the screen is already open, or if new models become available, users have to close and reopen the entire Fallback settings to get an updated list — with no indication that a refresh is even possible.

**What this does**: Adds a compact refresh button next to the model picker (and the empty-state hint) so users can reload the model list without leaving the sheet.

- Button is only visible when the proxy is running (no point refreshing with no backend)
- Shows a smooth spinning animation during the fetch
- Displays a brief ✅ / ❌ icon on success/failure before returning to idle
- `AgentSetupViewModel.loadModels()` now returns `Bool` indicating fetch success (`@discardableResult` keeps existing call sites unchanged)

https://github.com/user-attachments/assets/97f6d323-7426-4496-889a-357089eb8a33

## Changed files

- `Quotio/Views/Components/FallbackSheets.swift` — reorder resolution steps in `providerFromModel()`, add refresh button with `TimelineView`-driven rotation and success/failure feedback
- `Quotio/Views/Screens/FallbackScreen.swift` — narrow context menu scope in `VirtualModelRow`, conditionally provide `onRefresh` closure based on proxy status
- `Quotio/ViewModels/AgentSetupViewModel.swift` — `loadModels()` returns `Bool`
- `Quotio/Localizable.xcstrings` — localization updates

## Test plan

**Provider icon fix**
- [x] Aggregator-hosted models display the aggregator's icon correctly
- [x] Direct provider models still display the correct icon

**Context menu fix**
- [x] Right-clicking a fallback entry row does not show the virtual model context menu
- [x] Right-clicking virtual model title row still shows context menu normally

**Refresh button**
- [x] Refresh button appears next to model picker when proxy is running
- [x] Refresh button is hidden when proxy is not running
- [x] Clicking refresh shows spinning animation, then ✅ on success
- [ ] Stopping proxy mid-refresh shows ❌ feedback
- [x] Model list updates in-place after successful refresh
- [x] Previously selected model is preserved if still valid after refresh

**General**
- [x] Local build succeeded and app runs without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)