### PR TITLE
feat: add model selection and connection testing for custom providers

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -4462,6 +4462,136 @@
         }
       }
     },
+    "customProviders.fetchModels" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetch Models"
+          }
+        }
+      }
+    },
+    "customProviders.allModels" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All Models"
+          }
+        }
+      }
+    },
+    "customProviders.popularModels" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Popular Models"
+          }
+        }
+      }
+    },
+    "customProviders.searchModels" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search models..."
+          }
+        }
+      }
+    },
+    "customProviders.selectedModels" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld models selected"
+          }
+        }
+      }
+    },
+    "customProviders.clearSelection" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear"
+          }
+        }
+      }
+    },
+    "customProviders.selectAll" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select All"
+          }
+        }
+      }
+    },
+    "customProviders.deselectAll" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deselect All"
+          }
+        }
+      }
+    },
+    "customProviders.limitModels" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limit models to selection"
+          }
+        }
+      }
+    },
+    "customProviders.limitModelsDesc" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only selected models will be available via proxy"
+          }
+        }
+      }
+    },
+    "customProviders.selectModelsHint" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select models to make available via proxy"
+          }
+        }
+      }
+    },
+    "customProviders.testing" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Testing connection..."
+          }
+        }
+      }
+    },
+    "customProviders.enterManually" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Or enter model names manually:"
+          }
+        }
+      }
+    },
     "dashboard.accounts" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Models/CustomProviderModels.swift
+++ b/Quotio/Models/CustomProviderModels.swift
@@ -231,6 +231,7 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
     var apiKeys: [CustomAPIKeyEntry]
     var models: [ModelMapping]
     var headers: [CustomHeader]  // Only used for Gemini-compatible
+    var limitToSelectedModels: Bool
     var isEnabled: Bool
     var createdAt: Date
     var updatedAt: Date
@@ -244,6 +245,7 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
         apiKeys: [CustomAPIKeyEntry] = [],
         models: [ModelMapping] = [],
         headers: [CustomHeader] = [],
+        limitToSelectedModels: Bool = true,
         isEnabled: Bool = true,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
@@ -256,6 +258,7 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
         self.apiKeys = apiKeys
         self.models = models
         self.headers = headers
+        self.limitToSelectedModels = limitToSelectedModels
         self.isEnabled = isEnabled
         self.createdAt = createdAt
         self.updatedAt = updatedAt
@@ -266,6 +269,7 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
         case baseURL = "base-url"
         case apiKeys = "api-keys"
         case models, headers
+        case limitToSelectedModels = "limit-to-selected-models"
         case isEnabled = "is-enabled"
         case createdAt = "created-at"
         case updatedAt = "updated-at"

