### PR TITLE
fix: hide CLI-based providers from menu bar when CLI not installed

### DIFF
--- a/Quotio/Models/Models.swift
+++ b/Quotio/Models/Models.swift
@@ -185,6 +185,16 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         }
     }
     
+    /// Map provider to CLI agent (if applicable)
+    var cliAgent: CLIAgent? {
+        switch self {
+        case .claude: return .claudeCode
+        case .codex: return .codexCLI
+        case .gemini: return .geminiCLI
+        default: return nil
+        }
+    }
+    
     /// Whether this provider can be added manually (via OAuth, CLI login, or file import)
     /// Cursor, Trae, Windsurf are excluded because they only read from local app databases
     /// GLM is excluded because it should only be added via Custom Providers


### PR DESCRIPTION
## Summary
- Add `cliAgent` property to `AIProvider` to map providers to their CLI agents
- Filter CLI-based providers (Claude, Codex, Gemini) from menu bar when CLI binary is not installed
- Add synchronous binary existence check as fallback when agent statuses aren't cached

## Problem
When a CLI tool (like Gemini CLI) is uninstalled, the provider still appears in the menu bar if auth files exist in `~/.cli-proxy-api/`. This confuses users who see quota data for an uninstalled tool.

## Solution
- Added `cliAgent` computed property on `AIProvider` that maps to `CLIAgent` enum
- `StatusBarMenuBuilder.providersWithData` now filters out providers whose CLI isn't installed
- Fallback binary check in common paths when `agentStatuses` cache is empty

## Testing
- Uninstalled `gemini` CLI via `bun remove -g @anthropic/gemini-cli`
- Verified Gemini CLI no longer appears in menu bar
- Other non-CLI providers (Antigravity, Copilot, etc.) still show correctly