### PR TITLE
fix: OAuth reauth from QuotaScreen no longer auto-opens browser

### DIFF
--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -57,6 +57,14 @@ final class QuotaViewModel {
     var errorMessage: String?
     var oauthState: OAuthState?
 
+    /// OAuth launch mode for controlling browser behavior
+    enum OAuthLaunchMode {
+        /// User manually opens the link (shows "Open Link" button)
+        case manual
+        /// Automatically open browser when URL is available
+        case autoOpen
+    }
+
     /// Notification name for quota data updates (used for menu bar refresh)
     static let quotaDataDidChangeNotification = Notification.Name("QuotaViewModel.quotaDataDidChange")
     
@@ -1350,7 +1358,7 @@ final class QuotaViewModel {
         }
     }
     
-    func startOAuth(for provider: AIProvider, projectId: String? = nil, authMethod: AuthCommand? = nil) async {
+    func startOAuth(for provider: AIProvider, projectId: String? = nil, authMethod: AuthCommand? = nil, launchMode: OAuthLaunchMode = .manual) async {
         // GitHub Copilot uses Device Code Flow via CLI binary, not Management API
         if provider == .copilot {
             await startCopilotAuth()
@@ -1378,8 +1386,14 @@ final class QuotaViewModel {
                 return
             }
             
-            // Store URL for copy/open buttons (don't auto-open browser)
+            // Store URL for copy/open buttons
             oauthState = OAuthState(provider: provider, status: .polling, state: state, authURL: urlString)
+            
+            // Auto-open browser if launchMode is .autoOpen
+            if launchMode == .autoOpen, let url = URL(string: urlString) {
+                NSWorkspace.shared.open(url)
+            }
+            
             await pollOAuthStatus(state: state, provider: provider)
             
         } catch {

--- a/Quotio/Views/Screens/QuotaScreen.swift
+++ b/Quotio/Views/Screens/QuotaScreen.swift
@@ -446,6 +446,14 @@ private struct AccountQuotaCardV2: View {
         return oauthState.provider == provider &&
                (oauthState.status == .waiting || oauthState.status == .polling)
     }
+    
+    /// Get auth URL if available during reauthentication
+    private var reauthURL: URL? {
+        guard let oauthState = viewModel.oauthState,
+              oauthState.provider == provider,
+              let urlString = oauthState.authURL else { return nil }
+        return URL(string: urlString)
+    }
     @State private var showWarmupSheet = false
     
     private var hasQuotaData: Bool {
@@ -659,27 +667,47 @@ private struct AccountQuotaCardV2: View {
                 
                 if let data = account.quotaData, data.isForbidden {
                     if provider == .claude {
-                        Button {
-                            Task {
-                                await viewModel.startOAuth(for: .claude)
+                        // When reauthenticating with authURL available, show "Open Link" button
+                        if isReauthenticating, let url = reauthURL {
+                            Button {
+                                NSWorkspace.shared.open(url)
+                            } label: {
+                                HStack(spacing: 4) {
+                                    ProgressView()
+                                        .controlSize(.mini)
+                                    Image(systemName: "safari")
+                                        .font(.caption)
+                                }
+                                .foregroundStyle(.orange)
+                                .frame(width: 56, height: 28)
+                                .background(Color.orange.opacity(0.1))
+                                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
                             }
-                        } label: {
-                            if isReauthenticating {
-                                ProgressView()
-                                    .controlSize(.mini)
-                                    .frame(width: 28, height: 28)
-                            } else {
-                                Image(systemName: "arrow.clockwise.circle.fill")
-                                    .font(.caption)
-                                    .foregroundStyle(.orange)
-                                    .frame(width: 28, height: 28)
-                                    .background(Color.orange.opacity(0.1))
-                                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                            .buttonStyle(.plain)
+                            .help("oauth.openLink".localized())
+                        } else {
+                            Button {
+                                Task {
+                                    await viewModel.startOAuth(for: .claude, launchMode: .autoOpen)
+                                }
+                            } label: {
+                                if isReauthenticating {
+                                    ProgressView()
+                                        .controlSize(.mini)
+                                        .frame(width: 28, height: 28)
+                                } else {
+                                    Image(systemName: "arrow.clockwise.circle.fill")
+                                        .font(.caption)
+                                        .foregroundStyle(.orange)
+                                        .frame(width: 28, height: 28)
+                                        .background(Color.orange.opacity(0.1))
+                                        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                                }
                             }
+                            .buttonStyle(.plain)
+                            .disabled(isReauthenticating)
+                            .help("quota.reauthenticate".localized())
                         }
-                        .buttonStyle(.plain)
-                        .disabled(isReauthenticating)
-                        .help("quota.reauthenticate".localized())
                     } else {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .font(.caption)


### PR DESCRIPTION
## Summary

- Fixes regression from PR #330 where removing auto-open browser caused spinner to hang when reauthenticating Claude from QuotaScreen
- Added `OAuthLaunchMode` enum (`.manual`, `.autoOpen`) to control browser behavior
- `startOAuth()` now accepts `launchMode` param with default `.manual`
- QuotaScreen Claude reauth uses `.autoOpen` so browser opens automatically
- Added fallback "Open Link" button when polling with authURL available
- ProvidersScreen keeps manual behavior (no auto-open browser)

## Test Plan

1. Wait for Claude token to expire or become forbidden
2. Go to QuotaScreen, find the account with orange reauth button
3. Click the orange button
4. Browser should auto-open the auth page
5. Complete auth in browser
6. Status should change to success and quota should refresh
7. Verify ProvidersScreen "Open Link" button still works manually

## Files Changed

| File | Changes |
|------|---------|
| `Quotio/ViewModels/QuotaViewModel.swift` | +18 lines - Added OAuthLaunchMode enum, launchMode param |
| `Quotio/Views/Screens/QuotaScreen.swift` | +44/-20 lines - Auto-open + fallback button |