### PR TITLE
fix: deduplicate Codex quota accounts and menu bar mapping

### DIFF
--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -364,6 +364,7 @@ final class QuotaViewModel {
         _ = await (antigravity, openai, copilot, claudeCode, codexCLI, geminiCLI, glm, warp, kiro)
         
         checkQuotaNotifications()
+        pruneMenuBarItems()
         autoSelectMenuBarItems()
 
         isLoadingQuotas = false
@@ -1185,6 +1186,7 @@ final class QuotaViewModel {
         }
 
         checkQuotaNotifications()
+        pruneMenuBarItems()
         autoSelectMenuBarItems()
 
         isLoadingQuotas = false
@@ -1224,6 +1226,7 @@ final class QuotaViewModel {
         }
 
         checkQuotaNotifications()
+        pruneMenuBarItems()
         autoSelectMenuBarItems()
 
         isLoadingQuotas = false
@@ -1794,6 +1797,7 @@ final class QuotaViewModel {
         savePersistedIDEQuotas()
 
         // Update menu bar items
+        pruneMenuBarItems()
         autoSelectMenuBarItems()
 
         notifyQuotaDataChanged()


### PR DESCRIPTION
## Summary
- Normalize Codex quota account identity to use auth email/JWT email first, with filename as fallback.
- Remove stale menu bar quota selections before auto-selecting refreshed items.
- Add Codex-compatible key matching in menu bar rendering for legacy selected account keys.

## Impact
- Fixes duplicate Codex account cards caused by mixed keys (plain email vs `email-team`/`email-plus`).
- Restores menu bar quota visibility for affected Codex accounts after key normalization.
- Reduces stale menu bar entries after quota refresh cycles.

## Notes
- Changes are limited to Codex quota key mapping and menu bar account-key resolution paths.
- Verified with local `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build`.

## References / Links
- User-reported issue: duplicated Codex accounts in Quota screen and missing menu bar remaining quota.

The following is a screenshot of the error:

<img width="820" height="269" alt="image" src="https://github.com/user-attachments/assets/03d284ab-6831-4999-965a-c13f73a6fd97" />
<img width="140" height="30" alt="image" src="https://github.com/user-attachments/assets/9836ed49-2cf1-40e0-b2fd-509feac13d08" />
