### PR TITLE
fix: prevent menu bar from dropping accounts

### DIFF
--- a/Quotio/Models/MenuBarSettings.swift
+++ b/Quotio/Models/MenuBarSettings.swift
@@ -440,7 +440,7 @@ final class MenuBarSettingsManager {
 
     static let minMenuBarItems = 1
     static let maxMenuBarItems = 10
-    static let defaultMenuBarMaxItems = 3
+    static let defaultMenuBarMaxItems = 5
 
     /// Whether to show menu bar icon at all
     var showMenuBarIcon: Bool {
@@ -605,12 +605,17 @@ final class MenuBarSettingsManager {
     }
     
     func autoSelectNewAccounts(availableItems: [MenuBarQuotaItem]) {
-        // Don't auto-add if user has manually modified the menu bar selection
-        guard !hasUserModifiedMenuBar else { return }
-
         enforceMaxItems()
         let existingIds = Set(selectedItems.map(\.id))
         let newItems = availableItems.filter { !existingIds.contains($0.id) }
+
+        guard !newItems.isEmpty else { return }
+
+        // Auto-expand menuBarMaxItems to fit new accounts (up to hard cap)
+        let needed = selectedItems.count + newItems.count
+        if needed > menuBarMaxItems && needed <= Self.maxMenuBarItems {
+            menuBarMaxItems = needed
+        }
 
         let remainingSlots = menuBarMaxItems - selectedItems.count
         if remainingSlots > 0 {

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -112,7 +112,11 @@ final class StatusBarMenuBuilder {
         }
         
         // Filter out CLI-based providers if CLI is not installed
+        // Skip the check if we already have quota data for the provider
         return providers.filter { provider in
+            if let quotas = viewModel.providerQuotas[provider], !quotas.isEmpty {
+                return true
+            }
             guard let agent = provider.cliAgent else { return true }
             return isCLIInstalled(agent)
         }.sorted { $0.displayName < $1.displayName }

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -1300,7 +1300,20 @@ final class QuotaViewModel {
     
     private func refreshOpenAIQuotasInternal() async {
         let quotas = await openAIFetcher.fetchAllCodexQuotas()
-        providerQuotas[.codex] = quotas
+        if quotas.isEmpty {
+            if providerQuotas[.codex]?.isEmpty ?? true {
+                providerQuotas.removeValue(forKey: .codex)
+            }
+        } else {
+            if var existing = providerQuotas[.codex] {
+                for (key, quota) in quotas {
+                    existing[key] = quota
+                }
+                providerQuotas[.codex] = existing
+            } else {
+                providerQuotas[.codex] = quotas
+            }
+        }
     }
     
     private func refreshCopilotQuotasInternal() async {


### PR DESCRIPTION
## Summary
- Raise default max menu bar items from 3 to 5 and auto-expand when new accounts are discovered (up to hard cap of 10)
- Remove `hasUserModifiedMenuBar` guard that blocked auto-selection of new accounts after any manual toggle
- Preserve existing Codex quota data when the OpenAI API fetch fails (matching Claude fetcher pattern)
- Skip CLI binary existence check in dropdown when quota data already exists for the provider

## Test plan
- [ ] Add a new Claude/Codex auth file and verify it auto-appears in menu bar and dropdown
- [ ] Verify existing accounts persist across app restarts even when API calls intermittently fail
- [ ] Confirm Codex account shows in dropdown when `codex` binary is in a non-standard path
- [ ] Test with >5 accounts to verify auto-expand works up to the 10-item cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)