### PR TITLE
feat: token-based Cloudflare tunnel support + logs UX/build fixes

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -21424,6 +21424,556 @@
         }
       }
     },
+    "settings.tunnelToken.saveError.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The token could not be saved to Keychain. Please try again."
+          }
+        }
+      }
+    },
+    "settings.tunnelToken.saveError.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to Save Tunnel Token"
+          }
+        }
+      }
+    },
+    "skills.action.addServer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Server"
+          }
+        }
+      }
+    },
+    "skills.action.addSkill" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Skill"
+          }
+        }
+      }
+    },
+    "skills.action.browseRegistry" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browse Registry"
+          }
+        }
+      }
+    },
+    "skills.action.toggle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toggle"
+          }
+        }
+      }
+    },
+    "skills.card.agents" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agents:"
+          }
+        }
+      }
+    },
+    "skills.card.keywords" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keywords:"
+          }
+        }
+      }
+    },
+    "skills.card.lastUsedBy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last used by %@"
+          }
+        }
+      }
+    },
+    "skills.card.tools" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tools:"
+          }
+        }
+      }
+    },
+    "skills.card.uses" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d uses"
+          }
+        }
+      }
+    },
+    "skills.deleteServer.confirm.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete \"%@\"?"
+          }
+        }
+      }
+    },
+    "skills.deleteServer.confirm.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete MCP Server"
+          }
+        }
+      }
+    },
+    "skills.deleteSkill.confirm.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete \"%@\"?"
+          }
+        }
+      }
+    },
+    "skills.deleteSkill.confirm.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Skill"
+          }
+        }
+      }
+    },
+    "skills.editor.agents" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agents (comma-separated)"
+          }
+        }
+      }
+    },
+    "skills.editor.agents.help" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "e.g., claude, antigravity, opencode"
+          }
+        }
+      }
+    },
+    "skills.editor.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Description"
+          }
+        }
+      }
+    },
+    "skills.editor.editTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Skill"
+          }
+        }
+      }
+    },
+    "skills.editor.files" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "File patterns (comma-separated)"
+          }
+        }
+      }
+    },
+    "skills.editor.files.help" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "e.g., *.swift, *.ts, *.py"
+          }
+        }
+      }
+    },
+    "skills.editor.keywords" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keywords (comma-separated)"
+          }
+        }
+      }
+    },
+    "skills.editor.keywords.help" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "e.g., review, audit, check"
+          }
+        }
+      }
+    },
+    "skills.editor.name" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Name"
+          }
+        }
+      }
+    },
+    "skills.editor.newTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Skill"
+          }
+        }
+      }
+    },
+    "skills.editor.section.basicInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basic Info"
+          }
+        }
+      }
+    },
+    "skills.editor.section.instructions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instructions"
+          }
+        }
+      }
+    },
+    "skills.editor.section.mcpTools" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MCP Tools"
+          }
+        }
+      }
+    },
+    "skills.editor.section.triggers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Triggers"
+          }
+        }
+      }
+    },
+    "skills.editor.tools" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tool names (comma-separated)"
+          }
+        }
+      }
+    },
+    "skills.editor.tools.help" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "e.g., filesystem, git, terminal"
+          }
+        }
+      }
+    },
+    "skills.empty.createFirst" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create First Skill"
+          }
+        }
+      }
+    },
+    "skills.empty.mcpServers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No MCP servers configured"
+          }
+        }
+      }
+    },
+    "skills.empty.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create Skills to add reusable instructions\nthat work across all AI agents"
+          }
+        }
+      }
+    },
+    "skills.empty.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Skills Yet"
+          }
+        }
+      }
+    },
+    "skills.navigation.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skills"
+          }
+        }
+      }
+    },
+    "skills.registry.emptyMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Find MCP servers for filesystem, git, web search, and more"
+          }
+        }
+      }
+    },
+    "skills.registry.emptyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search the MCP Registry"
+          }
+        }
+      }
+    },
+    "skills.registry.errorTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
+          }
+        }
+      }
+    },
+    "skills.registry.foundServers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Found %d servers"
+          }
+        }
+      }
+    },
+    "skills.registry.searching" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Searching registry..."
+          }
+        }
+      }
+    },
+    "skills.registry.searchPrompt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search servers (e.g., filesystem, git)"
+          }
+        }
+      }
+    },
+    "skills.registry.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MCP Registry"
+          }
+        }
+      }
+    },
+    "skills.section.mcpServers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MCP Servers"
+          }
+        }
+      }
+    },
+    "skills.section.skills" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skills"
+          }
+        }
+      }
+    },
+    "skills.serverSheet.http" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTTP"
+          }
+        }
+      }
+    },
+    "skills.serverSheet.stdio" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stdio"
+          }
+        }
+      }
+    },
+    "skills.serverSheet.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add MCP Server"
+          }
+        }
+      }
+    },
+    "skills.serverSheet.type" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type"
+          }
+        }
+      }
+    },
+    "skills.serverSheet.url" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL"
+          }
+        }
+      }
+    },
     "warp.token.description" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -17989,6 +17989,267 @@
         }
       }
     },
+    "settings.tunnelToken" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare Tunnel Token"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jeton Cloudflare Tunnel"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token Cloudflare Tunnel"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare Tunnel 令牌"
+          }
+        }
+      }
+    },
+    "settings.tunnelToken.help" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use a Cloudflare tunnel token for a stable public URL. Leave empty to use Quick Tunnel."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilisez un jeton Cloudflare Tunnel pour une URL publique stable. Laissez vide pour utiliser Quick Tunnel."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dùng token Cloudflare Tunnel để có URL công khai ổn định. Để trống để dùng Quick Tunnel."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 Cloudflare Tunnel 令牌获得稳定的公开 URL。留空则使用 Quick Tunnel。"
+          }
+        }
+      }
+    },
+    "settings.tunnelToken.placeholder" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter Cloudflare tunnel token"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrez le jeton Cloudflare Tunnel"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhập token Cloudflare Tunnel"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "输入 Cloudflare Tunnel 令牌"
+          }
+        }
+      }
+    },
+    "settings.tunnelPublicURL" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom Tunnel Public URL"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL publique personnalisée du tunnel"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL công khai tùy chỉnh của tunnel"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义 Tunnel 公网 URL"
+          }
+        }
+      }
+    },
+    "settings.tunnelPublicURL.help" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Used for copy/setup when token mode is enabled. Example: https://proxy.example.com"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilisée pour la copie/configuration lorsque le mode token est activé. Exemple : https://proxy.example.com"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dùng để sao chép/cấu hình khi bật chế độ token. Ví dụ: https://proxy.example.com"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在启用 token 模式时用于复制/配置。例如：https://proxy.example.com"
+          }
+        }
+      }
+    },
+    "settings.tunnelPublicURL.invalid" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter a valid URL, e.g. https://proxy.example.com"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrez une URL valide, par ex. https://proxy.example.com"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhập URL hợp lệ, ví dụ https://proxy.example.com"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请输入有效 URL，例如 https://proxy.example.com"
+          }
+        }
+      }
+    },
+    "settings.tunnelPublicURL.placeholder" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://proxy.example.com"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://proxy.example.com"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://proxy.example.com"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://proxy.example.com"
+          }
+        }
+      }
+    },
+    "settings.tunnelPublicURL.requiredForToken" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A custom public URL is required when using a tunnel token."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une URL publique personnalisée est requise lors de l'utilisation d'un jeton de tunnel."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cần có URL công khai tùy chỉnh khi dùng tunnel token."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 tunnel token 时必须设置自定义公网 URL。"
+          }
+        }
+      }
+    },
+    "tunnel.error.customURLRequired" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Set a custom public URL before starting token mode."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Définissez une URL publique personnalisée avant de démarrer le mode token."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hãy đặt URL công khai tùy chỉnh trước khi khởi động chế độ token."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启动 token 模式前请先设置自定义公网 URL。"
+          }
+        }
+      }
+    },
     "settings.updateChannel.beta" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -8345,6 +8345,35 @@
         }
       }
     },
+    "logs.noTunnelLogs" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Tunnel Logs"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun journal du tunnel"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có nhật ký tunnel"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无隧道日志"
+          }
+        }
+      }
+    },
     "logs.noLogs" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -8490,6 +8519,64 @@
         }
       }
     },
+    "logs.searchTunnelLogs" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search tunnel logs..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher dans les journaux du tunnel..."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tìm kiếm nhật ký tunnel..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索隧道日志..."
+          }
+        }
+      }
+    },
+    "logs.source.tunnel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tunnel"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tunnel"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tunnel"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隧道"
+          }
+        }
+      }
+    },
     "logs.startProxy" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -8573,6 +8660,35 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "成功率"
+          }
+        }
+      }
+    },
+    "logs.stats.totalEntries" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entries"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrées"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mục nhật ký"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "条目"
           }
         }
       }
@@ -8689,6 +8805,64 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "请求"
+          }
+        }
+      }
+    },
+    "logs.tab.tunnelLogs" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tunnel Logs"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Journaux du tunnel"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhật ký Tunnel"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隧道日志"
+          }
+        }
+      }
+    },
+    "logs.tunnelLogsWillAppear" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare tunnel output will appear here while the tunnel is running"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La sortie du tunnel Cloudflare apparaîtra ici pendant son exécution"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đầu ra tunnel Cloudflare sẽ hiển thị tại đây khi tunnel đang chạy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare 隧道运行时，其输出会显示在这里"
           }
         }
       }

--- a/Quotio/Models/AgentModels.swift
+++ b/Quotio/Models/AgentModels.swift
@@ -73,6 +73,19 @@ nonisolated enum CLIAgent: String, CaseIterable, Identifiable, Codable, Sendable
         }
     }
 
+    var skillsDirectory: String {
+        switch self {
+        case .geminiCLI:
+            return "~/.gemini/skills"
+        default:
+            let primaryConfigPath = configPaths.first ?? "~/.config/\(rawValue)/settings.json"
+            return URL(fileURLWithPath: NSString(string: primaryConfigPath).expandingTildeInPath)
+                .deletingLastPathComponent()
+                .appendingPathComponent("skills")
+                .path
+        }
+    }
+
     var docsURL: URL? {
         switch self {
         case .claudeCode: return URL(string: "https://docs.anthropic.com/en/docs/claude-code")

--- a/Quotio/Models/SkillModels.swift
+++ b/Quotio/Models/SkillModels.swift
@@ -80,22 +80,69 @@ struct SkillTriggers: Codable, Sendable {
     }
     
     nonisolated func matches(text: String, filePath: String?, agent: String? = nil) -> Bool {
-        let keywordMatch = keywords.isEmpty || keywords.contains { text.localizedCaseInsensitiveContains($0) }
-        let fileMatch = files.isEmpty || (filePath.map { path in files.contains { pattern in matchesGlob(path: path, pattern: pattern) } } ?? false)
-        let agentMatch = agents.isEmpty || (agent.map { agentName in agents.contains { agentName.localizedCaseInsensitiveContains($0) } } ?? true)
+        let normalizedKeywords = keywords
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let normalizedFiles = files
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let normalizedAgents = agents
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty }
+
+        let keywordMatch = normalizedKeywords.isEmpty || normalizedKeywords.contains { text.localizedCaseInsensitiveContains($0) }
+        let fileMatch = normalizedFiles.isEmpty || (filePath.map { path in
+            normalizedFiles.contains { pattern in matchesGlob(path: path, pattern: pattern) }
+        } ?? false)
+
+        let agentMatch: Bool
+        if normalizedAgents.isEmpty {
+            agentMatch = true
+        } else if let agentName = agent?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(), !agentName.isEmpty {
+            agentMatch = normalizedAgents.contains { pattern in
+                agentName.contains(pattern) || pattern.contains(agentName)
+            }
+        } else {
+            agentMatch = false
+        }
+
         return keywordMatch && fileMatch && agentMatch
     }
     
     private nonisolated func matchesGlob(path: String, pattern: String) -> Bool {
-        let regex = pattern.replacingOccurrences(of: "*", with: ".*").replacingOccurrences(of: "?", with: ".")
-        return path.range(of: regex, options: .regularExpression) != nil
+        let escaped = NSRegularExpression.escapedPattern(for: pattern)
+        let wildcardRegex = escaped
+            .replacingOccurrences(of: "\\*", with: ".*")
+            .replacingOccurrences(of: "\\?", with: ".")
+        let regex = "^\(wildcardRegex)$"
+        return path.range(of: regex, options: [.regularExpression, .caseInsensitive]) != nil
     }
 }
 
 // MARK: - MCP Configuration
 
-struct MCPConfig: Codable, Sendable {
+struct MCPConfig: Sendable {
     let servers: [MCPServer]
+
+    nonisolated init(servers: [MCPServer]) {
+        self.servers = servers
+    }
+}
+
+extension MCPConfig: Codable {
+    enum CodingKeys: String, CodingKey {
+        case servers
+    }
+
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.servers = try container.decode([MCPServer].self, forKey: .servers)
+    }
+
+    nonisolated func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(servers, forKey: .servers)
+    }
 }
 
 struct MCPServer: Codable, Identifiable, Sendable {
@@ -104,16 +151,53 @@ struct MCPServer: Codable, Identifiable, Sendable {
     let url: String
     let type: MCPServerType
     
-    nonisolated init(id: UUID = UUID(), name: String, url: String) {
+    nonisolated init(id: UUID = UUID(), name: String, url: String, type: MCPServerType? = nil) {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedURL = url.trimmingCharacters(in: .whitespacesAndNewlines)
+
         self.id = id
-        self.name = name
-        self.url = url
-        self.type = url.hasPrefix("stdio://") ? .stdio : .http
+        self.name = trimmedName
+
+        if let type {
+            self.type = type
+            switch type {
+            case .stdio:
+                self.url = trimmedURL.hasPrefix("stdio://") ? trimmedURL : "stdio://\(trimmedURL)"
+            case .http:
+                self.url = trimmedURL
+            }
+        } else {
+            self.url = trimmedURL
+            self.type = trimmedURL.hasPrefix("stdio://") ? .stdio : .http
+        }
     }
     
     enum MCPServerType: String, Codable, Sendable {
         case stdio
         case http
+    }
+}
+
+extension MCPServer {
+    enum CodingKeys: String, CodingKey {
+        case id, name, url, type
+    }
+
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        let name = try container.decode(String.self, forKey: .name)
+        let url = try container.decode(String.self, forKey: .url)
+        let type = try container.decodeIfPresent(MCPServerType.self, forKey: .type)
+        self.init(id: id, name: name, url: url, type: type)
+    }
+
+    nonisolated func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(url, forKey: .url)
+        try container.encode(type, forKey: .type)
     }
 }
 

