### PR TITLE
Add GPT-5.4 and remove fake GPT-5.4 Codex variants

### DIFF
--- a/Quotio/Models/AgentModels.swift
+++ b/Quotio/Models/AgentModels.swift
@@ -222,6 +222,12 @@ nonisolated struct AvailableModel: Identifiable, Codable, Hashable, Sendable {
     let provider: String
     let isDefault: Bool
 
+    static let legacyModelReplacements: [String: String] = [
+        "gpt-5.4": "gpt-5",
+        "gpt-5.4-codex": "gpt-5-codex",
+        "gpt-5.4-codex-mini": "gpt-5-codex-mini"
+    ]
+
     var displayName: String {
         name.split(separator: "-")
             .map { $0.capitalized }
@@ -260,6 +266,36 @@ nonisolated struct AvailableModel: Identifiable, Codable, Hashable, Sendable {
         AvailableModel(id: "gpt-5-codex-mini", name: "gpt-5-codex-mini", provider: "openai", isDefault: false),
         AvailableModel(id: "gpt-oss-120b-medium", name: "gpt-oss-120b-medium", provider: "openai", isDefault: false),
     ]
+
+    static func normalizedModelName(_ modelName: String) -> String {
+        legacyModelReplacements[modelName] ?? modelName
+    }
+
+    static func normalizedModelSlots(_ modelSlots: [ModelSlot: String]) -> [ModelSlot: String] {
+        Dictionary(uniqueKeysWithValues: modelSlots.map { slot, modelName in
+            (slot, normalizedModelName(modelName))
+        })
+    }
+
+    static func sanitizedModels(_ models: [AvailableModel]) -> [AvailableModel] {
+        var seenIds = Set<String>()
+
+        return models.compactMap { model in
+            let normalizedId = normalizedModelName(model.id)
+            let normalizedName = normalizedModelName(model.name)
+
+            guard seenIds.insert(normalizedId).inserted else {
+                return nil
+            }
+
+            return AvailableModel(
+                id: normalizedId,
+                name: normalizedName,
+                provider: model.provider,
+                isDefault: model.isDefault
+            )
+        }
+    }
 }
 
 // MARK: - Agent Status
@@ -328,7 +364,7 @@ nonisolated struct AgentConfiguration: Codable, Sendable {
         var slots = Dictionary(uniqueKeysWithValues: ModelSlot.allCases.compactMap { slot in
             AvailableModel.defaultModels[slot].map { (slot, $0.name) }
         })
-        for (slot, model) in savedModelSlots {
+        for (slot, model) in AvailableModel.normalizedModelSlots(savedModelSlots) {
             slots[slot] = model
         }
         self.modelSlots = slots

--- a/Quotio/Models/AgentModels.swift
+++ b/Quotio/Models/AgentModels.swift
@@ -222,6 +222,11 @@ nonisolated struct AvailableModel: Identifiable, Codable, Hashable, Sendable {
     let provider: String
     let isDefault: Bool
 
+    static let legacyModelReplacements: [String: String] = [
+        "gpt-5.4-codex": "gpt-5-codex",
+        "gpt-5.4-codex-mini": "gpt-5-codex-mini"
+    ]
+
     var displayName: String {
         name.split(separator: "-")
             .map { $0.capitalized }
@@ -250,8 +255,6 @@ nonisolated struct AvailableModel: Identifiable, Codable, Hashable, Sendable {
         // GPT models
         AvailableModel(id: "gpt-5.3-codex", name: "gpt-5.3-codex", provider: "openai", isDefault: false),
         AvailableModel(id: "gpt-5.4", name: "gpt-5.4", provider: "openai", isDefault: false),
-        AvailableModel(id: "gpt-5.4-codex", name: "gpt-5.4-codex", provider: "openai", isDefault: false),
-        AvailableModel(id: "gpt-5.4-codex-mini", name: "gpt-5.4-codex-mini", provider: "openai", isDefault: false),
         AvailableModel(id: "gpt-5.2", name: "gpt-5.2", provider: "openai", isDefault: false),
         AvailableModel(id: "gpt-5.2-codex", name: "gpt-5.2-codex", provider: "openai", isDefault: false),
         AvailableModel(id: "gpt-5.1", name: "gpt-5.1", provider: "openai", isDefault: false),
@@ -263,6 +266,36 @@ nonisolated struct AvailableModel: Identifiable, Codable, Hashable, Sendable {
         AvailableModel(id: "gpt-5-codex-mini", name: "gpt-5-codex-mini", provider: "openai", isDefault: false),
         AvailableModel(id: "gpt-oss-120b-medium", name: "gpt-oss-120b-medium", provider: "openai", isDefault: false),
     ]
+
+    static func normalizedModelName(_ modelName: String) -> String {
+        legacyModelReplacements[modelName] ?? modelName
+    }
+
+    static func normalizedModelSlots(_ modelSlots: [ModelSlot: String]) -> [ModelSlot: String] {
+        Dictionary(uniqueKeysWithValues: modelSlots.map { slot, modelName in
+            (slot, normalizedModelName(modelName))
+        })
+    }
+
+    static func sanitizedModels(_ models: [AvailableModel]) -> [AvailableModel] {
+        var seenIds = Set<String>()
+
+        return models.compactMap { model in
+            let normalizedId = normalizedModelName(model.id)
+            let normalizedName = normalizedModelName(model.name)
+
+            guard seenIds.insert(normalizedId).inserted else {
+                return nil
+            }
+
+            return AvailableModel(
+                id: normalizedId,
+                name: normalizedName,
+                provider: model.provider,
+                isDefault: model.isDefault
+            )
+        }
+    }
 }
 
 // MARK: - Agent Status
@@ -331,7 +364,7 @@ nonisolated struct AgentConfiguration: Codable, Sendable {
         var slots = Dictionary(uniqueKeysWithValues: ModelSlot.allCases.compactMap { slot in
             AvailableModel.defaultModels[slot].map { (slot, $0.name) }
         })
-        for (slot, model) in savedModelSlots {
+        for (slot, model) in AvailableModel.normalizedModelSlots(savedModelSlots) {
             slots[slot] = model
         }
         self.modelSlots = slots

--- a/Quotio/Models/AgentModels.swift
+++ b/Quotio/Models/AgentModels.swift
@@ -222,12 +222,6 @@ nonisolated struct AvailableModel: Identifiable, Codable, Hashable, Sendable {
     let provider: String
     let isDefault: Bool
 
-    static let legacyModelReplacements: [String: String] = [
-        "gpt-5.4": "gpt-5",
-        "gpt-5.4-codex": "gpt-5-codex",
-        "gpt-5.4-codex-mini": "gpt-5-codex-mini"
-    ]
-
     var displayName: String {
         name.split(separator: "-")
             .map { $0.capitalized }
@@ -255,6 +249,9 @@ nonisolated struct AvailableModel: Identifiable, Codable, Hashable, Sendable {
         AvailableModel(id: "gemini-2.5-computer-use-preview-10-2025", name: "gemini-2.5-computer-use-preview-10-2025", provider: "google", isDefault: false),
         // GPT models
         AvailableModel(id: "gpt-5.3-codex", name: "gpt-5.3-codex", provider: "openai", isDefault: false),
+        AvailableModel(id: "gpt-5.4", name: "gpt-5.4", provider: "openai", isDefault: false),
+        AvailableModel(id: "gpt-5.4-codex", name: "gpt-5.4-codex", provider: "openai", isDefault: false),
+        AvailableModel(id: "gpt-5.4-codex-mini", name: "gpt-5.4-codex-mini", provider: "openai", isDefault: false),
         AvailableModel(id: "gpt-5.2", name: "gpt-5.2", provider: "openai", isDefault: false),
         AvailableModel(id: "gpt-5.2-codex", name: "gpt-5.2-codex", provider: "openai", isDefault: false),
         AvailableModel(id: "gpt-5.1", name: "gpt-5.1", provider: "openai", isDefault: false),
@@ -266,36 +263,6 @@ nonisolated struct AvailableModel: Identifiable, Codable, Hashable, Sendable {
         AvailableModel(id: "gpt-5-codex-mini", name: "gpt-5-codex-mini", provider: "openai", isDefault: false),
         AvailableModel(id: "gpt-oss-120b-medium", name: "gpt-oss-120b-medium", provider: "openai", isDefault: false),
     ]
-
-    static func normalizedModelName(_ modelName: String) -> String {
-        legacyModelReplacements[modelName] ?? modelName
-    }
-
-    static func normalizedModelSlots(_ modelSlots: [ModelSlot: String]) -> [ModelSlot: String] {
-        Dictionary(uniqueKeysWithValues: modelSlots.map { slot, modelName in
-            (slot, normalizedModelName(modelName))
-        })
-    }
-
-    static func sanitizedModels(_ models: [AvailableModel]) -> [AvailableModel] {
-        var seenIds = Set<String>()
-
-        return models.compactMap { model in
-            let normalizedId = normalizedModelName(model.id)
-            let normalizedName = normalizedModelName(model.name)
-
-            guard seenIds.insert(normalizedId).inserted else {
-                return nil
-            }
-
-            return AvailableModel(
-                id: normalizedId,
-                name: normalizedName,
-                provider: model.provider,
-                isDefault: model.isDefault
-            )
-        }
-    }
 }
 
 // MARK: - Agent Status
@@ -364,7 +331,7 @@ nonisolated struct AgentConfiguration: Codable, Sendable {
         var slots = Dictionary(uniqueKeysWithValues: ModelSlot.allCases.compactMap { slot in
             AvailableModel.defaultModels[slot].map { (slot, $0.name) }
         })
-        for (slot, model) in AvailableModel.normalizedModelSlots(savedModelSlots) {
+        for (slot, model) in savedModelSlots {
             slots[slot] = model
         }
         self.modelSlots = slots

--- a/Quotio/ViewModels/AgentSetupViewModel.swift
+++ b/Quotio/ViewModels/AgentSetupViewModel.swift
@@ -139,7 +139,7 @@ final class AgentSetupViewModel {
         selectedSetupMode = saved.isProxyConfigured ? .proxy : .defaultSetup
         
         // Update current configuration with saved model slots
-        for (slot, model) in saved.modelSlots {
+        for (slot, model) in AvailableModel.normalizedModelSlots(saved.modelSlots) {
             currentConfiguration?.modelSlots[slot] = model
         }
         
@@ -177,7 +177,7 @@ final class AgentSetupViewModel {
 
 
     func updateModelSlot(_ slot: ModelSlot, model: String) {
-        currentConfiguration?.modelSlots[slot] = model
+        currentConfiguration?.modelSlots[slot] = AvailableModel.normalizedModelName(model)
     }
 
     func applyConfiguration() async {
@@ -392,8 +392,9 @@ final class AgentSetupViewModel {
             // On error, use default models if list is empty
             logger.error("[AgentSetupViewModel] Failed to load models: \(error.localizedDescription)")
             if availableModels.isEmpty {
-                self.availableModels = AvailableModel.allModels
-                logger.debug("[AgentSetupViewModel] Using \(AvailableModel.allModels.count) default models")
+                let fallbackModels = AvailableModel.sanitizedModels(AvailableModel.allModels)
+                self.availableModels = fallbackModels
+                logger.debug("[AgentSetupViewModel] Using \(fallbackModels.count) default models")
             }
         }
 
@@ -404,10 +405,12 @@ final class AgentSetupViewModel {
     private func processModels(_ fetchedModels: [AvailableModel]) -> [AvailableModel] {
         // If API returned models, use them; otherwise fallback to default models
         if !fetchedModels.isEmpty {
-            return fetchedModels.sorted { $0.displayName < $1.displayName }
+            return AvailableModel.sanitizedModels(fetchedModels)
+                .sorted { $0.displayName < $1.displayName }
         }
 
-        return AvailableModel.allModels.sorted { $0.displayName < $1.displayName }
+        return AvailableModel.sanitizedModels(AvailableModel.allModels)
+            .sorted { $0.displayName < $1.displayName }
     }
 
     /// Refresh virtual models - removes old ones and adds current ones

--- a/Quotio/ViewModels/AgentSetupViewModel.swift
+++ b/Quotio/ViewModels/AgentSetupViewModel.swift
@@ -139,7 +139,7 @@ final class AgentSetupViewModel {
         selectedSetupMode = saved.isProxyConfigured ? .proxy : .defaultSetup
         
         // Update current configuration with saved model slots
-        for (slot, model) in AvailableModel.normalizedModelSlots(saved.modelSlots) {
+        for (slot, model) in saved.modelSlots {
             currentConfiguration?.modelSlots[slot] = model
         }
         
@@ -177,7 +177,7 @@ final class AgentSetupViewModel {
 
 
     func updateModelSlot(_ slot: ModelSlot, model: String) {
-        currentConfiguration?.modelSlots[slot] = AvailableModel.normalizedModelName(model)
+        currentConfiguration?.modelSlots[slot] = model
     }
 
     func applyConfiguration() async {
@@ -392,9 +392,8 @@ final class AgentSetupViewModel {
             // On error, use default models if list is empty
             logger.error("[AgentSetupViewModel] Failed to load models: \(error.localizedDescription)")
             if availableModels.isEmpty {
-                let fallbackModels = AvailableModel.sanitizedModels(AvailableModel.allModels)
-                self.availableModels = fallbackModels
-                logger.debug("[AgentSetupViewModel] Using \(fallbackModels.count) default models")
+                self.availableModels = AvailableModel.allModels
+                logger.debug("[AgentSetupViewModel] Using \(AvailableModel.allModels.count) default models")
             }
         }
 
@@ -405,12 +404,10 @@ final class AgentSetupViewModel {
     private func processModels(_ fetchedModels: [AvailableModel]) -> [AvailableModel] {
         // If API returned models, use them; otherwise fallback to default models
         if !fetchedModels.isEmpty {
-            return AvailableModel.sanitizedModels(fetchedModels)
-                .sorted { $0.displayName < $1.displayName }
+            return fetchedModels.sorted { $0.displayName < $1.displayName }
         }
 
-        return AvailableModel.sanitizedModels(AvailableModel.allModels)
-            .sorted { $0.displayName < $1.displayName }
+        return AvailableModel.allModels.sorted { $0.displayName < $1.displayName }
     }
 
     /// Refresh virtual models - removes old ones and adds current ones


### PR DESCRIPTION
## Summary

This keeps plain `gpt-5.4` available in Quotio while removing the fake `gpt-5.4-codex` and `gpt-5.4-codex-mini` variants.

## Changes

- keeps built-in `gpt-5.4`
- removes built-in `gpt-5.4-codex` and `gpt-5.4-codex-mini`
- normalizes stale saved selections:
  - `gpt-5.4-codex` -> `gpt-5-codex`
  - `gpt-5.4-codex-mini` -> `gpt-5-codex-mini`
- sanitizes fetched and fallback model lists so removed aliases do not reappear in the UI

## Why

`gpt-5.4` is a real model entry we want to expose, but the `gpt-5.4-codex*` variants are not real and should not appear as selectable models.

## Testing

- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build`
