### PR TITLE
fix: use local timezone for expired field to match existing auth files

### DIFF
--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -548,6 +548,7 @@ actor AntigravityQuotaFetcher {
         let expiryDate = now.addingTimeInterval(TimeInterval(expiresIn))
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = .current
         json["expired"] = formatter.string(from: expiryDate)
         json["expires_in"] = expiresIn
         json["timestamp"] = Int64(now.timeIntervalSince1970 * 1000)

--- a/Quotio/Services/QuotaFetchers/OpenAIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/OpenAIQuotaFetcher.swift
@@ -155,6 +155,7 @@ actor OpenAIQuotaFetcher {
         let expiryDate = Date().addingTimeInterval(3600)
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = .current
         json["expired"] = formatter.string(from: expiryDate)
 
         if let updatedData = try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys]) {


### PR DESCRIPTION
Existing auth files use +08:00 format. ISO8601DateFormatter defaults to UTC (Z suffix). Set formatter.timeZone = .current for consistency.