--- a/Quotio/Models/SkillModels.swift
+++ b/Quotio/Models/SkillModels.swift
@@ -1,0 +1,136 @@
+//
+//  SkillModels.swift
+//  Quotio
+//
+
+import Foundation
+
+// MARK: - Skill Definition
+
+struct Skill: Identifiable, Sendable {
+    let id: UUID
+    let name: String
+    let description: String
+    let triggers: SkillTriggers
+    let instructions: String
+    let tools: [String]
+    let enabled: Bool
+    var usageCount: Int
+    var lastUsed: Date?
+    var lastAgent: String?
+    
+    nonisolated init(id: UUID = UUID(), name: String, description: String, triggers: SkillTriggers, instructions: String, tools: [String] = [], enabled: Bool = true, usageCount: Int = 0, lastUsed: Date? = nil, lastAgent: String? = nil) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.triggers = triggers
+        self.instructions = instructions
+        self.tools = tools
+        self.enabled = enabled
+        self.usageCount = usageCount
+        self.lastUsed = lastUsed
+        self.lastAgent = lastAgent
+    }
+}
+
+// Manual Codable conformance to avoid MainActor isolation
+extension Skill: Codable {
+    enum CodingKeys: String, CodingKey {
+        case id, name, description, triggers, instructions, tools, enabled, usageCount, lastUsed, lastAgent
+    }
+    
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.description = try container.decode(String.self, forKey: .description)
+        self.triggers = try container.decode(SkillTriggers.self, forKey: .triggers)
+        self.instructions = try container.decode(String.self, forKey: .instructions)
+        self.tools = try container.decode([String].self, forKey: .tools)
+        self.enabled = try container.decode(Bool.self, forKey: .enabled)
+        self.usageCount = try container.decodeIfPresent(Int.self, forKey: .usageCount) ?? 0
+        self.lastUsed = try container.decodeIfPresent(Date.self, forKey: .lastUsed)
+        self.lastAgent = try container.decodeIfPresent(String.self, forKey: .lastAgent)
+    }
+    
+    nonisolated func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(description, forKey: .description)
+        try container.encode(triggers, forKey: .triggers)
+        try container.encode(instructions, forKey: .instructions)
+        try container.encode(tools, forKey: .tools)
+        try container.encode(enabled, forKey: .enabled)
+        try container.encode(usageCount, forKey: .usageCount)
+        try container.encodeIfPresent(lastUsed, forKey: .lastUsed)
+        try container.encodeIfPresent(lastAgent, forKey: .lastAgent)
+    }
+}
+
+struct SkillTriggers: Codable, Sendable {
+    let keywords: [String]
+    let files: [String]
+    let agents: [String] // e.g., ["claude", "antigravity", "opencode"]
+    
+    nonisolated init(keywords: [String] = [], files: [String] = [], agents: [String] = []) {
+        self.keywords = keywords
+        self.files = files
+        self.agents = agents
+    }
+    
+    nonisolated func matches(text: String, filePath: String?, agent: String? = nil) -> Bool {
+        let keywordMatch = keywords.isEmpty || keywords.contains { text.localizedCaseInsensitiveContains($0) }
+        let fileMatch = files.isEmpty || (filePath.map { path in files.contains { pattern in matchesGlob(path: path, pattern: pattern) } } ?? false)
+        let agentMatch = agents.isEmpty || (agent.map { agentName in agents.contains { agentName.localizedCaseInsensitiveContains($0) } } ?? true)
+        return keywordMatch && fileMatch && agentMatch
+    }
+    
+    private nonisolated func matchesGlob(path: String, pattern: String) -> Bool {
+        let regex = pattern.replacingOccurrences(of: "*", with: ".*").replacingOccurrences(of: "?", with: ".")
+        return path.range(of: regex, options: .regularExpression) != nil
+    }
+}
+
+// MARK: - MCP Configuration
+
+struct MCPConfig: Codable, Sendable {
+    let servers: [MCPServer]
+}
+
+struct MCPServer: Codable, Identifiable, Sendable {
+    let id: UUID
+    let name: String
+    let url: String
+    let type: MCPServerType
+    
+    nonisolated init(id: UUID = UUID(), name: String, url: String) {
+        self.id = id
+        self.name = name
+        self.url = url
+        self.type = url.hasPrefix("stdio://") ? .stdio : .http
+    }
+    
+    enum MCPServerType: String, Codable, Sendable {
+        case stdio
+        case http
+    }
+}
+
+// MARK: - Skill Request
+
+struct SkillRequest: Sendable {
+    let userPrompt: String
+    let skills: [Skill]
+    let filePath: String?
+    let mcpContext: [String: String]
+    
+    var composedPrompt: String {
+        var prompt = ""
+        for skill in skills {
+            prompt += "# \(skill.name)\n\(skill.instructions)\n\n"
+        }
+        prompt += userPrompt
+        return prompt
+    }
+}

--- a/Quotio/Services/ImageCacheService.swift
+++ b/Quotio/Services/ImageCacheService.swift
@@ -117,7 +117,9 @@ final class ImageCacheService: @unchecked Sendable {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.cache.countLimit = 20
+            Task { @MainActor in
+                self?.cache.countLimit = 20
+            }
         }
 
         NotificationCenter.default.addObserver(
@@ -125,7 +127,9 @@ final class ImageCacheService: @unchecked Sendable {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.cache.countLimit = 50
+            Task { @MainActor in
+                self?.cache.countLimit = 50
+            }
         }
     }
 }

--- a/Quotio/Services/ImageCacheService.swift
+++ b/Quotio/Services/ImageCacheService.swift
@@ -117,7 +117,7 @@ final class ImageCacheService: @unchecked Sendable {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor in
+            MainActor.assumeIsolated {
                 self?.cache.countLimit = 20
             }
         }
@@ -127,7 +127,7 @@ final class ImageCacheService: @unchecked Sendable {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor in
+            MainActor.assumeIsolated {
                 self?.cache.countLimit = 50
             }
         }

--- a/Quotio/Services/KeychainHelper.swift
+++ b/Quotio/Services/KeychainHelper.swift
@@ -13,8 +13,10 @@ import Security
 enum KeychainHelper {
     private static let remoteService = "dev.quotio.desktop.remote-management"
     private static let localService = "dev.quotio.desktop.local-management"
+    private static let cloudflareTunnelService = "dev.quotio.desktop.cloudflare-tunnel"
     private static let warpService = "dev.quotio.desktop.warp"
     private static let localManagementAccount = "local-management-key"
+    private static let cloudflareTunnelTokenAccount = "cloudflare-tunnel-token"
     private static let warpTokensAccount = "warp-tokens"
     private static let localManagementDefaultsKey = "managementKey"
     private static let warpTokensDefaultsKey = "warpTokens"
@@ -106,6 +108,23 @@ enum KeychainHelper {
             Log.keychain("Failed to save Warp tokens")
         }
         return saved
+    }
+
+    static func saveCloudflareTunnelToken(_ token: String) -> Bool {
+        guard let data = token.data(using: .utf8) else { return false }
+        let saved = saveData(data, service: cloudflareTunnelService, account: cloudflareTunnelTokenAccount)
+        if !saved {
+            Log.keychain("Failed to save Cloudflare tunnel token")
+        }
+        return saved
+    }
+
+    static func getCloudflareTunnelToken() -> String? {
+        readString(service: cloudflareTunnelService, account: cloudflareTunnelTokenAccount)
+    }
+
+    static func deleteCloudflareTunnelToken() {
+        deleteData(service: cloudflareTunnelService, account: cloudflareTunnelTokenAccount)
     }
 
     static func getWarpTokens() -> Data? {

--- a/Quotio/Services/MCPClient.swift
+++ b/Quotio/Services/MCPClient.swift
@@ -1,0 +1,334 @@
+//
+//  MCPClient.swift
+//  Quotio - Model Context Protocol Client
+//
+
+import Foundation
+
+actor MCPClient {
+    static let shared = MCPClient()
+    
+    private var servers: [MCPServer] = []
+    private let fileManager = FileManager.default
+    
+    private init() {}
+    
+    // MARK: - Configuration
+    
+    private var configPath: URL {
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport.appendingPathComponent("Quotio/quotio.yaml")
+    }
+
+    /// MCP sync currently writes JSON config payloads; skip agents that do not use JSON-backed MCP settings.
+    private func mcpSyncPath(for agent: CLIAgent) -> String? {
+        switch agent {
+        case .claudeCode, .ampCLI, .openCode, .factoryDroid:
+            return agent.configPaths.first
+        case .codexCLI, .geminiCLI:
+            return nil
+        }
+    }
+    
+    func loadConfig() async {
+        guard fileManager.fileExists(atPath: configPath.path),
+              let data = try? Data(contentsOf: configPath),
+              let yaml = String(data: data, encoding: .utf8) else {
+            servers = []
+            return
+        }
+        
+        // Simple YAML parser for MCP config
+        var loadedServers: [MCPServer] = []
+        var inServersSection = false
+        var currentName = ""
+        var currentURL = ""
+        
+        for line in yaml.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            
+            if trimmed == "servers:" {
+                inServersSection = true
+            } else if inServersSection {
+                if trimmed.hasPrefix("- name:") {
+                    if !currentName.isEmpty && !currentURL.isEmpty {
+                        loadedServers.append(MCPServer(name: currentName, url: currentURL))
+                    }
+                    currentName = trimmed.replacingOccurrences(of: "- name:", with: "").trimmingCharacters(in: .whitespaces)
+                    currentURL = ""
+                } else if trimmed.hasPrefix("url:") {
+                    currentURL = trimmed.replacingOccurrences(of: "url:", with: "").trimmingCharacters(in: .whitespaces)
+                }
+            }
+        }
+        
+        if !currentName.isEmpty && !currentURL.isEmpty {
+            loadedServers.append(MCPServer(name: currentName, url: currentURL))
+        }
+        
+        servers = loadedServers
+    }
+    
+    func saveConfig() async throws {
+        // Build MCP JSON config (standard format)
+        let mcpConfig: [String: Any] = [
+            "mcpServers": servers.reduce(into: [String: [String: Any]]()) { result, server in
+                result[server.name] = [
+                    "command": server.type == .stdio ? server.url.replacingOccurrences(of: "stdio://", with: "") : "node",
+                    "args": server.type == .http ? [server.url] : [] as [String],
+                    "env": [:] as [String: String]
+                ]
+            }
+        ]
+        
+        let jsonData = try JSONSerialization.data(withJSONObject: mcpConfig, options: [.prettyPrinted])
+        
+        // Save to Quotio's config
+        try jsonData.write(to: configPath)
+        
+        // Sync to all agent MCP configs
+        for agent in CLIAgent.allCases {
+            guard let mcpPath = mcpSyncPath(for: agent) else {
+                continue
+            }
+
+            let agentMCPPath = NSString(string: mcpPath).expandingTildeInPath
+            let agentMCPURL = URL(fileURLWithPath: agentMCPPath)
+            
+            // Create parent directory if needed
+            try? FileManager.default.createDirectory(at: agentMCPURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            
+            // Write MCP config
+            try? jsonData.write(to: agentMCPURL)
+            print("[MCP] Synced config to \(agent.displayName)")
+        }
+    }
+    
+    // MARK: - Fetch Context
+    
+    func fetchContext(for skills: [Skill]) async -> [String: String] {
+        var context: [String: String] = [:]
+        
+        // Collect required tools from Skills
+        let requiredTools = Set(skills.flatMap { $0.tools })
+        
+        for tool in requiredTools {
+            if let server = servers.first(where: { $0.name == tool }) {
+                if let toolContext = await fetchFromServer(server) {
+                    context[tool] = toolContext
+                }
+            }
+        }
+        
+        return context
+    }
+    
+    private func fetchFromServer(_ server: MCPServer) async -> String? {
+        // Context injection - fetch tool information and format as text
+        switch server.type {
+        case .stdio:
+            return await fetchStdioContext(server)
+        case .http:
+            return await fetchHTTPContext(server)
+        }
+    }
+    
+    private func fetchStdioContext(_ server: MCPServer) async -> String? {
+        // For stdio servers, return available tool descriptions
+        let toolDescriptions: [String: String] = [
+            "filesystem": "Access to read/write files in the workspace",
+            "git": "Git repository operations (status, diff, commit)",
+            "terminal": "Execute shell commands",
+            "browser": "Web browsing and search capabilities"
+        ]
+        
+        if let description = toolDescriptions[server.name] {
+            return "[MCP Tool: \(server.name)] \(description)"
+        }
+        
+        return "[MCP Tool: \(server.name)] Available"
+    }
+    
+    private func fetchHTTPContext(_ server: MCPServer) async -> String? {
+        guard let url = URL(string: server.url) else { return nil }
+        
+        // Try to fetch tool schema from HTTP endpoint
+        do {
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            
+            // JSON-RPC 2.0 request for tool list
+            let rpcRequest: [String: Any] = [
+                "jsonrpc": "2.0",
+                "method": "tools/list",
+                "id": 1
+            ]
+            
+            request.httpBody = try JSONSerialization.data(withJSONObject: rpcRequest)
+            
+            let (data, response) = try await URLSession.shared.data(for: request)
+            
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200,
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let result = json["result"] as? [String: Any],
+               let tools = result["tools"] as? [[String: Any]] {
+                
+                let toolNames = tools.compactMap { $0["name"] as? String }.joined(separator: ", ")
+                return "[MCP Server: \(server.name)] Tools: \(toolNames)"
+            }
+        } catch {
+            return nil
+        }
+        
+        return nil
+    }
+    
+    // MARK: - CRUD
+    
+    func getServers() -> [MCPServer] {
+        servers
+    }
+    
+    func addServer(_ server: MCPServer) async throws {
+        servers.append(server)
+        try await saveConfig()
+    }
+    
+    func removeServer(_ server: MCPServer) async throws {
+        servers.removeAll { $0.id == server.id }
+        try await saveConfig()
+    }
+    
+    // MARK: - MCP Registry API
+    
+    func fetchFromRegistry(search: String? = nil, limit: Int = 20) async throws -> [MCPServer] {
+        var urlString = "https://registry.modelcontextprotocol.io/v0/servers?limit=\(limit)"
+        if let search = search {
+            urlString += "&search=\(search.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
+        }
+        
+        guard let url = URL(string: urlString) else {
+            throw URLError(.badURL)
+        }
+        
+        print("[MCP Registry] Fetching: \(urlString)")
+        
+        let (data, _) = try await URLSession.shared.data(from: url)
+        
+        // Decode on a background task to avoid main actor isolation
+        let response = try await Task.detached {
+            try JSONDecoder().decode(MCPRegistryResponse.self, from: data)
+        }.value
+        
+        print("[MCP Registry] Found \(response.servers.count) servers")
+        
+        return response.servers.compactMap { entry in
+            // Try packages first, then remotes
+            if let package = entry.server.packages?.first {
+                let url = package.transport.type == .stdio 
+                    ? "stdio://\(package.identifier)"
+                    : package.transport.url ?? ""
+                
+                return MCPServer(
+                    name: entry.server.name.components(separatedBy: "/").last ?? entry.server.name,
+                    url: url
+                )
+            } else if let remote = entry.server.remotes?.first {
+                return MCPServer(
+                    name: entry.server.name.components(separatedBy: "/").last ?? entry.server.name,
+                    url: remote.url
+                )
+            }
+            
+            print("[MCP Registry] Skipping server with no packages or remotes: \(entry.server.name)")
+            return nil
+        }
+    }
+}
+
+// MARK: - Registry Response Models
+
+private struct MCPRegistryResponse: Sendable {
+    let servers: [MCPRegistryEntry]
+}
+
+extension MCPRegistryResponse: Codable {
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.servers = try container.decode([MCPRegistryEntry].self, forKey: .servers)
+    }
+}
+
+private struct MCPRegistryEntry: Sendable {
+    let server: MCPRegistryServer
+}
+
+extension MCPRegistryEntry: Codable {
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.server = try container.decode(MCPRegistryServer.self, forKey: .server)
+    }
+}
+
+private struct MCPRegistryServer: Sendable {
+    let name: String
+    let description: String
+    let packages: [MCPPackage]?
+    let remotes: [MCPRemote]?
+}
+
+extension MCPRegistryServer: Codable {
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.description = try container.decode(String.self, forKey: .description)
+        self.packages = try container.decodeIfPresent([MCPPackage].self, forKey: .packages)
+        self.remotes = try container.decodeIfPresent([MCPRemote].self, forKey: .remotes)
+    }
+}
+
+private struct MCPRemote: Sendable {
+    let type: String
+    let url: String
+}
+
+extension MCPRemote: Codable {
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.type = try container.decode(String.self, forKey: .type)
+        self.url = try container.decode(String.self, forKey: .url)
+    }
+}
+
+private struct MCPPackage: Sendable {
+    let identifier: String
+    let transport: MCPTransport
+}
+
+extension MCPPackage: Codable {
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.identifier = try container.decode(String.self, forKey: .identifier)
+        self.transport = try container.decode(MCPTransport.self, forKey: .transport)
+    }
+}
+
+private struct MCPTransport: Sendable {
+    let type: MCPTransportType
+    let url: String?
+    
+    enum MCPTransportType: String, Codable, Sendable {
+        case stdio
+        case sse
+        case streamableHttp = "streamable-http"
+    }
+}
+
+extension MCPTransport: Codable {
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.type = try container.decode(MCPTransportType.self, forKey: .type)
+        self.url = try container.decodeIfPresent(String.self, forKey: .url)
+    }
+}