--- a/Quotio/Models/CustomProviderModels.swift
+++ b/Quotio/Models/CustomProviderModels.swift
@@ -275,6 +275,38 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
         case updatedAt = "updated-at"
     }
     
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        type = try container.decode(CustomProviderType.self, forKey: .type)
+        baseURL = try container.decode(String.self, forKey: .baseURL)
+        prefix = try container.decodeIfPresent(String.self, forKey: .prefix)
+        apiKeys = try container.decodeIfPresent([CustomAPIKeyEntry].self, forKey: .apiKeys) ?? []
+        models = try container.decodeIfPresent([ModelMapping].self, forKey: .models) ?? []
+        headers = try container.decodeIfPresent([CustomHeader].self, forKey: .headers) ?? []
+        limitToSelectedModels = try container.decodeIfPresent(Bool.self, forKey: .limitToSelectedModels) ?? true
+        isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
+        updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt) ?? Date()
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(type, forKey: .type)
+        try container.encode(baseURL, forKey: .baseURL)
+        try container.encodeIfPresent(prefix, forKey: .prefix)
+        try container.encode(apiKeys, forKey: .apiKeys)
+        try container.encode(models, forKey: .models)
+        try container.encode(headers, forKey: .headers)
+        try container.encode(limitToSelectedModels, forKey: .limitToSelectedModels)
+        try container.encode(isEnabled, forKey: .isEnabled)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(updatedAt, forKey: .updatedAt)
+    }
+    
     /// Validate the provider configuration
     func validate() -> [String] {
         var errors: [String] = []

--- a/Quotio/Services/CustomProviderService.swift
+++ b/Quotio/Services/CustomProviderService.swift
@@ -42,6 +42,7 @@ final class CustomProviderService {
             apiKeys: provider.apiKeys,
             models: provider.models,
             headers: provider.headers,
+            limitToSelectedModels: provider.limitToSelectedModels,
             isEnabled: provider.isEnabled,
             createdAt: Date(),
             updatedAt: Date()
@@ -67,6 +68,7 @@ final class CustomProviderService {
             apiKeys: provider.apiKeys,
             models: provider.models,
             headers: provider.headers,
+            limitToSelectedModels: provider.limitToSelectedModels,
             isEnabled: provider.isEnabled,
             createdAt: providers[index].createdAt,
             updatedAt: Date()
@@ -95,6 +97,7 @@ final class CustomProviderService {
             apiKeys: provider.apiKeys,
             models: provider.models,
             headers: provider.headers,
+            limitToSelectedModels: provider.limitToSelectedModels,
             isEnabled: !provider.isEnabled,
             createdAt: provider.createdAt,
             updatedAt: Date()

--- a/Quotio/Views/Components/CustomProviderSheet.swift
+++ b/Quotio/Views/Components/CustomProviderSheet.swift
@@ -24,6 +24,16 @@ struct CustomProviderSheet: View {
     
     @State private var validationErrors: [String] = []
     @State private var showValidationAlert = false
+    @State private var isTestingConnection = false
+    @State private var testError: String?
+    
+    // Model fetching state
+    @State private var availableModels: [AvailableModel] = []
+    @State private var selectedModelIds: Set<String> = []
+    @State private var modelSearchText: String = ""
+    @State private var isLoadingModels: Bool = false
+    @State private var modelFetchError: String?
+    @State private var limitToSelectedModels: Bool = true
     
     private var isEditing: Bool {
         provider != nil
@@ -37,17 +47,23 @@ struct CustomProviderSheet: View {
             
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
+                    // Step 1: Provider name and type
                     basicInfoSection
+                    
+                    // Step 2: API Keys (needed before fetching models)
                     apiKeysSection
                     
+                    // Step 3: Model selection (requires API key to fetch)
                     if providerType.supportsModelMapping {
                         modelMappingSection
                     }
                     
+                    // Step 4: Custom headers (optional)
                     if providerType.supportsCustomHeaders {
                         customHeadersSection
                     }
                     
+                    // Step 5: Enable toggle
                     enabledSection
                 }
                 .padding(20)
@@ -62,9 +78,15 @@ struct CustomProviderSheet: View {
             loadProviderData()
         }
         .alert("customProviders.validationError".localized(), isPresented: $showValidationAlert) {
-            Button("action.ok".localized(), role: .cancel) {}
+            Button("action.ok".localized(), role: .cancel) {
+                testError = nil
+            }
         } message: {
-            Text(validationErrors.joined(separator: "\n"))
+            if let error = testError {
+                Text(error)
+            } else {
+                Text(validationErrors.joined(separator: "\n"))
+            }
         }
     }
     
@@ -105,8 +127,13 @@ struct CustomProviderSheet: View {
     
     private var basicInfoSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("customProviders.basicInfo".localized())
-                .font(.headline)
+            HStack {
+                Text("customProviders.basicInfo".localized())
+                    .font(.headline)
+                Text("• Step 1")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
             
             VStack(alignment: .leading, spacing: 8) {
                 Text("customProviders.providerName".localized())
@@ -187,6 +214,9 @@ struct CustomProviderSheet: View {
             HStack {
                 Text("customProviders.apiKeys".localized())
                     .font(.headline)
+                Text("• Step 2")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
                 
                 Spacer()
                 
@@ -248,12 +278,41 @@ struct CustomProviderSheet: View {
     
     // MARK: - Model Mapping Section
     
+    private var filteredModels: [AvailableModel] {
+        if modelSearchText.isEmpty {
+            return availableModels
+        }
+        return availableModels.filter { 
+            $0.name.localizedCaseInsensitiveContains(modelSearchText) ||
+            $0.id.localizedCaseInsensitiveContains(modelSearchText)
+        }
+    }
+    
+    private var topModels: [AvailableModel] {
+        // Return top 5 most popular models
+        let popularModelIds = [
+            "gpt-4o", "gpt-4-turbo", "gpt-3.5-turbo", "claude-3-opus", "claude-3-sonnet",
+            "claude-3-haiku", "claude-3-5-sonnet", "gemini-pro", "gemini-1.5-pro", "llama-3"
+        ]
+        return availableModels.filter { model in
+            popularModelIds.contains { popularId in
+                model.name.lowercased().contains(popularId.lowercased()) || 
+                model.id.lowercased().contains(popularId.lowercased())
+            }
+        }
+    }
+    
     private var modelMappingSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("customProviders.modelMapping".localized())
-                        .font(.headline)
+                    HStack {
+                        Text("customProviders.modelMapping".localized())
+                            .font(.headline)
+                        Text("• Step 3")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    }
                     
                     Text("customProviders.modelMappingDesc".localized())
                         .font(.caption)
@@ -262,14 +321,198 @@ struct CustomProviderSheet: View {
                 
                 Spacer()
                 
-                Button {
-                    models.append(ModelMapping(name: "", alias: ""))
-                } label: {
-                    Label("customProviders.addMapping".localized(), systemImage: "plus.circle")
-                        .font(.caption)
+                if isLoadingModels {
+                    ProgressView()
+                        .scaleEffect(0.6)
+                } else {
+                    Button {
+                        fetchModelsFromAPI()
+                    } label: {
+                        Label("customProviders.fetchModels".localized(), systemImage: "arrow.clockwise")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.sectionHeader)
+                    .disabled(apiKeys.first?.apiKey.trimmingCharacters(in: .whitespaces).isEmpty ?? true)
                 }
-                .buttonStyle(.sectionHeader)
             }
+            
+            // Limit models toggle
+            if !availableModels.isEmpty {
+                Toggle(isOn: $limitToSelectedModels) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("customProviders.limitModels".localized())
+                            .font(.subheadline)
+                        Text("customProviders.limitModelsDesc".localized())
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .toggleStyle(.checkbox)
+                
+                if limitToSelectedModels && selectedModelIds.isEmpty {
+                    HStack {
+                        Image(systemName: "info.circle")
+                            .foregroundStyle(.blue)
+                        Text("customProviders.selectModelsHint".localized())
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            
+            // Show fetch error if any
+            if let error = modelFetchError {
+                HStack {
+                    Image(systemName: "exclamationmark.triangle")
+                        .foregroundStyle(.orange)
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            
+            // Model selection interface
+            if !availableModels.isEmpty {
+                modelSelectionList
+            } else if !isLoadingModels {
+                // Manual entry fallback
+                manualModelEntry
+            }
+        }
+        .padding(16)
+        .background(Color(.controlBackgroundColor).opacity(0.5))
+        .cornerRadius(8)
+    }
+    
+    private var modelSelectionList: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Search box
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("customProviders.searchModels".localized(), text: $modelSearchText)
+                    .textFieldStyle(.plain)
+                if !modelSearchText.isEmpty {
+                    Button {
+                        modelSearchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(6)
+            .background(Color(.windowBackgroundColor))
+            .cornerRadius(6)
+            
+            // Top 5 popular models
+            if modelSearchText.isEmpty && !topModels.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("customProviders.popularModels".localized())
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    
+                    ForEach(topModels.prefix(5)) { model in
+                        modelSelectionRow(model: model)
+                    }
+                }
+            }
+            
+            // All models (searchable)
+            if !modelSearchText.isEmpty || topModels.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    if modelSearchText.isEmpty {
+                        Text("customProviders.allModels".localized())
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 2) {
+                            ForEach(filteredModels) { model in
+                                modelSelectionRow(model: model)
+                            }
+                        }
+                    }
+                    .frame(maxHeight: 200)
+                }
+            }
+            
+            // Selected models count and actions
+            if !selectedModelIds.isEmpty {
+                HStack {
+                    Text(String(format: "customProviders.selectedModels".localized(), selectedModelIds.count))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("customProviders.clearSelection".localized()) {
+                        selectedModelIds.removeAll()
+                    }
+                    .font(.caption)
+                }
+            }
+            
+            // Select All / Deselect All buttons
+            if !availableModels.isEmpty {
+                HStack {
+                    Button("customProviders.selectAll".localized()) {
+                        selectedModelIds = Set(availableModels.map { $0.id })
+                    }
+                    .font(.caption)
+                    
+                    Button("customProviders.deselectAll".localized()) {
+                        selectedModelIds.removeAll()
+                    }
+                    .font(.caption)
+                }
+            }
+        }
+    }
+    
+    private func modelSelectionRow(model: AvailableModel) -> some View {
+        Button {
+            if selectedModelIds.contains(model.id) {
+                selectedModelIds.remove(model.id)
+            } else {
+                selectedModelIds.insert(model.id)
+            }
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: selectedModelIds.contains(model.id) ? "checkmark.square" : "square")
+                    .foregroundStyle(selectedModelIds.contains(model.id) ? Color.accentColor : .secondary)
+                
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(model.name)
+                        .font(.subheadline)
+                        .foregroundStyle(.primary)
+                    if model.id != model.name {
+                        Text(model.id)
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                
+                Spacer()
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+    
+    private var manualModelEntry: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("customProviders.enterManually".localized())
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+            
+            Button {
+                models.append(ModelMapping(name: "", alias: ""))
+            } label: {
+                Label("customProviders.addMapping".localized(), systemImage: "plus.circle")
+                    .font(.caption)
+            }
+            .buttonStyle(.sectionHeader)
             
             if models.isEmpty {
                 Text("customProviders.noMappings".localized())
@@ -282,9 +525,6 @@ struct CustomProviderSheet: View {
                 }
             }
         }
-        .padding(16)
-        .background(Color(.controlBackgroundColor).opacity(0.5))
-        .cornerRadius(8)
     }
     
     private func modelMappingRow(index: Int) -> some View {
@@ -428,14 +668,26 @@ struct CustomProviderSheet: View {
                 dismiss()
             }
             .keyboardShortcut(.escape)
+            .disabled(isTestingConnection)
             
             Spacer()
+            
+            if isTestingConnection {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                    Text("customProviders.testing".localized())
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
             
             Button(isEditing ? "customProviders.saveChanges".localized() : "customProviders.addProvider".localized()) {
                 saveProvider()
             }
             .keyboardShortcut(.return, modifiers: .command)
             .buttonStyle(.borderedProminent)
+            .disabled(isTestingConnection)
         }
         .padding(20)
     }
@@ -453,9 +705,106 @@ struct CustomProviderSheet: View {
         models = provider.models
         headers = provider.headers
         isEnabled = provider.isEnabled
+        
+        // Set selected models from existing provider
+        selectedModelIds = Set(provider.models.map { $0.name })
+    }
+    
+    private func fetchModelsFromAPI() {
+        guard let firstKey = apiKeys.first, !firstKey.apiKey.trimmingCharacters(in: .whitespaces).isEmpty else {
+            modelFetchError = "Enter an API key first"
+            return
+        }
+        
+        let effectiveBaseURL = baseURL.isEmpty 
+            ? (providerType.defaultBaseURL ?? "")
+            : baseURL
+        
+        guard let url = URL(string: effectiveBaseURL) else {
+            modelFetchError = "Invalid base URL"
+            return
+        }
+        
+        let modelsURL = url.appendingPathComponent("v1/models")
+        
+        var request = URLRequest(url: modelsURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 15
+        
+        // Set authorization header based on provider type
+        switch providerType {
+        case .openaiCompatibility, .codexCompatibility:
+            request.setValue("Bearer \(firstKey.apiKey)", forHTTPHeaderField: "Authorization")
+        case .claudeCompatibility:
+            request.setValue("Bearer \(firstKey.apiKey)", forHTTPHeaderField: "Authorization")
+            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        case .geminiCompatibility:
+            var components = URLComponents(url: modelsURL, resolvingAgainstBaseURL: false)
+            components?.queryItems = [URLQueryItem(name: "key", value: firstKey.apiKey)]
+            if let newURL = components?.url {
+                request.url = newURL
+            }
+        case .glmCompatibility:
+            request.setValue("Bearer \(firstKey.apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        
+        // Add custom headers
+        for header in headers {
+            request.setValue(header.value, forHTTPHeaderField: header.key)
+        }
+        
+        isLoadingModels = true
+        modelFetchError = nil
+        
+        Task {
+            do {
+                let (data, response) = try await URLSession.shared.data(for: request)
+                
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    await MainActor.run {
+                        isLoadingModels = false
+                        modelFetchError = "Invalid response"
+                    }
+                    return
+                }
+                
+                guard httpResponse.statusCode == 200 else {
+                    await MainActor.run {
+                        isLoadingModels = false
+                        modelFetchError = "Failed to fetch models: HTTP \(httpResponse.statusCode)"
+                    }
+                    return
+                }
+                
+                let modelsResponse = try JSONDecoder().decode(ModelsListResponse.self, from: data)
+                let fetchedModels = modelsResponse.allModels.map { $0.toAvailableModel() }
+                
+                await MainActor.run {
+                    isLoadingModels = false
+                    availableModels = fetchedModels.sorted { $0.name < $1.name }
+                }
+            } catch {
+                await MainActor.run {
+                    isLoadingModels = false
+                    modelFetchError = "Failed to fetch models: \(error.localizedDescription)"
+                }
+            }
+        }
     }
     
     private func saveProvider() {
+        // Clear previous errors
+        testError = nil
+        
+        // Convert selected model IDs to ModelMapping
+        let selectedModelMappings = selectedModelIds.compactMap { modelId -> ModelMapping? in
+            guard let model = availableModels.first(where: { $0.id == modelId }) else { return nil }
+            return ModelMapping(name: model.id, alias: model.id)
+        }
+        
+        // Merge with manually added models
+        let allModels = models.filter { !$0.name.trimmingCharacters(in: .whitespaces).isEmpty } + selectedModelMappings
+        
         // Build provider
         let newProvider = CustomProvider(
             id: provider?.id ?? UUID(),
@@ -464,22 +813,157 @@ struct CustomProviderSheet: View {
             baseURL: baseURL.trimmingCharacters(in: .whitespaces),
             prefix: prefix.trimmingCharacters(in: .whitespaces).isEmpty ? nil : prefix.trimmingCharacters(in: .whitespaces),
             apiKeys: apiKeys.filter { !$0.apiKey.trimmingCharacters(in: .whitespaces).isEmpty },
-            models: models.filter { !$0.name.trimmingCharacters(in: .whitespaces).isEmpty },
+            models: allModels,
             headers: headers.filter { !$0.key.trimmingCharacters(in: .whitespaces).isEmpty },
             isEnabled: isEnabled,
             createdAt: provider?.createdAt ?? Date(),
             updatedAt: Date()
         )
         
-        // Validate
+        // Validate basic fields
         validationErrors = CustomProviderService.shared.validateProvider(newProvider)
         
-        if validationErrors.isEmpty {
-            onSave(newProvider)
-            dismiss()
-        } else {
+        if !validationErrors.isEmpty {
             showValidationAlert = true
+            return
         }
+        
+        // Test connection before saving
+        isTestingConnection = true
+        
+        Task {
+            do {
+                let success = try await testConnection(provider: newProvider)
+                await MainActor.run {
+                    isTestingConnection = false
+                    if success {
+                        onSave(newProvider)
+                        dismiss()
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    isTestingConnection = false
+                    testError = error.localizedDescription
+                    showValidationAlert = true
+                }
+            }
+        }
+    }
+    
+    private func testConnection(provider: CustomProvider) async throws -> Bool {
+        guard let firstKey = provider.apiKeys.first else {
+            throw CustomProviderTestError.noAPIKey
+        }
+        
+        let effectiveBaseURL = provider.baseURL.isEmpty 
+            ? (provider.type.defaultBaseURL ?? "")
+            : provider.baseURL
+        
+        guard let url = URL(string: effectiveBaseURL) else {
+            throw CustomProviderTestError.invalidURL
+        }
+        
+        let modelsURL = url.appendingPathComponent("v1/models")
+        
+        var request = URLRequest(url: modelsURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 15
+        
+        // Set authorization header based on provider type
+        switch provider.type {
+        case .openaiCompatibility, .codexCompatibility:
+            request.setValue("Bearer \(firstKey.apiKey)", forHTTPHeaderField: "Authorization")
+        case .claudeCompatibility:
+            request.setValue("Bearer \(firstKey.apiKey)", forHTTPHeaderField: "Authorization")
+            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        case .geminiCompatibility:
+            // Gemini uses query parameter for API key
+            var components = URLComponents(url: modelsURL, resolvingAgainstBaseURL: false)
+            components?.queryItems = [URLQueryItem(name: "key", value: firstKey.apiKey)]
+            if let newURL = components?.url {
+                request.url = newURL
+            }
+        case .glmCompatibility:
+            request.setValue("Bearer \(firstKey.apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        
+        // Add custom headers if any
+        for header in provider.headers {
+            request.setValue(header.value, forHTTPHeaderField: header.key)
+        }
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CustomProviderTestError.invalidResponse
+        }
+        
+        switch httpResponse.statusCode {
+        case 200..<300:
+            return true
+        case 401, 403:
+            throw CustomProviderTestError.unauthorized
+        case 404:
+            throw CustomProviderTestError.endpointNotFound
+        default:
+            if let errorMessage = String(data: data, encoding: .utf8) {
+                throw CustomProviderTestError.serverError(httpResponse.statusCode, errorMessage)
+            }
+            throw CustomProviderTestError.serverError(httpResponse.statusCode, "Unknown error")
+        }
+    }
+}
+
+enum CustomProviderTestError: LocalizedError {
+    case noAPIKey
+    case invalidURL
+    case invalidResponse
+    case unauthorized
+    case endpointNotFound
+    case serverError(Int, String)
+    
+    var errorDescription: String? {
+        switch self {
+        case .noAPIKey:
+            return "No API key provided"
+        case .invalidURL:
+            return "Invalid base URL"
+        case .invalidResponse:
+            return "Invalid response from server"
+        case .unauthorized:
+            return "API key is invalid or unauthorized"
+        case .endpointNotFound:
+            return "Models endpoint not found at this URL"
+        case .serverError(let code, let message):
+            return "Server error (\(code)): \(message)"
+        }
+    }
+}
+
+// MARK: - Models Response Parsing
+
+private struct ModelsListResponse: Codable {
+    let data: [ModelData]?
+    let models: [ModelData]?
+    
+    var allModels: [ModelData] {
+        data ?? models ?? []
+    }
+}
+
+private struct ModelData: Codable {
+    let id: String
+    let name: String?
+    let ownedBy: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case id, name
+        case ownedBy = "owned_by"
+    }
+    
+    func toAvailableModel() -> AvailableModel {
+        AvailableModel(id: id, name: name ?? id, provider: ownedBy ?? "unknown", isDefault: false)
     }
 }
 


### PR DESCRIPTION
## Summary
- Reorder custom provider form: Base URL/API Key first, then model selection (Step 1-3)
- Add "Fetch Models" button to fetch available models from `/v1/models` endpoint
- Show top 5 popular models first, with search box to filter all models
- Add Select All / Deselect All buttons for easy model selection
- Add "Limit models to selection" toggle - when enabled, only selected models are exposed via proxy
- Test API connection before saving provider configuration

## Problem
When adding a custom provider like OpenRouter (200+ models), users had no way to limit which models are available via the proxy. All models were exposed, making it confusing to select specific models.

## Solution
1. **Reordered form flow**: Provider info → API Key → Model selection (logical progression)
2. **Model fetching**: Fetch models from provider's `/v1/models` endpoint
3. **Visual selection**: Checkboxes with search, top 5 popular models highlighted
4. **Limit toggle**: Option to expose only selected models via proxy
5. **Connection testing**: Validates API key works before saving

## Testing
- Added custom provider (OpenRouter, Ollama) with API key
- Fetched models successfully from provider endpoint
- Selected specific models and verified they're saved to config
- Tested invalid API key - shows error message