### PR TITLE
fix: don't auto-open browser during OAuth flow

### DIFF
--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -1378,11 +1378,7 @@ final class QuotaViewModel {
                 return
             }
             
-            // Auto-open browser AND store URL for copy/open buttons
-            if let url = URL(string: urlString) {
-                NSWorkspace.shared.open(url)
-            }
-            
+            // Store URL for copy/open buttons (don't auto-open browser)
             oauthState = OAuthState(provider: provider, status: .polling, state: state, authURL: urlString)
             await pollOAuthStatus(state: state, provider: provider)
             


### PR DESCRIPTION
## Summary
- Remove automatic browser opening during OAuth flow
- User must click "Open Link" button to open auth URL in browser

## Issue
Fixes issue from #325 where the browser was opening automatically before user could click the "Open Link" button. The original PR added copy/open buttons but still auto-opened the browser, defeating the purpose of having user control.

## Changes
- `QuotaViewModel.swift`: Removed `NSWorkspace.shared.open(url)` call in `startOAuth()`

## Testing
- Build succeeded