--- a/Quotio/Services/MCPClient.swift
+++ b/Quotio/Services/MCPClient.swift
@@ -10,98 +10,113 @@ actor MCPClient {
     
     private var servers: [MCPServer] = []
     private let fileManager = FileManager.default
+    private let configFileName = "mcp_servers.json"
+    private let legacyConfigFileName = "quotio.yaml"
     
     private init() {}
     
     // MARK: - Configuration
     
-    private var configPath: URL {
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        return appSupport.appendingPathComponent("Quotio/quotio.yaml")
+    private enum MCPStorageError: Error {
+        case applicationSupportUnavailable
+        case invalidLegacyEncoding
     }
 
-    /// MCP sync currently writes JSON config payloads; skip agents that do not use JSON-backed MCP settings.
-    private func mcpSyncPath(for agent: CLIAgent) -> String? {
-        switch agent {
-        case .claudeCode, .ampCLI, .openCode, .factoryDroid:
-            return agent.configPaths.first
-        case .codexCLI, .geminiCLI:
-            return nil
+    private func appSupportDirectory() throws -> URL {
+        guard let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            throw MCPStorageError.applicationSupportUnavailable
         }
+        return appSupport.appendingPathComponent("Quotio", isDirectory: true)
     }
-    
-    func loadConfig() async {
-        guard fileManager.fileExists(atPath: configPath.path),
-              let data = try? Data(contentsOf: configPath),
-              let yaml = String(data: data, encoding: .utf8) else {
-            servers = []
-            return
+
+    private func configPath() throws -> URL {
+        try appSupportDirectory().appendingPathComponent(configFileName)
+    }
+
+    private func legacyConfigPath() throws -> URL {
+        try appSupportDirectory().appendingPathComponent(legacyConfigFileName)
+    }
+
+    private func loadJSONConfig(from url: URL) throws -> [MCPServer] {
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(MCPConfig.self, from: data).servers
+    }
+
+    private func loadLegacyYAMLConfig(from url: URL) throws -> [MCPServer] {
+        let data = try Data(contentsOf: url)
+        guard let yaml = String(data: data, encoding: .utf8) else {
+            throw MCPStorageError.invalidLegacyEncoding
         }
-        
-        // Simple YAML parser for MCP config
+
         var loadedServers: [MCPServer] = []
         var inServersSection = false
         var currentName = ""
         var currentURL = ""
-        
+        var currentType: MCPServer.MCPServerType?
+
         for line in yaml.components(separatedBy: .newlines) {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
-            
+
             if trimmed == "servers:" {
                 inServersSection = true
-            } else if inServersSection {
-                if trimmed.hasPrefix("- name:") {
-                    if !currentName.isEmpty && !currentURL.isEmpty {
-                        loadedServers.append(MCPServer(name: currentName, url: currentURL))
-                    }
-                    currentName = trimmed.replacingOccurrences(of: "- name:", with: "").trimmingCharacters(in: .whitespaces)
-                    currentURL = ""
-                } else if trimmed.hasPrefix("url:") {
-                    currentURL = trimmed.replacingOccurrences(of: "url:", with: "").trimmingCharacters(in: .whitespaces)
-                }
-            }
-        }
-        
-        if !currentName.isEmpty && !currentURL.isEmpty {
-            loadedServers.append(MCPServer(name: currentName, url: currentURL))
-        }
-        
-        servers = loadedServers
-    }
-    
-    func saveConfig() async throws {
-        // Build MCP JSON config (standard format)
-        let mcpConfig: [String: Any] = [
-            "mcpServers": servers.reduce(into: [String: [String: Any]]()) { result, server in
-                result[server.name] = [
-                    "command": server.type == .stdio ? server.url.replacingOccurrences(of: "stdio://", with: "") : "node",
-                    "args": server.type == .http ? [server.url] : [] as [String],
-                    "env": [:] as [String: String]
-                ]
-            }
-        ]
-        
-        let jsonData = try JSONSerialization.data(withJSONObject: mcpConfig, options: [.prettyPrinted])
-        
-        // Save to Quotio's config
-        try jsonData.write(to: configPath)
-        
-        // Sync to all agent MCP configs
-        for agent in CLIAgent.allCases {
-            guard let mcpPath = mcpSyncPath(for: agent) else {
                 continue
             }
 
-            let agentMCPPath = NSString(string: mcpPath).expandingTildeInPath
-            let agentMCPURL = URL(fileURLWithPath: agentMCPPath)
-            
-            // Create parent directory if needed
-            try? FileManager.default.createDirectory(at: agentMCPURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-            
-            // Write MCP config
-            try? jsonData.write(to: agentMCPURL)
-            print("[MCP] Synced config to \(agent.displayName)")
+            guard inServersSection else { continue }
+
+            if trimmed.hasPrefix("- name:") {
+                if !currentName.isEmpty && !currentURL.isEmpty {
+                    loadedServers.append(MCPServer(name: currentName, url: currentURL, type: currentType))
+                }
+                currentName = trimmed.replacingOccurrences(of: "- name:", with: "").trimmingCharacters(in: .whitespaces)
+                currentURL = ""
+                currentType = nil
+            } else if trimmed.hasPrefix("url:") {
+                currentURL = trimmed.replacingOccurrences(of: "url:", with: "").trimmingCharacters(in: .whitespaces)
+            } else if trimmed.hasPrefix("type:") {
+                let typeValue = trimmed.replacingOccurrences(of: "type:", with: "").trimmingCharacters(in: .whitespaces).lowercased()
+                currentType = typeValue == "stdio" ? .stdio : .http
+            }
         }
+
+        if !currentName.isEmpty && !currentURL.isEmpty {
+            loadedServers.append(MCPServer(name: currentName, url: currentURL, type: currentType))
+        }
+
+        return loadedServers
+    }
+    
+    func loadConfig() async {
+        do {
+            let configURL = try configPath()
+            if fileManager.fileExists(atPath: configURL.path) {
+                servers = try loadJSONConfig(from: configURL)
+                return
+            }
+
+            let legacyURL = try legacyConfigPath()
+            if fileManager.fileExists(atPath: legacyURL.path) {
+                servers = try loadLegacyYAMLConfig(from: legacyURL)
+                try await saveConfig()
+                return
+            }
+
+            servers = []
+        } catch {
+            print("[MCP] Failed to load config: \(error)")
+            servers = []
+        }
+    }
+    
+    func saveConfig() async throws {
+        let directory = try appSupportDirectory()
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let jsonData = try encoder.encode(MCPConfig(servers: servers))
+
+        try jsonData.write(to: directory.appendingPathComponent(configFileName), options: .atomic)
     }
     
     // MARK: - Fetch Context

--- a/Quotio/Services/SkillsManager.swift
+++ b/Quotio/Services/SkillsManager.swift
@@ -1,0 +1,360 @@
+//
+//  SkillsManager.swift
+//  Quotio - Skills Management Service
+//
+
+import Foundation
+
+actor SkillsManager {
+    static let shared = SkillsManager()
+    
+    private var skills: [Skill] = []
+    private let fileManager = FileManager.default
+    
+    private init() {}
+    
+    // MARK: - Skills Directory
+    
+    private var skillsDirectory: URL {
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport.appendingPathComponent("Quotio/skills")
+    }
+    
+    // MARK: - Load Skills
+    
+    func loadSkills() async {
+        // Ensure directory exists
+        try? fileManager.createDirectory(at: skillsDirectory, withIntermediateDirectories: true)
+        
+        var loadedSkills: [Skill] = []
+        
+        guard let files = try? fileManager.contentsOfDirectory(at: skillsDirectory, includingPropertiesForKeys: nil) else {
+            print("[Skills] Failed to read skills directory")
+            skills = []
+            return
+        }
+        
+        print("[Skills] Found \(files.count) files in skills directory")
+        
+        for file in files where file.pathExtension == "yaml" || file.pathExtension == "yml" {
+            print("[Skills] Loading: \(file.lastPathComponent)")
+            if let skill = try? await loadSkill(from: file) {
+                loadedSkills.append(skill)
+                print("[Skills] ✓ Loaded: \(skill.name)")
+            } else {
+                print("[Skills] ✗ Failed to load: \(file.lastPathComponent)")
+            }
+        }
+        
+        skills = loadedSkills
+        print("[Skills] Total loaded: \(skills.count) skills")
+    }
+    
+    private func loadSkill(from url: URL) async throws -> Skill {
+        let data = try Data(contentsOf: url)
+        let decoder = YAMLDecoder()
+        return try decoder.decode(Skill.self, from: data)
+    }
+    
+    // MARK: - Match Skills
+    
+    func findMatchingSkills(prompt: String, filePath: String?, agent: String?) -> [Skill] {
+        print("[Skills] Finding matches for prompt: '\(prompt.prefix(50))...', agent: \(agent ?? "none")")
+        let matched = skills.filter { skill in
+            let matches = skill.enabled && skill.triggers.matches(text: prompt, filePath: filePath, agent: agent)
+            if matches {
+                print("[Skills] ✓ Matched: \(skill.name)")
+            }
+            return matches
+        }
+        print("[Skills] Total matches: \(matched.count)")
+        return matched
+    }
+    
+    // MARK: - Usage Tracking
+    
+    func recordUsage(skillId: UUID, agent: String?) async {
+        guard let index = skills.firstIndex(where: { $0.id == skillId }) else { return }
+        
+        var skill = skills[index]
+        skill.usageCount += 1
+        skill.lastUsed = Date()
+        skill.lastAgent = agent
+        skills[index] = skill
+        
+        // Save to disk
+        try? await saveSkill(skill)
+    }
+    
+    // MARK: - Agent Detection
+    
+    func detectAgent(from headers: [String: String]) -> String? {
+        // Check User-Agent header
+        if let userAgent = headers["User-Agent"] ?? headers["user-agent"] {
+            if userAgent.contains("claude") { return "Claude Code" }
+            if userAgent.contains("antigravity") { return "Antigravity" }
+            if userAgent.contains("opencode") { return "OpenCode" }
+            if userAgent.contains("gemini") { return "Gemini CLI" }
+            if userAgent.contains("codex") { return "Codex CLI" }
+            if userAgent.contains("amp") { return "Amp CLI" }
+        }
+        
+        // Check custom headers
+        if let clientName = headers["X-Client-Name"] ?? headers["x-client-name"] {
+            return clientName
+        }
+        
+        return nil
+    }
+    
+    // MARK: - Enrich Request
+    
+    func enrichRequest(body: String, skills: [Skill], mcpContext: [String: String]) -> String {
+        guard !skills.isEmpty else { return body }
+        
+        guard let bodyData = body.data(using: .utf8),
+              var json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any] else {
+            return body
+        }
+        
+        // Build enriched prompt
+        var enrichedPrompt = ""
+        
+        // Add Skill instructions
+        for skill in skills {
+            enrichedPrompt += "# \(skill.name)\n\(skill.instructions)\n\n"
+        }
+        
+        // Add MCP context if available
+        if !mcpContext.isEmpty {
+            enrichedPrompt += "# Context\n"
+            for (key, value) in mcpContext {
+                enrichedPrompt += "- \(key): \(value)\n"
+            }
+            enrichedPrompt += "\n"
+        }
+        
+        // Append original prompt
+        if let messages = json["messages"] as? [[String: Any]],
+           let lastMessage = messages.last,
+           let content = lastMessage["content"] as? String {
+            enrichedPrompt += content
+            
+            // Update last message
+            var updatedMessages = messages
+            var updatedLastMessage = lastMessage
+            updatedLastMessage["content"] = enrichedPrompt
+            updatedMessages[updatedMessages.count - 1] = updatedLastMessage
+            json["messages"] = updatedMessages
+        } else if let prompt = json["prompt"] as? String {
+            enrichedPrompt += prompt
+            json["prompt"] = enrichedPrompt
+        }
+        
+        // Convert back to JSON
+        guard let updatedData = try? JSONSerialization.data(withJSONObject: json),
+              let updatedBody = String(data: updatedData, encoding: .utf8) else {
+            return body
+        }
+        
+        return updatedBody
+    }
+    
+    // MARK: - CRUD Operations
+    
+    func getSkills() -> [Skill] {
+        skills
+    }
+    
+    func saveSkill(_ skill: Skill) async throws {
+        let filename = skill.name.lowercased().replacingOccurrences(of: " ", with: "-") + ".yaml"
+        let url = skillsDirectory.appendingPathComponent(filename)
+        
+        let encoder = YAMLEncoder()
+        let data = try encoder.encode(skill)
+        try data.write(to: url)
+        
+        // Sync to all agent directories
+        await syncSkillToAgents(skill, filename: filename, data: data)
+        
+        await loadSkills()
+    }
+    
+    private func syncSkillToAgents(_ skill: Skill, filename: String, data: Data) async {
+        for agent in CLIAgent.allCases {
+            let agentSkillsDir = NSString(string: agent.skillsDirectory).expandingTildeInPath
+            let agentSkillsURL = URL(fileURLWithPath: agentSkillsDir)
+            
+            // Create skill directory (e.g., ~/.claude/skills/code-review/)
+            let skillName = skill.name.lowercased().replacingOccurrences(of: " ", with: "-")
+            let skillDir = agentSkillsURL.appendingPathComponent(skillName)
+            try? fileManager.createDirectory(at: skillDir, withIntermediateDirectories: true)
+            
+            // All agents use SKILL.md format (Agent Skills open standard)
+            let skillMD = """
+            ---
+            name: \(skillName)
+            description: \(skill.description). Triggers: \(skill.triggers.keywords.joined(separator: ", "))
+            version: 1.0.0
+            ---
+            
+            # \(skill.name)
+            
+            \(skill.instructions)
+            
+            ## When to Use
+            
+            This skill activates when:
+            \(skill.triggers.keywords.map { "- User mentions '\($0)'" }.joined(separator: "\n"))
+            
+            ## File Patterns
+            
+            \(skill.triggers.files.isEmpty ? "Applies to all files" : skill.triggers.files.map { "- `\($0)`" }.joined(separator: "\n"))
+            
+            ## Tools Available
+            
+            \(skill.tools.isEmpty ? "No specific tools required" : skill.tools.map { "- \($0)" }.joined(separator: "\n"))
+            """
+            
+            let skillFile = skillDir.appendingPathComponent("SKILL.md")
+            try? skillMD.data(using: .utf8)?.write(to: skillFile)
+            
+            print("[Skills] Synced '\(skill.name)' to \(agent.displayName)")
+        }
+    }
+    
+    func deleteSkill(_ skill: Skill) async throws {
+        let filename = skill.name.lowercased().replacingOccurrences(of: " ", with: "-") + ".yaml"
+        let url = skillsDirectory.appendingPathComponent(filename)
+        try fileManager.removeItem(at: url)
+        
+        // Delete from all agent directories (all use SKILL.md format)
+        let skillName = skill.name.lowercased().replacingOccurrences(of: " ", with: "-")
+        for agent in CLIAgent.allCases {
+            let agentSkillsDir = NSString(string: agent.skillsDirectory).expandingTildeInPath
+            let skillDir = URL(fileURLWithPath: agentSkillsDir).appendingPathComponent(skillName)
+            try? fileManager.removeItem(at: skillDir)
+            print("[Skills] Deleted '\(skill.name)' from \(agent.displayName)")
+        }
+        
+        await loadSkills()
+    }
+}
+
+// MARK: - YAML Coding (Minimal Implementation)
+
+private struct YAMLDecoder {
+    nonisolated func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        // Simple YAML parser for Skill format
+        guard let yaml = String(data: data, encoding: .utf8) else {
+            throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Invalid UTF-8"))
+        }
+        
+        var name = ""
+        var description = ""
+        var keywords: [String] = []
+        var files: [String] = []
+        var agents: [String] = []
+        var instructions = ""
+        var tools: [String] = []
+        var enabled = true
+        var usageCount = 0
+        var lastUsed: Date?
+        var lastAgent: String?
+        
+        var currentSection = ""
+        var instructionsLines: [String] = []
+        
+        for line in yaml.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            
+            if trimmed.hasPrefix("name:") {
+                name = trimmed.replacingOccurrences(of: "name:", with: "").trimmingCharacters(in: .whitespaces)
+            } else if trimmed.hasPrefix("description:") {
+                description = trimmed.replacingOccurrences(of: "description:", with: "").trimmingCharacters(in: .whitespaces)
+            } else if trimmed.hasPrefix("enabled:") {
+                enabled = trimmed.replacingOccurrences(of: "enabled:", with: "").trimmingCharacters(in: .whitespaces) == "true"
+            } else if trimmed.hasPrefix("usageCount:") {
+                usageCount = Int(trimmed.replacingOccurrences(of: "usageCount:", with: "").trimmingCharacters(in: .whitespaces)) ?? 0
+            } else if trimmed.hasPrefix("lastUsed:") {
+                let dateStr = trimmed.replacingOccurrences(of: "lastUsed:", with: "").trimmingCharacters(in: .whitespaces)
+                if !dateStr.isEmpty, let date = try? Date(dateStr, strategy: .iso8601) {
+                    lastUsed = date
+                }
+            } else if trimmed.hasPrefix("lastAgent:") {
+                let agent = trimmed.replacingOccurrences(of: "lastAgent:", with: "").trimmingCharacters(in: .whitespaces)
+                lastAgent = agent.isEmpty ? nil : agent
+            } else if trimmed == "triggers:" {
+                currentSection = "triggers"
+            } else if trimmed == "instructions: |" {
+                currentSection = "instructions"
+            } else if trimmed == "tools:" {
+                currentSection = "tools"
+            } else if currentSection == "triggers" {
+                if trimmed.hasPrefix("keywords:") {
+                    let keywordsStr = trimmed.replacingOccurrences(of: "keywords:", with: "").trimmingCharacters(in: .whitespaces)
+                    keywords = parseArray(keywordsStr)
+                } else if trimmed.hasPrefix("files:") {
+                    let filesStr = trimmed.replacingOccurrences(of: "files:", with: "").trimmingCharacters(in: .whitespaces)
+                    files = parseArray(filesStr)
+                } else if trimmed.hasPrefix("agents:") {
+                    let agentsStr = trimmed.replacingOccurrences(of: "agents:", with: "").trimmingCharacters(in: .whitespaces)
+                    agents = parseArray(agentsStr)
+                }
+            } else if currentSection == "instructions" && !trimmed.isEmpty {
+                instructionsLines.append(line.trimmingCharacters(in: .whitespaces))
+            } else if currentSection == "tools" && trimmed.hasPrefix("-") {
+                let tool = trimmed.replacingOccurrences(of: "-", with: "").trimmingCharacters(in: .whitespaces)
+                tools.append(tool)
+            }
+        }
+        
+        instructions = instructionsLines.joined(separator: "\n")
+        
+        let skill = Skill(
+            name: name,
+            description: description,
+            triggers: SkillTriggers(keywords: keywords, files: files, agents: agents),
+            instructions: instructions,
+            tools: tools,
+            enabled: enabled,
+            usageCount: usageCount,
+            lastUsed: lastUsed,
+            lastAgent: lastAgent
+        )
+        
+        return skill as! T
+    }
+    
+    private nonisolated func parseArray(_ str: String) -> [String] {
+        let cleaned = str.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+        return cleaned.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
+    }
+}
+
+private struct YAMLEncoder {
+    nonisolated func encode<T: Encodable>(_ value: T) throws -> Data {
+        guard let skill = value as? Skill else {
+            throw EncodingError.invalidValue(value, .init(codingPath: [], debugDescription: "Not a Skill"))
+        }
+        
+        let yaml = """
+        name: \(skill.name)
+        description: \(skill.description)
+        enabled: \(skill.enabled)
+        usageCount: \(skill.usageCount)
+        lastUsed: \(skill.lastUsed?.ISO8601Format() ?? "")
+        lastAgent: \(skill.lastAgent ?? "")
+        triggers:
+          keywords: [\(skill.triggers.keywords.joined(separator: ", "))]
+          files: [\(skill.triggers.files.joined(separator: ", "))]
+          agents: [\(skill.triggers.agents.joined(separator: ", "))]
+        instructions: |
+        \(skill.instructions.components(separatedBy: .newlines).map { "  " + $0 }.joined(separator: "\n"))
+        tools:
+        \(skill.tools.map { "  - " + $0 }.joined(separator: "\n"))
+        """
+        
+        return yaml.data(using: .utf8)!
+    }
+}

--- a/Quotio/Services/SkillsManager.swift
+++ b/Quotio/Services/SkillsManager.swift
@@ -14,31 +14,84 @@ actor SkillsManager {
     private init() {}
     
     // MARK: - Skills Directory
-    
-    private var skillsDirectory: URL {
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        return appSupport.appendingPathComponent("Quotio/skills")
+
+    private enum SkillsStorageError: Error {
+        case applicationSupportUnavailable
+    }
+
+    private func skillsDirectory() throws -> URL {
+        guard let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            throw SkillsStorageError.applicationSupportUnavailable
+        }
+        return appSupport.appendingPathComponent("Quotio/skills", isDirectory: true)
+    }
+
+    private func ensureSkillsDirectory() throws -> URL {
+        let directory = try skillsDirectory()
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func sanitizedComponent(_ value: String) -> String {
+        let lowered = value.lowercased()
+        let mapped = lowered.map { char -> Character in
+            if char.isLetter || char.isNumber {
+                return char
+            }
+            return "-"
+        }
+        let raw = String(mapped)
+        let collapsed = raw.replacingOccurrences(of: "-{2,}", with: "-", options: .regularExpression)
+        let trimmed = collapsed.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        return trimmed.isEmpty ? "skill" : trimmed
+    }
+
+    private func skillFilename(for skill: Skill) -> String {
+        "\(sanitizedComponent(skill.name))-\(skill.id.uuidString.lowercased()).yaml"
+    }
+
+    private func agentSkillDirectoryName(for skill: Skill) -> String {
+        "\(sanitizedComponent(skill.name))-\(skill.id.uuidString.lowercased())"
+    }
+
+    private func listSkillFiles(in directory: URL) -> [URL] {
+        guard let files = try? fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil) else {
+            return []
+        }
+
+        return files.filter { $0.pathExtension == "yaml" || $0.pathExtension == "yml" }
+    }
+
+    private func removePersistedSkillFiles(matching skill: Skill, in directory: URL) {
+        for file in listSkillFiles(in: directory) {
+            guard let persistedSkill = try? loadSkill(from: file) else { continue }
+            if persistedSkill.id == skill.id || persistedSkill.name.caseInsensitiveCompare(skill.name) == .orderedSame {
+                try? fileManager.removeItem(at: file)
+            }
+        }
     }
     
     // MARK: - Load Skills
     
     func loadSkills() async {
-        // Ensure directory exists
-        try? fileManager.createDirectory(at: skillsDirectory, withIntermediateDirectories: true)
-        
-        var loadedSkills: [Skill] = []
-        
-        guard let files = try? fileManager.contentsOfDirectory(at: skillsDirectory, includingPropertiesForKeys: nil) else {
-            print("[Skills] Failed to read skills directory")
+        let directory: URL
+        do {
+            directory = try ensureSkillsDirectory()
+        } catch {
+            print("[Skills] Failed to resolve skills directory: \(error)")
             skills = []
             return
         }
         
+        var loadedSkills: [Skill] = []
+        
+        let files = listSkillFiles(in: directory)
+        
         print("[Skills] Found \(files.count) files in skills directory")
         
-        for file in files where file.pathExtension == "yaml" || file.pathExtension == "yml" {
+        for file in files {
             print("[Skills] Loading: \(file.lastPathComponent)")
-            if let skill = try? await loadSkill(from: file) {
+            if let skill = try? loadSkill(from: file) {
                 loadedSkills.append(skill)
                 print("[Skills] ✓ Loaded: \(skill.name)")
             } else {
@@ -50,10 +103,10 @@ actor SkillsManager {
         print("[Skills] Total loaded: \(skills.count) skills")
     }
     
-    private func loadSkill(from url: URL) async throws -> Skill {
+    private func loadSkill(from url: URL) throws -> Skill {
         let data = try Data(contentsOf: url)
         let decoder = YAMLDecoder()
-        return try decoder.decode(Skill.self, from: data)
+        return try decoder.decodeSkill(from: data)
     }
     
     // MARK: - Match Skills
@@ -167,26 +220,29 @@ actor SkillsManager {
     }
     
     func saveSkill(_ skill: Skill) async throws {
-        let filename = skill.name.lowercased().replacingOccurrences(of: " ", with: "-") + ".yaml"
-        let url = skillsDirectory.appendingPathComponent(filename)
+        let directory = try ensureSkillsDirectory()
+        let filename = skillFilename(for: skill)
+        let url = directory.appendingPathComponent(filename)
         
         let encoder = YAMLEncoder()
-        let data = try encoder.encode(skill)
+        let data = try encoder.encodeSkill(skill)
+
+        removePersistedSkillFiles(matching: skill, in: directory)
         try data.write(to: url)
         
         // Sync to all agent directories
-        await syncSkillToAgents(skill, filename: filename, data: data)
+        await syncSkillToAgents(skill)
         
         await loadSkills()
     }
     
-    private func syncSkillToAgents(_ skill: Skill, filename: String, data: Data) async {
+    private func syncSkillToAgents(_ skill: Skill) async {
         for agent in CLIAgent.allCases {
             let agentSkillsDir = NSString(string: agent.skillsDirectory).expandingTildeInPath
             let agentSkillsURL = URL(fileURLWithPath: agentSkillsDir)
             
             // Create skill directory (e.g., ~/.claude/skills/code-review/)
-            let skillName = skill.name.lowercased().replacingOccurrences(of: " ", with: "-")
+            let skillName = agentSkillDirectoryName(for: skill)
             let skillDir = agentSkillsURL.appendingPathComponent(skillName)
             try? fileManager.createDirectory(at: skillDir, withIntermediateDirectories: true)
             
@@ -224,12 +280,11 @@ actor SkillsManager {
     }
     
     func deleteSkill(_ skill: Skill) async throws {
-        let filename = skill.name.lowercased().replacingOccurrences(of: " ", with: "-") + ".yaml"
-        let url = skillsDirectory.appendingPathComponent(filename)
-        try fileManager.removeItem(at: url)
+        let directory = try ensureSkillsDirectory()
+        removePersistedSkillFiles(matching: skill, in: directory)
         
         // Delete from all agent directories (all use SKILL.md format)
-        let skillName = skill.name.lowercased().replacingOccurrences(of: " ", with: "-")
+        let skillName = agentSkillDirectoryName(for: skill)
         for agent in CLIAgent.allCases {
             let agentSkillsDir = NSString(string: agent.skillsDirectory).expandingTildeInPath
             let skillDir = URL(fileURLWithPath: agentSkillsDir).appendingPathComponent(skillName)
@@ -244,12 +299,13 @@ actor SkillsManager {
 // MARK: - YAML Coding (Minimal Implementation)
 
 private struct YAMLDecoder {
-    nonisolated func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+    nonisolated func decodeSkill(from data: Data) throws -> Skill {
         // Simple YAML parser for Skill format
         guard let yaml = String(data: data, encoding: .utf8) else {
             throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Invalid UTF-8"))
         }
         
+        var id = UUID()
         var name = ""
         var description = ""
         var keywords: [String] = []
@@ -268,7 +324,12 @@ private struct YAMLDecoder {
         for line in yaml.components(separatedBy: .newlines) {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             
-            if trimmed.hasPrefix("name:") {
+            if trimmed.hasPrefix("id:") {
+                let idString = trimmed.replacingOccurrences(of: "id:", with: "").trimmingCharacters(in: .whitespaces)
+                if let parsedID = UUID(uuidString: idString) {
+                    id = parsedID
+                }
+            } else if trimmed.hasPrefix("name:") {
                 name = trimmed.replacingOccurrences(of: "name:", with: "").trimmingCharacters(in: .whitespaces)
             } else if trimmed.hasPrefix("description:") {
                 description = trimmed.replacingOccurrences(of: "description:", with: "").trimmingCharacters(in: .whitespaces)
@@ -312,6 +373,7 @@ private struct YAMLDecoder {
         instructions = instructionsLines.joined(separator: "\n")
         
         let skill = Skill(
+            id: id,
             name: name,
             description: description,
             triggers: SkillTriggers(keywords: keywords, files: files, agents: agents),
@@ -323,22 +385,21 @@ private struct YAMLDecoder {
             lastAgent: lastAgent
         )
         
-        return skill as! T
+        return skill
     }
     
     private nonisolated func parseArray(_ str: String) -> [String] {
         let cleaned = str.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
-        return cleaned.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
+        return cleaned.components(separatedBy: ",")
+            .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: " \"'")) }
+            .filter { !$0.isEmpty }
     }
 }
 
 private struct YAMLEncoder {
-    nonisolated func encode<T: Encodable>(_ value: T) throws -> Data {
-        guard let skill = value as? Skill else {
-            throw EncodingError.invalidValue(value, .init(codingPath: [], debugDescription: "Not a Skill"))
-        }
-        
+    nonisolated func encodeSkill(_ skill: Skill) throws -> Data {
         let yaml = """
+        id: \(skill.id.uuidString.lowercased())
         name: \(skill.name)
         description: \(skill.description)
         enabled: \(skill.enabled)
@@ -354,7 +415,14 @@ private struct YAMLEncoder {
         tools:
         \(skill.tools.map { "  - " + $0 }.joined(separator: "\n"))
         """
-        
-        return yaml.data(using: .utf8)!
+
+        guard let data = yaml.data(using: .utf8) else {
+            throw EncodingError.invalidValue(
+                skill,
+                .init(codingPath: [], debugDescription: "Failed to encode YAML as UTF-8")
+            )
+        }
+
+        return data
     }
 }

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -519,7 +519,7 @@ private struct MenuNetworkInfoView: View {
 
     private let tunnelManager = TunnelManager.shared
     private var tunnelStatus: CloudflareTunnelStatus { tunnelManager.tunnelState.status }
-    private var tunnelURL: String? { tunnelManager.tunnelState.publicURL }
+    private var tunnelURL: String? { tunnelManager.effectivePublicURL }
     private var proxyURL: String { "http://127.0.0.1:" + port }
 
     @State private var didCopyProxy = false

--- a/Quotio/Services/Tunnel/CloudflaredService.swift
+++ b/Quotio/Services/Tunnel/CloudflaredService.swift
@@ -17,7 +17,7 @@ actor CloudflaredService {
         "/usr/bin/cloudflared"
     ]
     
-    private static let tunnelURLPattern = #"https://[a-z0-9-]+\.trycloudflare\.com"#
+    private static let httpsURLPattern = #"https://[A-Za-z0-9._~:/?#\[\]@!\$&'()*+,;=%-]+"#
     
     nonisolated func detectInstallation() -> CloudflaredInstallation {
         for path in Self.binaryPaths {
@@ -53,6 +53,32 @@ actor CloudflaredService {
             return nil
         }
     }
+
+    nonisolated private static func extractPublicURL(from text: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: httpsURLPattern) else { return nil }
+        let nsText = text as NSString
+        let matches = regex.matches(in: text, range: NSRange(location: 0, length: nsText.length))
+
+        for match in matches {
+            guard match.range.location != NSNotFound else { continue }
+            let candidate = nsText.substring(with: match.range)
+            guard let url = URL(string: candidate), let host = url.host?.lowercased() else { continue }
+
+            // Keep the quick tunnel URL and allow custom domains.
+            if host.hasSuffix("trycloudflare.com") {
+                return candidate
+            }
+
+            // Skip Cloudflare control-plane URLs; keep user-owned hostnames.
+            if host.hasSuffix("cloudflare.com") || host.hasSuffix("cloudflareclient.com") {
+                continue
+            }
+
+            return candidate
+        }
+
+        return nil
+    }
     
     func start(port: UInt16, onURLDetected: @escaping @Sendable (String) -> Void) async throws {
         guard process == nil else {
@@ -66,9 +92,19 @@ actor CloudflaredService {
         
         let newProcess = Process()
         newProcess.executableURL = URL(fileURLWithPath: binaryPath)
-        // Use --config /dev/null to ignore user's existing config file
-        // This ensures Quick Tunnel works without interference from named tunnels
-        newProcess.arguments = ["tunnel", "--config", "/dev/null", "--protocol", "http2", "--url", "http://localhost:" + String(port)]
+
+        let tunnelToken = await MainActor.run {
+            KeychainHelper.getCloudflareTunnelToken()?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if let token = tunnelToken, !token.isEmpty {
+            // Token mode uses named tunnels configured in Cloudflare dashboard.
+            // Include --url so origin always matches the current local proxy port.
+            newProcess.arguments = ["tunnel", "run", "--token", token, "--url", "http://localhost:" + String(port)]
+        } else {
+            // Use --config /dev/null to ignore user's existing config file.
+            // This ensures Quick Tunnel works without interference from named tunnels.
+            newProcess.arguments = ["tunnel", "--config", "/dev/null", "--protocol", "http2", "--url", "http://localhost:" + String(port)]
+        }
         
         let outputPipe = Pipe()
         let errorPipe = Pipe()
@@ -97,9 +133,9 @@ actor CloudflaredService {
                     buffer = String(buffer.dropFirst(dropCount))
                 }
                 
-                if let range = buffer.range(of: CloudflaredService.tunnelURLPattern, options: .regularExpression) {
+                if let url = CloudflaredService.extractPublicURL(from: buffer) {
                     urlFound = true
-                    return String(buffer[range])
+                    return url
                 }
                 return nil
             }
@@ -110,9 +146,9 @@ actor CloudflaredService {
                 
                 guard !urlFound else { return nil }
                 
-                if let range = buffer.range(of: CloudflaredService.tunnelURLPattern, options: .regularExpression) {
+                if let url = CloudflaredService.extractPublicURL(from: buffer) {
                     urlFound = true
-                    return String(buffer[range])
+                    return url
                 }
                 return nil
             }
@@ -211,36 +247,42 @@ actor CloudflaredService {
     }
     
     nonisolated static func killOrphanProcesses() {
-        // Use app-specific pattern matching tunnels spawned by Quotio (--config /dev/null)
-        let pattern = "cloudflared.*tunnel.*--config.*/dev/null.*--url"
-        
-        // First try graceful SIGTERM
+        // Match both quick-tunnel and token-mode processes spawned by Quotio.
+        let patterns = [
+            "cloudflared.*tunnel.*--config.*/dev/null.*--url",
+            "cloudflared.*tunnel.*run.*--token"
+        ]
+
+        for pattern in patterns {
+            killProcesses(matching: pattern)
+        }
+    }
+
+    nonisolated private static func killProcesses(matching pattern: String) {
         let termProcess = Process()
         termProcess.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
         termProcess.arguments = ["-TERM", "-f", pattern]
         termProcess.standardOutput = FileHandle.nullDevice
         termProcess.standardError = FileHandle.nullDevice
-        
+
         do {
             try termProcess.run()
             termProcess.waitUntilExit()
-            
-            // Wait briefly for graceful shutdown
+
+            // Wait briefly for graceful shutdown.
             Thread.sleep(forTimeInterval: 0.3)
-            
-            // Check if any matching processes remain and force kill
+
             let killProcess = Process()
             killProcess.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
             killProcess.arguments = ["-9", "-f", pattern]
             killProcess.standardOutput = FileHandle.nullDevice
             killProcess.standardError = FileHandle.nullDevice
-            
+
             try killProcess.run()
             killProcess.waitUntilExit()
-            
-            NSLog("[CloudflaredService] Cleaned up orphan cloudflared processes")
+            NSLog("[CloudflaredService] Cleaned up orphan cloudflared processes for pattern: %@", pattern)
         } catch {
-            // Silent failure - no orphans to kill is fine
+            // Silent failure - no orphans to kill is fine.
         }
     }
 }

--- a/Quotio/Services/Tunnel/CloudflaredService.swift
+++ b/Quotio/Services/Tunnel/CloudflaredService.swift
@@ -80,7 +80,11 @@ actor CloudflaredService {
         return nil
     }
     
-    func start(port: UInt16, onURLDetected: @escaping @Sendable (String) -> Void) async throws {
+    func start(
+        port: UInt16,
+        onURLDetected: @escaping @Sendable (String) -> Void,
+        onLogLine: (@Sendable (String, Bool) -> Void)? = nil
+    ) async throws {
         guard process == nil else {
             throw TunnelError.alreadyRunning
         }
@@ -153,15 +157,61 @@ actor CloudflaredService {
                 return nil
             }
         }
+
+        final class LineBuffer: @unchecked Sendable {
+            private let lock = NSLock()
+            private var pending = ""
+
+            func append(_ text: String) -> [String] {
+                lock.lock()
+                defer { lock.unlock() }
+
+                pending += text.replacingOccurrences(of: "\r\n", with: "\n").replacingOccurrences(of: "\r", with: "\n")
+                let parts = pending.components(separatedBy: "\n")
+                pending = parts.last ?? ""
+                guard parts.count > 1 else { return [] }
+                return parts[0..<(parts.count - 1)].filter { !$0.isEmpty }
+            }
+
+            func flush() -> [String] {
+                lock.lock()
+                defer { lock.unlock() }
+
+                let last = pending.trimmingCharacters(in: .whitespacesAndNewlines)
+                pending = ""
+                return last.isEmpty ? [] : [last]
+            }
+        }
         
         let buffer = OutputBuffer()
+        let stdoutLines = LineBuffer()
+        let stderrLines = LineBuffer()
         
+        let emitLogLines: @Sendable (String, Bool) -> Void = { text, isErrorStream in
+            guard let onLogLine else { return }
+            let lineBuffer = isErrorStream ? stderrLines : stdoutLines
+            let lines = lineBuffer.append(text)
+            for line in lines {
+                onLogLine(line, isErrorStream)
+            }
+        }
+
+        let emitRemainingLines: @Sendable (Bool) -> Void = { isErrorStream in
+            guard let onLogLine else { return }
+            let lineBuffer = isErrorStream ? stderrLines : stdoutLines
+            let lines = lineBuffer.flush()
+            for line in lines {
+                onLogLine(line, isErrorStream)
+            }
+        }
+
         errorPipe.fileHandleForReading.readabilityHandler = { handle in
             let data = handle.availableData
             
             // EOF detected - empty data means stream closed
             if data.isEmpty {
                 handle.readabilityHandler = nil
+                emitRemainingLines(true)
                 // Check remaining buffer for URL on EOF
                 if let url = buffer.checkRemaining() {
                     onURLDetected(url)
@@ -170,6 +220,7 @@ actor CloudflaredService {
             }
             
             guard let text = String(data: data, encoding: .utf8) else { return }
+            emitLogLines(text, true)
             
             if let url = buffer.append(text) {
                 onURLDetected(url)
@@ -182,6 +233,7 @@ actor CloudflaredService {
             // EOF detected - empty data means stream closed
             if data.isEmpty {
                 handle.readabilityHandler = nil
+                emitRemainingLines(false)
                 // Check remaining buffer for URL on EOF
                 if let url = buffer.checkRemaining() {
                     onURLDetected(url)
@@ -190,6 +242,7 @@ actor CloudflaredService {
             }
             
             guard let text = String(data: data, encoding: .utf8) else { return }
+            emitLogLines(text, false)
             
             if let url = buffer.append(text) {
                 onURLDetected(url)

--- a/Quotio/Services/Tunnel/TunnelManager.swift
+++ b/Quotio/Services/Tunnel/TunnelManager.swift
@@ -16,6 +16,7 @@ final class TunnelManager {
     
     private(set) var tunnelState = CloudflareTunnelState()
     private(set) var installation: CloudflaredInstallation = .notInstalled
+    private(set) var tunnelLogs: [LogEntry] = []
 
     var customPublicURL: String? {
         get {
@@ -49,6 +50,7 @@ final class TunnelManager {
     private let autoRestartDelaySeconds: TimeInterval = 5
     private var autoRestartAttempts: Int = 0
     private let maxAutoRestartAttempts: Int = 3
+    private let maxTunnelLogEntries = 400
     private var hasCustomTunnelToken: Bool {
         !(KeychainHelper.getCloudflareTunnelToken()?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -96,6 +98,10 @@ final class TunnelManager {
     func refreshInstallation() async {
         installation = service.detectInstallation()
     }
+
+    func clearLogs() {
+        tunnelLogs.removeAll()
+    }
     
     func startTunnel(port: UInt16) async {
         guard tunnelState.status == .idle || tunnelState.status == .error else {
@@ -106,6 +112,7 @@ final class TunnelManager {
         guard installation.isInstalled else {
             tunnelState.status = .error
             tunnelState.errorMessage = "tunnel.error.notInstalled".localized()
+            appendTunnelLog("Cloudflared is not installed", level: .error)
             return
         }
         
@@ -116,6 +123,7 @@ final class TunnelManager {
         if usingCustomToken && customPublicURL == nil {
             tunnelState.status = .error
             tunnelState.errorMessage = "tunnel.error.customURLRequired".localized()
+            appendTunnelLog("Custom tunnel token requires a custom public URL", level: .error)
             return
         }
         
@@ -123,27 +131,40 @@ final class TunnelManager {
         tunnelState.errorMessage = nil
         tunnelState.publicURL = nil
         cancelStartTimeout()
+        appendTunnelLog(
+            "Starting tunnel on localhost:" + String(port) + (usingCustomToken ? " (token mode)" : " (quick tunnel mode)"),
+            level: .info
+        )
         
         do {
             CLIProxyManager.shared.updateConfigAllowRemote(true)
 
-            try await service.start(port: port) { [weak self] url in
-                Task { @MainActor in
-                    guard let self = self else { return }
-                    guard self.tunnelRequestId == currentRequestId else {
-                        NSLog("[TunnelManager] Ignoring stale callback for request %llu (current: %llu)", currentRequestId, self.tunnelRequestId)
-                        return
+            try await service.start(
+                port: port,
+                onURLDetected: { [weak self] url in
+                    Task { @MainActor in
+                        guard let self = self else { return }
+                        guard self.tunnelRequestId == currentRequestId else {
+                            NSLog("[TunnelManager] Ignoring stale callback for request %llu (current: %llu)", currentRequestId, self.tunnelRequestId)
+                            return
+                        }
+                        self.tunnelState.publicURL = url
+                        self.tunnelState.status = .active
+                        self.tunnelState.startTime = Date()
+                        self.lastPort = port
+                        self.cancelStartTimeout()
+                        self.cancelAutoRestart()
+                        self.resetAutoRestartAttempts()
+                        self.appendTunnelLog("Public URL detected: " + url, level: .info)
+                        NSLog("[TunnelManager] Tunnel active: %@", url)
                     }
-                    self.tunnelState.publicURL = url
-                    self.tunnelState.status = .active
-                    self.tunnelState.startTime = Date()
-                    self.lastPort = port
-                    self.cancelStartTimeout()
-                    self.cancelAutoRestart()
-                    self.resetAutoRestartAttempts()
-                    NSLog("[TunnelManager] Tunnel active: %@", url)
+                },
+                onLogLine: { [weak self] line, isErrorStream in
+                    Task { @MainActor in
+                        self?.appendTunnelProcessLine(line, isErrorStream: isErrorStream)
+                    }
                 }
-            }
+            )
 
             scheduleStartTimeout(requestId: currentRequestId, port: port, allowMissingURL: usingCustomToken)
             startMonitoring()
@@ -154,6 +175,7 @@ final class TunnelManager {
             tunnelState.errorMessage = error.localizedMessage
             cancelStartTimeout()
             CLIProxyManager.shared.updateConfigAllowRemote(false)
+            appendTunnelLog("Failed to start tunnel: " + error.localizedMessage, level: .error)
             NSLog("[TunnelManager] Failed to start tunnel: %@", error.localizedMessage)
         } catch {
             guard tunnelRequestId == currentRequestId else { return }
@@ -161,6 +183,7 @@ final class TunnelManager {
             tunnelState.errorMessage = error.localizedDescription
             cancelStartTimeout()
             CLIProxyManager.shared.updateConfigAllowRemote(false)
+            appendTunnelLog("Failed to start tunnel: " + error.localizedDescription, level: .error)
             NSLog("[TunnelManager] Failed to start tunnel: %@", error.localizedDescription)
         }
     }
@@ -176,11 +199,13 @@ final class TunnelManager {
         
         tunnelState.status = .stopping
         stopMonitoring()
+        appendTunnelLog("Stopping tunnel", level: .info)
         
         await service.stop()
         CLIProxyManager.shared.updateConfigAllowRemote(false)
 
         tunnelState.reset()
+        appendTunnelLog("Tunnel stopped", level: .info)
         NSLog("[TunnelManager] Tunnel stopped")
     }
     
@@ -228,6 +253,7 @@ final class TunnelManager {
                     self.tunnelState.status = .error
                     self.tunnelState.errorMessage = "tunnel.error.unexpectedExit".localized()
                     CLIProxyManager.shared.updateConfigAllowRemote(false)
+                    self.appendTunnelLog("Tunnel process exited unexpectedly", level: .error)
                     NSLog("[TunnelManager] Tunnel process exited unexpectedly")
                     await self.service.stop()
                     self.scheduleAutoRestart()
@@ -261,6 +287,7 @@ final class TunnelManager {
                     self.tunnelState.status = .error
                     self.tunnelState.errorMessage = "tunnel.error.startTimeout".localized()
                     CLIProxyManager.shared.updateConfigAllowRemote(false)
+                    self.appendTunnelLog("Tunnel start timed out after " + String(Int(self.startTimeoutSeconds)) + " seconds", level: .error)
                     NSLog("[TunnelManager] Tunnel start timed out after %.0f seconds", self.startTimeoutSeconds)
                     await self.service.stop()
                     return
@@ -271,6 +298,7 @@ final class TunnelManager {
                 self.lastPort = port
                 self.cancelAutoRestart()
                 self.resetAutoRestartAttempts()
+                self.appendTunnelLog("Tunnel active without detected public URL (token mode)", level: .warn)
                 NSLog("[TunnelManager] Tunnel active without detected public URL (token mode)")
                 return
             }
@@ -278,6 +306,7 @@ final class TunnelManager {
             self.tunnelState.status = .error
             self.tunnelState.errorMessage = "tunnel.error.startTimeout".localized()
             CLIProxyManager.shared.updateConfigAllowRemote(false)
+            self.appendTunnelLog("Tunnel start timed out after " + String(Int(self.startTimeoutSeconds)) + " seconds", level: .error)
             NSLog("[TunnelManager] Tunnel start timed out after %.0f seconds", self.startTimeoutSeconds)
             await self.service.stop()
         }
@@ -295,6 +324,7 @@ final class TunnelManager {
         guard autoRestartEnabled, lastPort > 0 else { return }
         
         guard autoRestartAttempts < maxAutoRestartAttempts else {
+            appendTunnelLog("Max auto-restart attempts reached (" + String(autoRestartAttempts) + ")", level: .warn)
             NSLog("[TunnelManager] Max auto-restart attempts reached (%d), stopping", autoRestartAttempts)
             return
         }
@@ -302,6 +332,10 @@ final class TunnelManager {
         let delay = autoRestartDelaySeconds
         let port = lastPort
         
+        appendTunnelLog(
+            "Scheduling auto-restart in " + String(Int(delay)) + " seconds (attempt " + String(autoRestartAttempts + 1) + "/" + String(maxAutoRestartAttempts) + ")",
+            level: .warn
+        )
         NSLog("[TunnelManager] Scheduling auto-restart in %.0f seconds (attempt %d/%d)", delay, autoRestartAttempts + 1, maxAutoRestartAttempts)
         
         autoRestartTask = Task { [weak self] in
@@ -319,6 +353,7 @@ final class TunnelManager {
             }
             
             self.autoRestartAttempts += 1
+            self.appendTunnelLog("Auto-restarting tunnel (attempt " + String(self.autoRestartAttempts) + ")", level: .warn)
             NSLog("[TunnelManager] Auto-restarting tunnel on port %d (attempt %d)", port, self.autoRestartAttempts)
             await self.startTunnel(port: port)
         }
@@ -331,5 +366,36 @@ final class TunnelManager {
     
     private func resetAutoRestartAttempts() {
         autoRestartAttempts = 0
+    }
+
+    private func appendTunnelProcessLine(_ line: String, isErrorStream: Bool) {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let level = inferTunnelLogLevel(for: trimmed, isErrorStream: isErrorStream)
+        appendTunnelLog(trimmed, level: level)
+    }
+
+    private func appendTunnelLog(_ message: String, level: LogEntry.LogLevel) {
+        tunnelLogs.append(LogEntry(timestamp: Date(), level: level, message: message))
+        if tunnelLogs.count > maxTunnelLogEntries {
+            tunnelLogs = Array(tunnelLogs.suffix(maxTunnelLogEntries))
+        }
+    }
+
+    private func inferTunnelLogLevel(for line: String, isErrorStream: Bool) -> LogEntry.LogLevel {
+        let lowercased = line.lowercased()
+        if lowercased.contains("error") || lowercased.contains("failed") || lowercased.contains("timeout") {
+            return .error
+        }
+        if lowercased.contains("warn") || lowercased.contains("retry") {
+            return .warn
+        }
+        if lowercased.contains("debug") {
+            return .debug
+        }
+        if isErrorStream {
+            return .warn
+        }
+        return .info
     }
 }

--- a/Quotio/Services/Tunnel/TunnelManager.swift
+++ b/Quotio/Services/Tunnel/TunnelManager.swift
@@ -10,11 +10,32 @@ import AppKit
 @Observable
 final class TunnelManager {
     static let shared = TunnelManager()
+    private static let customPublicURLDefaultsKey = "customTunnelPublicURL"
     
     // MARK: - State
     
     private(set) var tunnelState = CloudflareTunnelState()
     private(set) var installation: CloudflaredInstallation = .notInstalled
+
+    var customPublicURL: String? {
+        get {
+            Self.normalizedCustomPublicURL(UserDefaults.standard.string(forKey: Self.customPublicURLDefaultsKey))
+        }
+        set {
+            if let normalized = Self.normalizedCustomPublicURL(newValue) {
+                UserDefaults.standard.set(normalized, forKey: Self.customPublicURLDefaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Self.customPublicURLDefaultsKey)
+            }
+        }
+    }
+
+    var effectivePublicURL: String? {
+        if hasCustomTunnelToken, let customPublicURL {
+            return customPublicURL
+        }
+        return tunnelState.publicURL
+    }
     
     // MARK: - Private Properties
     
@@ -28,6 +49,11 @@ final class TunnelManager {
     private let autoRestartDelaySeconds: TimeInterval = 5
     private var autoRestartAttempts: Int = 0
     private let maxAutoRestartAttempts: Int = 3
+    private var hasCustomTunnelToken: Bool {
+        !(KeychainHelper.getCloudflareTunnelToken()?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty ?? true)
+    }
     
     // MARK: - Init
     
@@ -36,6 +62,33 @@ final class TunnelManager {
             await refreshInstallation()
             Self.cleanupOrphans()
         }
+    }
+
+    nonisolated static func normalizedCustomPublicURL(_ rawURL: String?) -> String? {
+        guard let rawURL else { return nil }
+        let trimmed = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let candidate = trimmed.contains("://") ? trimmed : "https://" + trimmed
+        guard var components = URLComponents(string: candidate),
+              let scheme = components.scheme?.lowercased(),
+              (scheme == "http" || scheme == "https"),
+              let host = components.host,
+              !host.isEmpty else {
+            return nil
+        }
+
+        components.scheme = scheme
+        components.fragment = nil
+        if components.path == "/" {
+            components.path = ""
+        }
+
+        guard var normalized = components.string else { return nil }
+        if normalized.hasSuffix("/") && components.path.isEmpty {
+            normalized.removeLast()
+        }
+        return normalized
     }
     
     // MARK: - Public API
@@ -58,6 +111,13 @@ final class TunnelManager {
         
         tunnelRequestId &+= 1
         let currentRequestId = tunnelRequestId
+        let usingCustomToken = hasCustomTunnelToken
+
+        if usingCustomToken && customPublicURL == nil {
+            tunnelState.status = .error
+            tunnelState.errorMessage = "tunnel.error.customURLRequired".localized()
+            return
+        }
         
         tunnelState.status = .starting
         tunnelState.errorMessage = nil
@@ -85,7 +145,7 @@ final class TunnelManager {
                 }
             }
 
-            scheduleStartTimeout(requestId: currentRequestId)
+            scheduleStartTimeout(requestId: currentRequestId, port: port, allowMissingURL: usingCustomToken)
             startMonitoring()
             
         } catch let error as TunnelError {
@@ -133,7 +193,7 @@ final class TunnelManager {
     }
     
     func copyURLToClipboard() {
-        guard let url = tunnelState.publicURL else { return }
+        guard let url = effectivePublicURL else { return }
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(url, forType: .string)
     }
@@ -182,7 +242,7 @@ final class TunnelManager {
         monitorTask = nil
     }
 
-    private func scheduleStartTimeout(requestId: UInt64) {
+    private func scheduleStartTimeout(requestId: UInt64, port: UInt16, allowMissingURL: Bool) {
         cancelStartTimeout()
         startTimeoutTask = Task { [weak self] in
             guard let self = self else { return }
@@ -194,6 +254,27 @@ final class TunnelManager {
             guard !Task.isCancelled else { return }
             guard self.tunnelRequestId == requestId else { return }
             guard self.tunnelState.status == .starting else { return }
+
+            if allowMissingURL {
+                let isRunning = await self.service.isRunning
+                guard isRunning else {
+                    self.tunnelState.status = .error
+                    self.tunnelState.errorMessage = "tunnel.error.startTimeout".localized()
+                    CLIProxyManager.shared.updateConfigAllowRemote(false)
+                    NSLog("[TunnelManager] Tunnel start timed out after %.0f seconds", self.startTimeoutSeconds)
+                    await self.service.stop()
+                    return
+                }
+
+                self.tunnelState.status = .active
+                self.tunnelState.startTime = Date()
+                self.lastPort = port
+                self.cancelAutoRestart()
+                self.resetAutoRestartAttempts()
+                NSLog("[TunnelManager] Tunnel active without detected public URL (token mode)")
+                return
+            }
+
             self.tunnelState.status = .error
             self.tunnelState.errorMessage = "tunnel.error.startTimeout".localized()
             CLIProxyManager.shared.updateConfigAllowRemote(false)

--- a/Quotio/ViewModels/AgentSetupViewModel.swift
+++ b/Quotio/ViewModels/AgentSetupViewModel.swift
@@ -94,7 +94,7 @@ final class AgentSetupViewModel {
 
         // Use tunnel URL if active, otherwise use local proxy endpoint
         let endpoint: String
-        if let tunnelURL = TunnelManager.shared.tunnelState.publicURL {
+        if let tunnelURL = TunnelManager.shared.effectivePublicURL {
             endpoint = tunnelURL
         } else {
             endpoint = proxyManager.clientEndpoint
@@ -362,7 +362,7 @@ final class AgentSetupViewModel {
 
             // Use tunnel URL if active, otherwise use local proxy endpoint
             let modelEndpoint: String
-            if let tunnelURL = TunnelManager.shared.tunnelState.publicURL {
+            if let tunnelURL = TunnelManager.shared.effectivePublicURL {
                 modelEndpoint = tunnelURL
             } else {
                 modelEndpoint = proxyManager.clientEndpoint

--- a/Quotio/Views/Components/TunnelSheet.swift
+++ b/Quotio/Views/Components/TunnelSheet.swift
@@ -173,7 +173,7 @@ struct TunnelSheet: View {
                 .foregroundStyle(.primary)
             
             HStack(spacing: 12) {
-                Text(tunnelManager.tunnelState.publicURL ?? "—")
+                Text(tunnelManager.effectivePublicURL ?? "—")
                     .font(.system(.body, design: .monospaced))
                     .foregroundStyle(.primary)
                     .lineLimit(1)

--- a/Quotio/Views/Screens/DashboardScreen.swift
+++ b/Quotio/Views/Screens/DashboardScreen.swift
@@ -755,7 +755,7 @@ struct DashboardScreen: View {
                         TunnelStatusBadge(status: tunnelManager.tunnelState.status, compact: true)
                     }
                     
-                    if tunnelManager.tunnelState.isActive, let url = tunnelManager.tunnelState.publicURL {
+                    if tunnelManager.tunnelState.isActive, let url = tunnelManager.effectivePublicURL {
                         Text(url)
                             .font(.caption)
                             .foregroundStyle(.secondary)

--- a/Quotio/Views/Screens/LogsScreen.swift
+++ b/Quotio/Views/Screens/LogsScreen.swift
@@ -18,11 +18,13 @@ struct LogsScreen: View {
     enum LogsTab: String, CaseIterable {
         case requests = "requests"
         case proxyLogs = "proxyLogs"
+        case tunnelLogs = "tunnelLogs"
         
         var title: String {
             switch self {
             case .requests: return "logs.tab.requests".localizedStatic()
             case .proxyLogs: return "logs.tab.proxyLogs".localizedStatic()
+            case .tunnelLogs: return "logs.tab.tunnelLogs".localizedStatic()
             }
         }
         
@@ -30,6 +32,7 @@ struct LogsScreen: View {
             switch self {
             case .requests: return "arrow.up.arrow.down"
             case .proxyLogs: return "doc.text"
+            case .tunnelLogs: return "point.3.connected.trianglepath.dotted"
             }
         }
     }
@@ -61,7 +64,9 @@ struct LogsScreen: View {
                     case .requests:
                         requestHistoryView
                     case .proxyLogs:
-                        proxyLogsView
+                        logsViewForSelectedSource
+                    case .tunnelLogs:
+                        logsViewForSelectedSource
                     }
                 }
             }
@@ -95,6 +100,8 @@ struct LogsScreen: View {
             return "logs.searchRequests".localized()
         case .proxyLogs:
             return "logs.searchLogs".localized()
+        case .tunnelLogs:
+            return "logs.searchTunnelLogs".localized()
         }
     }
     
@@ -209,8 +216,19 @@ struct LogsScreen: View {
     
     // MARK: - Proxy Logs View
     
-    var filteredLogs: [LogEntry] {
-        var logs = logsViewModel.logs
+    private var selectedLogSourceEntries: [LogEntry] {
+        switch selectedTab {
+        case .requests:
+            return []
+        case .proxyLogs:
+            return logsViewModel.logs
+        case .tunnelLogs:
+            return viewModel.tunnelManager.tunnelLogs
+        }
+    }
+
+    private var filteredLogs: [LogEntry] {
+        var logs = selectedLogSourceEntries
         
         if let level = filterLevel {
             logs = logs.filter { $0.level == level }
@@ -223,27 +241,90 @@ struct LogsScreen: View {
         return logs
     }
     
-    private var proxyLogsView: some View {
+    private var logsViewForSelectedSource: some View {
         Group {
             if filteredLogs.isEmpty {
                 ContentUnavailableView {
-                    Label("logs.noLogs".localized(), systemImage: "doc.text")
+                    Label(emptyStateTitle, systemImage: emptyStateIcon)
                 } description: {
-                    Text("logs.logsWillAppear".localized())
+                    Text(emptyStateDescription)
                 }
             } else {
-                logList
+                VStack(spacing: 0) {
+                    logsSummaryHeader
+                    Divider()
+                    logList
+                }
             }
         }
+    }
+
+    private var emptyStateTitle: String {
+        switch selectedTab {
+        case .requests:
+            return "logs.noRequests".localized()
+        case .proxyLogs:
+            return "logs.noLogs".localized()
+        case .tunnelLogs:
+            return "logs.noTunnelLogs".localized()
+        }
+    }
+
+    private var emptyStateDescription: String {
+        switch selectedTab {
+        case .requests:
+            return "logs.requestsWillAppear".localized()
+        case .proxyLogs:
+            return "logs.logsWillAppear".localized()
+        case .tunnelLogs:
+            return "logs.tunnelLogsWillAppear".localized()
+        }
+    }
+
+    private var emptyStateIcon: String {
+        switch selectedTab {
+        case .requests:
+            return "arrow.up.arrow.down"
+        case .proxyLogs:
+            return "doc.text"
+        case .tunnelLogs:
+            return "point.3.connected.trianglepath.dotted"
+        }
+    }
+
+    private var logsSummaryHeader: some View {
+        HStack(spacing: 16) {
+            StatItem(
+                title: "logs.stats.totalEntries".localized(),
+                value: "\(filteredLogs.count)"
+            )
+
+            if selectedTab == .tunnelLogs {
+                Label(viewModel.tunnelManager.tunnelState.status.displayName, systemImage: viewModel.tunnelManager.tunnelState.status.icon)
+                    .font(.caption)
+                    .foregroundStyle(viewModel.tunnelManager.tunnelState.status.color)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(.quinary)
+                    .clipShape(Capsule())
+            }
+
+            Spacer()
+        }
+        .padding()
+        .background(.regularMaterial)
     }
     
     private var logList: some View {
         ScrollViewReader { proxy in
             List(filteredLogs) { entry in
-                LogRow(entry: entry)
+                LogRow(
+                    entry: entry,
+                    sourceLabel: selectedTab == .tunnelLogs ? "logs.source.tunnel".localized() : nil
+                )
                     .id(entry.id)
             }
-            .onChange(of: logsViewModel.logs.count) { _, _ in
+            .onChange(of: selectedLogSourceEntries.count) { _, _ in
                 if autoScroll, let last = filteredLogs.last {
                     withAnimation {
                         proxy.scrollTo(last.id, anchor: .bottom)
@@ -258,7 +339,7 @@ struct LogsScreen: View {
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
         ToolbarItemGroup {
-            if selectedTab == .proxyLogs {
+            if selectedTab != .requests {
                 Picker("Filter", selection: $filterLevel) {
                     Text("logs.all".localized()).tag(nil as LogEntry.LogLevel?)
                     Divider()
@@ -276,18 +357,21 @@ struct LogsScreen: View {
             Button {
                 if selectedTab == .requests {
                     // Refresh handled by RequestTracker automatically
-                } else {
+                } else if selectedTab == .proxyLogs {
                     Task { await logsViewModel.refreshLogs() }
                 }
             } label: {
                 Image(systemName: "arrow.clockwise")
             }
+            .disabled(selectedTab == .tunnelLogs)
             
             Button(role: .destructive) {
                 if selectedTab == .requests {
                     viewModel.requestTracker.clearHistory()
-                } else {
+                } else if selectedTab == .proxyLogs {
                     Task { await logsViewModel.clearLogs() }
+                } else {
+                    viewModel.tunnelManager.clearLogs()
                 }
             } label: {
                 Image(systemName: "trash")
@@ -517,25 +601,42 @@ struct StatItem: View {
 
 struct LogRow: View {
     let entry: LogEntry
+    var sourceLabel: String? = nil
     
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            Text(entry.timestamp, style: .time)
-                .font(.system(.caption, design: .monospaced))
-                .foregroundStyle(.secondary)
-                .frame(width: 70, alignment: .leading)
-            
-            Text(entry.level.rawValue.uppercased())
-                .font(.system(.caption2, design: .monospaced, weight: .bold))
-                .foregroundStyle(.white)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(entry.level.color)
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-            
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center, spacing: 10) {
+                Text(entry.timestamp, style: .time)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 70, alignment: .leading)
+
+                Text(entry.level.rawValue.uppercased())
+                    .font(.system(.caption2, design: .monospaced, weight: .bold))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(entry.level.color)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+
+                if let sourceLabel {
+                    Text(sourceLabel)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.quinary)
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                }
+
+                Spacer(minLength: 0)
+            }
+
             Text(entry.message)
                 .font(.system(.caption, design: .monospaced))
                 .textSelection(.enabled)
+                .lineLimit(6)
         }
+        .padding(.vertical, 3)
     }
 }

--- a/Quotio/Views/Screens/SettingsScreen.swift
+++ b/Quotio/Views/Screens/SettingsScreen.swift
@@ -722,6 +722,7 @@ struct LocalProxyServerSection: View {
     @State private var customTunnelPublicURL: String = ""
     @State private var customTunnelPublicURLInvalid = false
     @State private var tunnelTokenRequiresCustomURL = false
+    @State private var showTunnelTokenSaveError = false
     @State private var revealTunnelToken = false
     @State private var isLoadingConfig = false  // Prevents onChange from firing during initial load
     
@@ -854,6 +855,11 @@ struct LocalProxyServerSection: View {
                 isLoadingConfig = false
             }
         }
+        .alert("settings.tunnelToken.saveError.title".localized(), isPresented: $showTunnelTokenSaveError) {
+            Button("action.ok".localized(), role: .cancel) {}
+        } message: {
+            Text("settings.tunnelToken.saveError.message".localized())
+        }
     }
 
     private func saveTunnelToken() {
@@ -863,8 +869,13 @@ struct LocalProxyServerSection: View {
         if trimmed.isEmpty {
             KeychainHelper.deleteCloudflareTunnelToken()
             tunnelTokenRequiresCustomURL = false
+            showTunnelTokenSaveError = false
         } else {
-            _ = KeychainHelper.saveCloudflareTunnelToken(trimmed)
+            guard KeychainHelper.saveCloudflareTunnelToken(trimmed) else {
+                showTunnelTokenSaveError = true
+                return
+            }
+            showTunnelTokenSaveError = false
             tunnelTokenRequiresCustomURL = TunnelManager.normalizedCustomPublicURL(customTunnelPublicURL) == nil
         }
 

--- a/Quotio/Views/Screens/SettingsScreen.swift
+++ b/Quotio/Views/Screens/SettingsScreen.swift
@@ -718,6 +718,11 @@ struct LocalProxyServerSection: View {
     @AppStorage("autoRestartTunnel") private var autoRestartTunnel = false
     @AppStorage("allowNetworkAccess") private var allowNetworkAccess = false
     @State private var portText: String = ""
+    @State private var tunnelToken: String = ""
+    @State private var customTunnelPublicURL: String = ""
+    @State private var customTunnelPublicURLInvalid = false
+    @State private var tunnelTokenRequiresCustomURL = false
+    @State private var revealTunnelToken = false
     @State private var isLoadingConfig = false  // Prevents onChange from firing during initial load
     
     var body: some View {
@@ -760,6 +765,68 @@ struct LocalProxyServerSection: View {
             
             Toggle("settings.autoRestartTunnel".localized(), isOn: $autoRestartTunnel)
                 .disabled(!viewModel.tunnelManager.installation.isInstalled)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("settings.tunnelToken".localized())
+                    .font(.subheadline)
+
+                HStack(spacing: 8) {
+                    if revealTunnelToken {
+                        TextField("settings.tunnelToken.placeholder".localized(), text: $tunnelToken)
+                            .textFieldStyle(.roundedBorder)
+                    } else {
+                        SecureField("settings.tunnelToken.placeholder".localized(), text: $tunnelToken)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    Button {
+                        revealTunnelToken.toggle()
+                    } label: {
+                        Image(systemName: revealTunnelToken ? "eye.slash" : "eye")
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button("action.save".localized()) {
+                        saveTunnelToken()
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+
+                Text("settings.tunnelToken.help".localized())
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if tunnelTokenRequiresCustomURL {
+                    Text("settings.tunnelPublicURL.requiredForToken".localized())
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("settings.tunnelPublicURL".localized())
+                    .font(.subheadline)
+
+                HStack(spacing: 8) {
+                    TextField("settings.tunnelPublicURL.placeholder".localized(), text: $customTunnelPublicURL)
+                        .textFieldStyle(.roundedBorder)
+
+                    Button("action.save".localized()) {
+                        saveCustomTunnelPublicURL()
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+
+                Text("settings.tunnelPublicURL.help".localized())
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if customTunnelPublicURLInvalid {
+                    Text("settings.tunnelPublicURL.invalid".localized())
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
                 
             NetworkAccessSection(allowNetworkAccess: $allowNetworkAccess)
                 .onChange(of: allowNetworkAccess) { _, newValue in
@@ -777,11 +844,58 @@ struct LocalProxyServerSection: View {
         .onAppear {
             isLoadingConfig = true
             portText = String(viewModel.proxyManager.port)
+            tunnelToken = KeychainHelper.getCloudflareTunnelToken() ?? ""
+            customTunnelPublicURL = viewModel.tunnelManager.customPublicURL ?? ""
+            customTunnelPublicURLInvalid = false
+            tunnelTokenRequiresCustomURL = !tunnelToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && TunnelManager.normalizedCustomPublicURL(customTunnelPublicURL) == nil
             // Delay clearing the flag to allow onChange to be suppressed
             DispatchQueue.main.async {
                 isLoadingConfig = false
             }
         }
+    }
+
+    private func saveTunnelToken() {
+        let trimmed = tunnelToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        tunnelToken = trimmed
+
+        if trimmed.isEmpty {
+            KeychainHelper.deleteCloudflareTunnelToken()
+            tunnelTokenRequiresCustomURL = false
+        } else {
+            _ = KeychainHelper.saveCloudflareTunnelToken(trimmed)
+            tunnelTokenRequiresCustomURL = TunnelManager.normalizedCustomPublicURL(customTunnelPublicURL) == nil
+        }
+
+        // Apply token changes immediately when tunnel is already active.
+        if viewModel.tunnelManager.tunnelState.isActive || viewModel.tunnelManager.tunnelState.status == .starting {
+            Task { @MainActor in
+                await viewModel.tunnelManager.stopTunnel()
+                await viewModel.tunnelManager.startTunnel(port: viewModel.proxyManager.port)
+            }
+        }
+    }
+
+    private func saveCustomTunnelPublicURL() {
+        let trimmed = customTunnelPublicURL.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if trimmed.isEmpty {
+            customTunnelPublicURLInvalid = false
+            customTunnelPublicURL = ""
+            viewModel.tunnelManager.customPublicURL = nil
+            return
+        }
+
+        guard let normalized = TunnelManager.normalizedCustomPublicURL(trimmed) else {
+            customTunnelPublicURLInvalid = true
+            return
+        }
+
+        customTunnelPublicURLInvalid = false
+        customTunnelPublicURL = normalized
+        viewModel.tunnelManager.customPublicURL = normalized
+        tunnelTokenRequiresCustomURL = false
     }
 }
 

--- a/Quotio/Views/Screens/SkillsScreen.swift
+++ b/Quotio/Views/Screens/SkillsScreen.swift
@@ -13,6 +13,8 @@ struct SkillsScreen: View {
     @State private var showAddServer = false
     @State private var showBrowseRegistry = false
     @State private var selectedSkill: Skill?
+    @State private var pendingSkillDeletion: Skill?
+    @State private var pendingServerDeletion: MCPServer?
     
     var body: some View {
         ScrollView {
@@ -33,13 +35,13 @@ struct SkillsScreen: View {
             }
             .padding()
         }
-        .navigationTitle("Skills")
+        .navigationTitle("skills.navigation.title".localized())
         .toolbar {
             ToolbarItem {
                 Button {
                     showAddSkill = true
                 } label: {
-                    Label("Add Skill", systemImage: "plus")
+                    Label("skills.action.addSkill".localized(), systemImage: "plus")
                 }
             }
         }
@@ -62,26 +64,88 @@ struct SkillsScreen: View {
         .task {
             await loadData()
         }
+        .confirmationDialog(
+            "skills.deleteSkill.confirm.title".localized(),
+            isPresented: isSkillDeleteConfirmationPresented,
+            titleVisibility: .visible
+        ) {
+            if let skill = pendingSkillDeletion {
+                Button("action.delete".localized(), role: .destructive) {
+                    Task { await deleteSkill(skill) }
+                    pendingSkillDeletion = nil
+                }
+            }
+
+            Button("action.cancel".localized(), role: .cancel) {
+                pendingSkillDeletion = nil
+            }
+        } message: {
+            if let skill = pendingSkillDeletion {
+                Text(String(format: "skills.deleteSkill.confirm.message".localized(), skill.name))
+            }
+        }
+        .confirmationDialog(
+            "skills.deleteServer.confirm.title".localized(),
+            isPresented: isServerDeleteConfirmationPresented,
+            titleVisibility: .visible
+        ) {
+            if let server = pendingServerDeletion {
+                Button("action.delete".localized(), role: .destructive) {
+                    Task { await deleteServer(server) }
+                    pendingServerDeletion = nil
+                }
+            }
+
+            Button("action.cancel".localized(), role: .cancel) {
+                pendingServerDeletion = nil
+            }
+        } message: {
+            if let server = pendingServerDeletion {
+                Text(String(format: "skills.deleteServer.confirm.message".localized(), server.name))
+            }
+        }
     }
     
+    private var isSkillDeleteConfirmationPresented: Binding<Bool> {
+        Binding(
+            get: { pendingSkillDeletion != nil },
+            set: { isPresented in
+                if !isPresented {
+                    pendingSkillDeletion = nil
+                }
+            }
+        )
+    }
+
+    private var isServerDeleteConfirmationPresented: Binding<Bool> {
+        Binding(
+            get: { pendingServerDeletion != nil },
+            set: { isPresented in
+                if !isPresented {
+                    pendingServerDeletion = nil
+                }
+            }
+        )
+    }
+
     private var emptyState: some View {
         VStack(spacing: 16) {
             Image(systemName: "wand.and.stars")
                 .font(.system(size: 48))
                 .foregroundStyle(.secondary)
             
-            Text("No Skills Yet")
+            Text("skills.empty.title".localized())
                 .font(.title2)
                 .fontWeight(.semibold)
             
-            Text("Create Skills to add reusable instructions\nthat work across all AI agents")
+            Text("skills.empty.message".localized())
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
             
             Button {
                 showAddSkill = true
             } label: {
-                Label("Create First Skill", systemImage: "plus.circle.fill")
+                Label("skills.empty.createFirst".localized(), systemImage: "plus.circle.fill")
             }
             .buttonStyle(.borderedProminent)
         }
@@ -91,7 +155,7 @@ struct SkillsScreen: View {
     
     private var skillsList: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Skills")
+            Text("skills.section.skills".localized())
                 .font(.headline)
             
             ForEach(skills) { skill in
@@ -100,7 +164,7 @@ struct SkillsScreen: View {
                 } onToggle: {
                     Task { await toggleSkill(skill) }
                 } onDelete: {
-                    Task { await deleteSkill(skill) }
+                    pendingSkillDeletion = skill
                 }
             }
         }
@@ -109,7 +173,7 @@ struct SkillsScreen: View {
     private var mcpServersSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
-                Text("MCP Servers")
+                Text("skills.section.mcpServers".localized())
                     .font(.headline)
                 
                 Spacer()
@@ -117,26 +181,26 @@ struct SkillsScreen: View {
                 Button {
                     showBrowseRegistry = true
                 } label: {
-                    Label("Browse Registry", systemImage: "globe")
+                    Label("skills.action.browseRegistry".localized(), systemImage: "globe")
                         .font(.caption)
                 }
                 
                 Button {
                     showAddServer = true
                 } label: {
-                    Label("Add Server", systemImage: "plus.circle")
+                    Label("skills.action.addServer".localized(), systemImage: "plus.circle")
                         .font(.caption)
                 }
             }
             
             if mcpServers.isEmpty {
-                Text("No MCP servers configured")
+                Text("skills.empty.mcpServers".localized())
                     .foregroundStyle(.secondary)
                     .font(.caption)
             } else {
                 ForEach(mcpServers) { server in
                     MCPServerRow(server: server) {
-                        Task { await deleteServer(server) }
+                        pendingServerDeletion = server
                     }
                 }
             }
@@ -145,6 +209,8 @@ struct SkillsScreen: View {
     
     private func loadData() async {
         isLoading = true
+        await SkillsManager.shared.loadSkills()
+        await MCPClient.shared.loadConfig()
         skills = await SkillsManager.shared.getSkills()
         mcpServers = await MCPClient.shared.getServers()
         isLoading = false
@@ -200,7 +266,7 @@ struct SkillCard: View {
                 
                 // Usage badge
                 if skill.usageCount > 0 {
-                    Text("\(skill.usageCount) uses")
+                    Text(String(format: "skills.card.uses".localized(), skill.usageCount))
                         .font(.caption2)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
@@ -209,9 +275,9 @@ struct SkillCard: View {
                 }
                 
                 Menu {
-                    Button("Edit", action: onEdit)
-                    Button("Toggle", action: onToggle)
-                    Button("Delete", role: .destructive, action: onDelete)
+                    Button("action.edit".localized(), action: onEdit)
+                    Button("skills.action.toggle".localized(), action: onToggle)
+                    Button("action.delete".localized(), role: .destructive, action: onDelete)
                 } label: {
                     Image(systemName: "ellipsis.circle")
                 }
@@ -226,7 +292,7 @@ struct SkillCard: View {
                 HStack(spacing: 4) {
                     Image(systemName: "clock")
                         .font(.caption2)
-                    Text("Last used by \(lastAgent)")
+                    Text(String(format: "skills.card.lastUsedBy".localized(), lastAgent))
                         .font(.caption2)
                     Text("•")
                         .font(.caption2)
@@ -238,7 +304,7 @@ struct SkillCard: View {
             
             if !skill.triggers.keywords.isEmpty {
                 HStack {
-                    Text("Keywords:")
+                    Text("skills.card.keywords".localized())
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                     Text(skill.triggers.keywords.joined(separator: ", "))
@@ -248,7 +314,7 @@ struct SkillCard: View {
             
             if !skill.triggers.agents.isEmpty {
                 HStack {
-                    Text("Agents:")
+                    Text("skills.card.agents".localized())
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                     Text(skill.triggers.agents.joined(separator: ", "))
@@ -258,7 +324,7 @@ struct SkillCard: View {
             
             if !skill.tools.isEmpty {
                 HStack {
-                    Text("Tools:")
+                    Text("skills.card.tools".localized())
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                     Text(skill.tools.joined(separator: ", "))
@@ -320,37 +386,37 @@ struct SkillEditorSheet: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section("Basic Info") {
-                    TextField("Name", text: $name)
-                    TextField("Description", text: $description)
+                Section("skills.editor.section.basicInfo".localized()) {
+                    TextField("skills.editor.name".localized(), text: $name)
+                    TextField("skills.editor.description".localized(), text: $description)
                 }
                 
-                Section("Triggers") {
-                    TextField("Keywords (comma-separated)", text: $keywords)
-                        .help("e.g., review, audit, check")
-                    TextField("File patterns (comma-separated)", text: $files)
-                        .help("e.g., *.swift, *.ts, *.py")
-                    TextField("Agents (comma-separated)", text: $agents)
-                        .help("e.g., claude, antigravity, opencode")
+                Section("skills.editor.section.triggers".localized()) {
+                    TextField("skills.editor.keywords".localized(), text: $keywords)
+                        .help("skills.editor.keywords.help".localized())
+                    TextField("skills.editor.files".localized(), text: $files)
+                        .help("skills.editor.files.help".localized())
+                    TextField("skills.editor.agents".localized(), text: $agents)
+                        .help("skills.editor.agents.help".localized())
                 }
                 
-                Section("Instructions") {
+                Section("skills.editor.section.instructions".localized()) {
                     TextEditor(text: $instructions)
                         .frame(minHeight: 150)
                 }
                 
-                Section("MCP Tools") {
-                    TextField("Tool names (comma-separated)", text: $tools)
-                        .help("e.g., filesystem, git, terminal")
+                Section("skills.editor.section.mcpTools".localized()) {
+                    TextField("skills.editor.tools".localized(), text: $tools)
+                        .help("skills.editor.tools.help".localized())
                 }
             }
-            .navigationTitle(skill == nil ? "New Skill" : "Edit Skill")
+            .navigationTitle(skill == nil ? "skills.editor.newTitle".localized() : "skills.editor.editTitle".localized())
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button("action.cancel".localized()) { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") {
+                    Button("action.save".localized()) {
                         Task {
                             await save()
                             dismiss()
@@ -409,35 +475,42 @@ struct MCPServerSheet: View {
     var body: some View {
         NavigationStack {
             Form {
-                TextField("Name", text: $name)
+                TextField("skills.editor.name".localized(), text: $name)
                 
-                Picker("Type", selection: $serverType) {
-                    Text("HTTP").tag(MCPServer.MCPServerType.http)
-                    Text("Stdio").tag(MCPServer.MCPServerType.stdio)
+                Picker("skills.serverSheet.type".localized(), selection: $serverType) {
+                    Text("skills.serverSheet.http".localized()).tag(MCPServer.MCPServerType.http)
+                    Text("skills.serverSheet.stdio".localized()).tag(MCPServer.MCPServerType.stdio)
                 }
                 
-                TextField("URL", text: $url)
+                TextField("skills.serverSheet.url".localized(), text: $url)
             }
-            .navigationTitle("Add MCP Server")
+            .navigationTitle("skills.serverSheet.title".localized())
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button("action.cancel".localized()) { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Add") {
+                    Button("action.create".localized()) {
                         Task {
                             await save()
                             dismiss()
                         }
                     }
-                    .disabled(name.isEmpty || url.isEmpty)
+                    .disabled(
+                        name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                        url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    )
                 }
             }
         }
     }
     
     private func save() async {
-        let server = MCPServer(name: name, url: url)
+        let server = MCPServer(
+            name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+            url: url.trimmingCharacters(in: .whitespacesAndNewlines),
+            type: serverType
+        )
         try? await MCPClient.shared.addServer(server)
         await onSave()
     }
@@ -463,27 +536,27 @@ struct MCPRegistryBrowser: View {
                         Image(systemName: "exclamationmark.triangle")
                             .font(.system(size: 48))
                             .foregroundStyle(.red)
-                        Text("Error")
+                        Text("skills.registry.errorTitle".localized())
                             .font(.headline)
                         Text(error)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)
-                        Button("Retry") {
+                        Button("action.retry".localized()) {
                             Task { await search(searchText) }
                         }
                     }
                     .padding()
                 } else if isLoading {
-                    ProgressView("Searching registry...")
+                    ProgressView("skills.registry.searching".localized())
                 } else if servers.isEmpty {
                     VStack(spacing: 16) {
                         Image(systemName: "magnifyingglass")
                             .font(.system(size: 48))
                             .foregroundStyle(.secondary)
-                        Text("Search the MCP Registry")
+                        Text("skills.registry.emptyTitle".localized())
                             .font(.headline)
-                        Text("Find MCP servers for filesystem, git, web search, and more")
+                        Text("skills.registry.emptyMessage".localized())
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)
@@ -492,7 +565,7 @@ struct MCPRegistryBrowser: View {
                 } else {
                     ScrollView {
                         VStack(spacing: 8) {
-                            Text("Found \(servers.count) servers")
+                            Text(String(format: "skills.registry.foundServers".localized(), servers.count))
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                                 .padding(.top)
@@ -528,8 +601,8 @@ struct MCPRegistryBrowser: View {
                     }
                 }
             }
-            .navigationTitle("MCP Registry")
-            .searchable(text: $searchText, prompt: "Search servers (e.g., filesystem, git)")
+            .navigationTitle("skills.registry.title".localized())
+            .searchable(text: $searchText, prompt: "skills.registry.searchPrompt".localized())
             .onChange(of: searchText) { _, newValue in
                 Task {
                     await search(newValue)
@@ -537,7 +610,7 @@ struct MCPRegistryBrowser: View {
             }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Close") { dismiss() }
+                    Button("action.close".localized()) { dismiss() }
                 }
             }
             .onAppear {

--- a/Quotio/Views/Screens/SkillsScreen.swift
+++ b/Quotio/Views/Screens/SkillsScreen.swift
@@ -1,0 +1,581 @@
+//
+//  SkillsScreen.swift
+//  Quotio - Skills Management UI
+//
+
+import SwiftUI
+
+struct SkillsScreen: View {
+    @State private var skills: [Skill] = []
+    @State private var mcpServers: [MCPServer] = []
+    @State private var isLoading = false
+    @State private var showAddSkill = false
+    @State private var showAddServer = false
+    @State private var showBrowseRegistry = false
+    @State private var selectedSkill: Skill?
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                if isLoading {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, alignment: .center)
+                } else if skills.isEmpty {
+                    emptyState
+                } else {
+                    skillsList
+                }
+                
+                Divider()
+                    .padding(.vertical)
+                
+                mcpServersSection
+            }
+            .padding()
+        }
+        .navigationTitle("Skills")
+        .toolbar {
+            ToolbarItem {
+                Button {
+                    showAddSkill = true
+                } label: {
+                    Label("Add Skill", systemImage: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showAddSkill) {
+            SkillEditorSheet(skill: nil) {
+                Task { await loadData() }
+            }
+        }
+        .sheet(item: $selectedSkill) { skill in
+            SkillEditorSheet(skill: skill) {
+                Task { await loadData() }
+            }
+        }
+        .sheet(isPresented: $showAddServer) {
+            MCPServerSheet { await loadData() }
+        }
+        .sheet(isPresented: $showBrowseRegistry) {
+            MCPRegistryBrowser { await loadData() }
+        }
+        .task {
+            await loadData()
+        }
+    }
+    
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "wand.and.stars")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+            
+            Text("No Skills Yet")
+                .font(.title2)
+                .fontWeight(.semibold)
+            
+            Text("Create Skills to add reusable instructions\nthat work across all AI agents")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+            
+            Button {
+                showAddSkill = true
+            } label: {
+                Label("Create First Skill", systemImage: "plus.circle.fill")
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 60)
+    }
+    
+    private var skillsList: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Skills")
+                .font(.headline)
+            
+            ForEach(skills) { skill in
+                SkillCard(skill: skill) {
+                    selectedSkill = skill
+                } onToggle: {
+                    Task { await toggleSkill(skill) }
+                } onDelete: {
+                    Task { await deleteSkill(skill) }
+                }
+            }
+        }
+    }
+    
+    private var mcpServersSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("MCP Servers")
+                    .font(.headline)
+                
+                Spacer()
+                
+                Button {
+                    showBrowseRegistry = true
+                } label: {
+                    Label("Browse Registry", systemImage: "globe")
+                        .font(.caption)
+                }
+                
+                Button {
+                    showAddServer = true
+                } label: {
+                    Label("Add Server", systemImage: "plus.circle")
+                        .font(.caption)
+                }
+            }
+            
+            if mcpServers.isEmpty {
+                Text("No MCP servers configured")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            } else {
+                ForEach(mcpServers) { server in
+                    MCPServerRow(server: server) {
+                        Task { await deleteServer(server) }
+                    }
+                }
+            }
+        }
+    }
+    
+    private func loadData() async {
+        isLoading = true
+        skills = await SkillsManager.shared.getSkills()
+        mcpServers = await MCPClient.shared.getServers()
+        isLoading = false
+    }
+    
+    private func toggleSkill(_ skill: Skill) async {
+        var updated = skill
+        updated = Skill(
+            id: skill.id,
+            name: skill.name,
+            description: skill.description,
+            triggers: skill.triggers,
+            instructions: skill.instructions,
+            tools: skill.tools,
+            enabled: !skill.enabled,
+            usageCount: skill.usageCount,
+            lastUsed: skill.lastUsed,
+            lastAgent: skill.lastAgent
+        )
+        try? await SkillsManager.shared.saveSkill(updated)
+        await loadData()
+    }
+    
+    private func deleteSkill(_ skill: Skill) async {
+        try? await SkillsManager.shared.deleteSkill(skill)
+        await loadData()
+    }
+    
+    private func deleteServer(_ server: MCPServer) async {
+        try? await MCPClient.shared.removeServer(server)
+        await loadData()
+    }
+}
+
+// MARK: - Skill Card
+
+struct SkillCard: View {
+    let skill: Skill
+    let onEdit: () -> Void
+    let onToggle: () -> Void
+    let onDelete: () -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: skill.enabled ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(skill.enabled ? .green : .secondary)
+                
+                Text(skill.name)
+                    .font(.headline)
+                
+                Spacer()
+                
+                // Usage badge
+                if skill.usageCount > 0 {
+                    Text("\(skill.usageCount) uses")
+                        .font(.caption2)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.blue.opacity(0.2))
+                        .cornerRadius(4)
+                }
+                
+                Menu {
+                    Button("Edit", action: onEdit)
+                    Button("Toggle", action: onToggle)
+                    Button("Delete", role: .destructive, action: onDelete)
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+            }
+            
+            Text(skill.description)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            
+            // Last used info
+            if let lastUsed = skill.lastUsed, let lastAgent = skill.lastAgent {
+                HStack(spacing: 4) {
+                    Image(systemName: "clock")
+                        .font(.caption2)
+                    Text("Last used by \(lastAgent)")
+                        .font(.caption2)
+                    Text("•")
+                        .font(.caption2)
+                    Text(lastUsed, style: .relative)
+                        .font(.caption2)
+                }
+                .foregroundStyle(.secondary)
+            }
+            
+            if !skill.triggers.keywords.isEmpty {
+                HStack {
+                    Text("Keywords:")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(skill.triggers.keywords.joined(separator: ", "))
+                        .font(.caption2)
+                }
+            }
+            
+            if !skill.triggers.agents.isEmpty {
+                HStack {
+                    Text("Agents:")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(skill.triggers.agents.joined(separator: ", "))
+                        .font(.caption2)
+                }
+            }
+            
+            if !skill.tools.isEmpty {
+                HStack {
+                    Text("Tools:")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(skill.tools.joined(separator: ", "))
+                        .font(.caption2)
+                }
+            }
+        }
+        .padding()
+        .background(.regularMaterial)
+        .cornerRadius(8)
+    }
+}
+
+// MARK: - MCP Server Row
+
+struct MCPServerRow: View {
+    let server: MCPServer
+    let onDelete: () -> Void
+    
+    var body: some View {
+        HStack {
+            Image(systemName: server.type == .stdio ? "terminal" : "network")
+                .foregroundStyle(.blue)
+            
+            VStack(alignment: .leading) {
+                Text(server.name)
+                    .font(.subheadline)
+                Text(server.url)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            
+            Spacer()
+            
+            Button(role: .destructive, action: onDelete) {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Skill Editor Sheet
+
+struct SkillEditorSheet: View {
+    let skill: Skill?
+    let onSave: () -> Void
+    
+    @State private var name = ""
+    @State private var description = ""
+    @State private var keywords = ""
+    @State private var files = ""
+    @State private var agents = ""
+    @State private var instructions = ""
+    @State private var tools = ""
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Basic Info") {
+                    TextField("Name", text: $name)
+                    TextField("Description", text: $description)
+                }
+                
+                Section("Triggers") {
+                    TextField("Keywords (comma-separated)", text: $keywords)
+                        .help("e.g., review, audit, check")
+                    TextField("File patterns (comma-separated)", text: $files)
+                        .help("e.g., *.swift, *.ts, *.py")
+                    TextField("Agents (comma-separated)", text: $agents)
+                        .help("e.g., claude, antigravity, opencode")
+                }
+                
+                Section("Instructions") {
+                    TextEditor(text: $instructions)
+                        .frame(minHeight: 150)
+                }
+                
+                Section("MCP Tools") {
+                    TextField("Tool names (comma-separated)", text: $tools)
+                        .help("e.g., filesystem, git, terminal")
+                }
+            }
+            .navigationTitle(skill == nil ? "New Skill" : "Edit Skill")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        Task {
+                            await save()
+                            dismiss()
+                        }
+                    }
+                    .disabled(name.isEmpty)
+                }
+            }
+            .onAppear {
+                if let skill = skill {
+                    name = skill.name
+                    description = skill.description
+                    keywords = skill.triggers.keywords.joined(separator: ", ")
+                    files = skill.triggers.files.joined(separator: ", ")
+                    agents = skill.triggers.agents.joined(separator: ", ")
+                    instructions = skill.instructions
+                    tools = skill.tools.joined(separator: ", ")
+                }
+            }
+        }
+    }
+    
+    private func save() async {
+        let newSkill = Skill(
+            id: skill?.id ?? UUID(),
+            name: name,
+            description: description,
+            triggers: SkillTriggers(
+                keywords: keywords.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) },
+                files: files.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) },
+                agents: agents.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+            ),
+            instructions: instructions,
+            tools: tools.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) },
+            enabled: skill?.enabled ?? true,
+            usageCount: skill?.usageCount ?? 0,
+            lastUsed: skill?.lastUsed,
+            lastAgent: skill?.lastAgent
+        )
+        
+        try? await SkillsManager.shared.saveSkill(newSkill)
+        onSave()
+    }
+}
+
+// MARK: - MCP Server Sheet
+
+struct MCPServerSheet: View {
+    let onSave: () async -> Void
+    
+    @State private var name = ""
+    @State private var url = ""
+    @State private var serverType: MCPServer.MCPServerType = .http
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        NavigationStack {
+            Form {
+                TextField("Name", text: $name)
+                
+                Picker("Type", selection: $serverType) {
+                    Text("HTTP").tag(MCPServer.MCPServerType.http)
+                    Text("Stdio").tag(MCPServer.MCPServerType.stdio)
+                }
+                
+                TextField("URL", text: $url)
+            }
+            .navigationTitle("Add MCP Server")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Add") {
+                        Task {
+                            await save()
+                            dismiss()
+                        }
+                    }
+                    .disabled(name.isEmpty || url.isEmpty)
+                }
+            }
+        }
+    }
+    
+    private func save() async {
+        let server = MCPServer(name: name, url: url)
+        try? await MCPClient.shared.addServer(server)
+        await onSave()
+    }
+}
+
+
+// MARK: - MCP Registry Browser
+
+struct MCPRegistryBrowser: View {
+    let onSave: () async -> Void
+    
+    @State private var searchText = ""
+    @State private var servers: [MCPServer] = []
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        NavigationStack {
+            Group {
+                if let error = errorMessage {
+                    VStack(spacing: 16) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .font(.system(size: 48))
+                            .foregroundStyle(.red)
+                        Text("Error")
+                            .font(.headline)
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                        Button("Retry") {
+                            Task { await search(searchText) }
+                        }
+                    }
+                    .padding()
+                } else if isLoading {
+                    ProgressView("Searching registry...")
+                } else if servers.isEmpty {
+                    VStack(spacing: 16) {
+                        Image(systemName: "magnifyingglass")
+                            .font(.system(size: 48))
+                            .foregroundStyle(.secondary)
+                        Text("Search the MCP Registry")
+                            .font(.headline)
+                        Text("Find MCP servers for filesystem, git, web search, and more")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding()
+                } else {
+                    ScrollView {
+                        VStack(spacing: 8) {
+                            Text("Found \(servers.count) servers")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .padding(.top)
+                            
+                            ForEach(servers) { server in
+                                Button {
+                                    Task {
+                                        try? await MCPClient.shared.addServer(server)
+                                        await onSave()
+                                        dismiss()
+                                    }
+                                } label: {
+                                    HStack {
+                                        VStack(alignment: .leading, spacing: 4) {
+                                            Text(server.name)
+                                                .font(.headline)
+                                            Text(server.url)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                        Spacer()
+                                        Image(systemName: "plus.circle")
+                                            .foregroundStyle(.blue)
+                                    }
+                                    .padding()
+                                    .background(.regularMaterial)
+                                    .cornerRadius(8)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                            .padding(.horizontal)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("MCP Registry")
+            .searchable(text: $searchText, prompt: "Search servers (e.g., filesystem, git)")
+            .onChange(of: searchText) { _, newValue in
+                Task {
+                    await search(newValue)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+            .onAppear {
+                print("[MCP Browser] View appeared")
+                Task {
+                    await search("")
+                }
+            }
+        }
+    }
+    
+    private func search(_ query: String) async {
+        print("[MCP Browser] Searching for: '\(query)'")
+        isLoading = true
+        errorMessage = nil
+        
+        do {
+            let results = try await MCPClient.shared.fetchFromRegistry(
+                search: query.isEmpty ? nil : query,
+                limit: 50
+            )
+            print("[MCP Browser] Got \(results.count) servers")
+            
+            // Update on main actor
+            await MainActor.run {
+                self.servers = results
+                print("[MCP Browser] Updated UI with \(self.servers.count) servers")
+            }
+        } catch {
+            print("[MCP Browser] Error: \(error)")
+            await MainActor.run {
+                self.errorMessage = error.localizedDescription
+                self.servers = []
+            }
+        }
+        
+        await MainActor.run {
+            self.isLoading = false
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Cloudflare token storage and token-mode tunnel startup flow
- add custom public URL handling for token-based tunnels
- update UI and consumers to use effective tunnel URL consistently
- include skills/MCP service files used by current app build
- fix compile blockers in agent integration (`mcpConfigPath`/`skillsDirectory`) and resolve Swift 6 closure warnings

## Added in latest push
- add a dedicated **Tunnel Logs** tab in Logs screen
- improve Logs UX with clearer empty states, summary header, and better log row readability
- surface live cloudflared stdout/stderr output into UI via `CloudflaredService` -> `TunnelManager`
- track tunnel lifecycle/error messages in `TunnelManager` and expose clear action for tunnel logs
- add localization keys for all new tunnel log UI strings

## Verification
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/quotio-derived build`
- result: **BUILD SUCCEEDED**

## Known issue (operational)
- tunnel can be healthy while some recursive DNS resolvers still return stale NXDOMAIN/no answer for the new hostname
- authoritative Cloudflare nameservers already return valid A records for `ai.1saif.me`; affected resolvers require cache expiry/flush
