### PR TITLE
fix: use HTTP/2 protocol for Cloudflare tunnels

### DIFF
--- a/Quotio/Services/Tunnel/CloudflaredService.swift
+++ b/Quotio/Services/Tunnel/CloudflaredService.swift
@@ -68,7 +68,7 @@ actor CloudflaredService {
         newProcess.executableURL = URL(fileURLWithPath: binaryPath)
         // Use --config /dev/null to ignore user's existing config file
         // This ensures Quick Tunnel works without interference from named tunnels
-        newProcess.arguments = ["tunnel", "--config", "/dev/null", "--url", "http://localhost:" + String(port)]
+        newProcess.arguments = ["tunnel", "--config", "/dev/null", "--protocol", "http2", "--url", "http://localhost:" + String(port)]
         
         let outputPipe = Pipe()
         let errorPipe = Pipe()


### PR DESCRIPTION
## Summary
- Force HTTP/2 protocol for Cloudflare Quick Tunnels instead of default QUIC
- Fixes tunnel failures on networks where UDP/QUIC is blocked

## Problem
Cloudflare Quick Tunnels were failing with Error 1033 on networks that block QUIC protocol (UDP). The tunnel would get assigned a URL but fail to establish connection to Cloudflare's edge servers.

## Solution
Added `--protocol http2` flag to the cloudflared command, which uses TCP instead of UDP. This ensures tunnels work reliably across all network configurations.

## Testing
Verified that tunnels now successfully connect and proxy requests work:
```
curl https://census-museums-grades-ppm.trycloudflare.com/v1/models
# Returns valid JSON response instead of Cloudflare error page
```