### PR TITLE
fix: preserve disabled field when token refresh rewrites auth files

### DIFF
--- a/Quotio/Services/Antigravity/AntigravityAccountSwitcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityAccountSwitcher.swift
@@ -138,7 +138,7 @@ final class AntigravityAccountSwitcher {
                         json["access_token"] = freshToken
                         json["expired"] = authFile.expired
                         if let updatedData = try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys]) {
-                            try updatedData.write(to: url)
+                            try? updatedData.write(to: url)
                         }
                     }
                 } catch {

--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -544,12 +544,13 @@ actor AntigravityQuotaFetcher {
         guard var json = try? JSONSerialization.jsonObject(with: originalData) as? [String: Any] else { return }
         json["access_token"] = newAccessToken
 
-        let expiryDate = Date().addingTimeInterval(TimeInterval(expiresIn))
+        let now = Date()
+        let expiryDate = now.addingTimeInterval(TimeInterval(expiresIn))
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
         json["expired"] = formatter.string(from: expiryDate)
         json["expires_in"] = expiresIn
-        json["timestamp"] = Int64(Date().timeIntervalSince1970 * 1000)
+        json["timestamp"] = Int64(now.timeIntervalSince1970 * 1000)
 
         if let updatedData = try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys]) {
             try? updatedData.write(to: url)


### PR DESCRIPTION
## Summary

- Token refresh in `AntigravityQuotaFetcher`, `OpenAIQuotaFetcher`, and `AntigravityAccountSwitcher` used `JSONEncoder().encode(authFile)` to persist refreshed tokens. Since the Codable structs (`AntigravityAuthFile`, `CodexAuthFile`) do not include the `disabled` field, every write silently dropped it — causing disabled accounts to automatically re-enable after the next quota refresh cycle (~10 min default cadence + token expiry).
- Replaced all 5 occurrences with a `JSONSerialization`-based read-modify-write pattern that only updates `access_token` (and expiry fields) while preserving every existing field in the auth JSON file, including `disabled`.
- Also fixed Antigravity token refresh to update `expired` / `expires_in` / `timestamp`, preventing unnecessary re-refresh on every cycle.

## Root Cause

1. User disables an account → `disabled: true` is written to the auth JSON file via `PATCH /auth-files/status`
2. Quota fetcher runs periodically (default 10 min) → detects token expired → calls `refreshAccessToken()`
3. `JSONEncoder().encode(authFile)` serializes the struct back to file — but the struct has no `disabled` field → **field is dropped**
4. Next `refreshData()` reads from backend → backend reads file without `disabled` → account shows as enabled again

## Files Changed

| File | Changes |
|------|---------|
| `AntigravityQuotaFetcher.swift` | 3 call sites fixed + added `persistRefreshedToken` helper + added `refreshAccessTokenWithExpiry` to also persist expiry |
| `OpenAIQuotaFetcher.swift` | 1 call site fixed + added `persistRefreshedToken` helper |
| `AntigravityAccountSwitcher.swift` | 1 call site fixed (Step 0: token refresh before account switch) |

## Test Plan

- [x] Disable an account, manually set `expired` to a past date in the auth JSON file, trigger manual refresh
- [x] Verify `disabled` field is preserved after token refresh
- [x] Verify `expired` field is updated to a future time after Antigravity token refresh
- [x] Build succeeds with no errors