### PR TITLE
Fix Vertex service account import flow

### DIFF
--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -274,12 +274,6 @@ struct QuotioApp: App {
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private nonisolated(unsafe) var windowWillCloseObserver: NSObjectProtocol?
     private nonisolated(unsafe) var windowDidBecomeKeyObserver: NSObjectProtocol?
-    private nonisolated(unsafe) var windowDidBecomeMainObserver: NSObjectProtocol?
-    private nonisolated(unsafe) var appDidResignActiveObserver: NSObjectProtocol?
-    private var pendingForegroundReassert = false
-    private weak var trackedDashboardWindow: NSWindow?
-    private var lastDashboardActivationDate: Date?
-    private var hasTriggeredAntiDropForCurrentActivation = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Move orphan cleanup off main thread to avoid blocking app launch
@@ -318,10 +312,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             forName: NSWindow.willCloseNotification,
             object: nil,
             queue: .main
-        ) { [weak self] notification in
-            let closingWindow = notification.object as? NSWindow
+        ) { [weak self] _ in
             MainActor.assumeIsolated {
-                self?.handleWindowWillClose(closingWindow)
+                self?.handleWindowWillClose()
             }
         }
 
@@ -334,27 +327,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.handleWindowDidBecomeKey()
             }
         }
-
-        windowDidBecomeMainObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.didBecomeMainNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            let mainWindow = notification.object as? NSWindow
-            MainActor.assumeIsolated {
-                self?.handleWindowDidBecomeMain(mainWindow)
-            }
-        }
-
-        appDidResignActiveObserver = NotificationCenter.default.addObserver(
-            forName: NSApplication.didResignActiveNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated {
-                self?.handleApplicationDidResignActive()
-            }
-        }
     }
     
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
@@ -362,114 +334,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        _ = bringMainWindowToFront(in: sender)
-        return true
-    }
-
-    private var shouldUseAccessoryPolicy: Bool {
-        !UserDefaults.standard.bool(forKey: "showInDock")
-    }
-
-    private func ensureRegularPolicyForMainWindowForeground(in app: NSApplication) -> Bool {
-        guard shouldUseAccessoryPolicy else { return true }
-
-        if app.activationPolicy() == .regular {
-            return true
-        }
-
-        guard app.setActivationPolicy(.regular) else {
-            return false
-        }
-
-        return true
-    }
-
-    private func promoteToRegularPolicyIfNeeded() -> Bool {
-        guard shouldUseAccessoryPolicy else { return true }
-
-        if NSApp.activationPolicy() == .regular {
-            return true
-        }
-
-        _ = NSApp.setActivationPolicy(.regular)
-        return NSApp.activationPolicy() == .regular
-    }
-
-    private func promoteToRegularPolicyWithRetry(reason: String, remainingAttempts: Int = 3) {
-        guard remainingAttempts > 0 else { return }
-
-        if promoteToRegularPolicyIfNeeded() {
-            if let window = mainWindow(in: NSApp) {
-                NSApp.activate(ignoringOtherApps: true)
-                window.makeKeyAndOrderFront(nil)
+        // When user clicks dock icon or menubar "Open Quotio" and no visible windows
+        if !flag {
+            // Find and show the main window
+            for window in sender.windows {
+                if window.title == "Quotio" {
+                    // Restore minimized window first
+                    if window.isMiniaturized {
+                        window.deminiaturize(nil)
+                    }
+                    window.makeKeyAndOrderFront(nil)
+                    return true
+                }
             }
-            return
         }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
-            self.promoteToRegularPolicyWithRetry(reason: reason, remainingAttempts: remainingAttempts - 1)
-        }
-    }
-
-    private func restoreAccessoryPolicyIfNeeded(in app: NSApplication) {
-        guard shouldUseAccessoryPolicy else { return }
-
-        let hasVisibleMainCapableWindow = app.windows.contains { window in
-            window.canBecomeMain && window.isVisible && !window.isMiniaturized
-        }
-
-        if !hasVisibleMainCapableWindow && app.activationPolicy() != .accessory {
-            app.setActivationPolicy(.accessory)
-        }
-    }
-
-    private func bringMainWindowToFront(in app: NSApplication) -> Bool {
-        guard let window = mainWindow(in: app) else { return false }
-        guard ensureRegularPolicyForMainWindowForeground(in: app) else { return false }
-
-        trackedDashboardWindow = window
-        pendingForegroundReassert = true
-
-        if window.isMiniaturized {
-            window.deminiaturize(nil)
-        }
-
-        window.makeKeyAndOrderFront(nil)
-
-        DispatchQueue.main.async {
-            app.activate(ignoringOtherApps: true)
-            NSRunningApplication.current.activate(options: [.activateAllWindows])
-
-            if let refreshedWindow = self.mainWindow(in: app) {
-                self.trackedDashboardWindow = refreshedWindow
-                refreshedWindow.makeKeyAndOrderFront(nil)
-            }
-
-            if !app.isActive {
-                window.orderFrontRegardless()
-            } else {
-                self.pendingForegroundReassert = false
-            }
-
-        }
-
         return true
-    }
-
-    private func mainWindow(in app: NSApplication) -> NSWindow? {
-        if let trackedDashboardWindow,
-           app.windows.contains(where: { $0 === trackedDashboardWindow }),
-           isDashboardWindowCandidate(trackedDashboardWindow) {
-            return trackedDashboardWindow
-        }
-
-        let dashboardCandidates = app.windows.filter { isDashboardWindowCandidate($0) }
-        return dashboardCandidates.first
-    }
-
-    private func isDashboardWindowCandidate(_ window: NSWindow) -> Bool {
-        window.canBecomeMain
-            && window.level == .normal
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -496,72 +375,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    func applicationDidBecomeActive(_ notification: Notification) {
-        let keyWindowIsDashboardCandidate = NSApp.keyWindow.map(isDashboardWindowCandidate) ?? false
-
-        if keyWindowIsDashboardCandidate {
-            promoteToRegularPolicyWithRetry(reason: "didBecomeActive")
-            lastDashboardActivationDate = Date()
-            hasTriggeredAntiDropForCurrentActivation = false
-        }
-
-        guard pendingForegroundReassert else { return }
-        guard let window = mainWindow(in: NSApp) else {
-            pendingForegroundReassert = false
-            return
-        }
-
-        window.makeKeyAndOrderFront(nil)
-        pendingForegroundReassert = false
-    }
-
-    private func handleWindowDidBecomeMain(_ window: NSWindow?) {
-        guard let window else { return }
-        guard isDashboardWindowCandidate(window) else { return }
-
-        trackedDashboardWindow = window
-    }
-
-    private func handleApplicationDidResignActive() {
-        guard !hasTriggeredAntiDropForCurrentActivation else { return }
-        guard let activationDate = lastDashboardActivationDate else { return }
-
-        let elapsedSinceActivation = Date().timeIntervalSince(activationDate)
-        guard elapsedSinceActivation <= 0.5 else { return }
-        guard let dashboardWindow = mainWindow(in: NSApp), dashboardWindow.isVisible else { return }
-
-        hasTriggeredAntiDropForCurrentActivation = true
-
-        DispatchQueue.main.async {
-            NSApp.activate(ignoringOtherApps: true)
-            dashboardWindow.makeKeyAndOrderFront(nil)
-        }
-    }
-
     private func handleWindowDidBecomeKey() {
-        guard let keyWindow = NSApp.keyWindow else { return }
-        guard let appMainWindow = mainWindow(in: NSApp), keyWindow === appMainWindow else { return }
-
-        promoteToRegularPolicyWithRetry(reason: "didBecomeKey")
-        guard ensureRegularPolicyForMainWindowForeground(in: NSApp) else { return }
-
-        if !NSApp.isActive {
-            pendingForegroundReassert = true
-            NSApp.activate(ignoringOtherApps: true)
-            keyWindow.makeKeyAndOrderFront(nil)
-        }
+        // Do nothing - activation policy is managed by showInDock setting only
     }
 
-    private func handleWindowWillClose(_ closingWindow: NSWindow?) {
-        let isClosingDashboardWindow = closingWindow.map {
-            ($0 === trackedDashboardWindow) || isDashboardWindowCandidate($0)
-        } ?? false
-
-        guard isClosingDashboardWindow else { return }
-
-        DispatchQueue.main.async {
-            self.restoreAccessoryPolicyIfNeeded(in: NSApp)
-        }
+    private func handleWindowWillClose() {
+        // Do nothing - activation policy is managed by showInDock setting only
+        // When showInDock = true, dock icon stays visible even when window is closed
+        // When showInDock = false, dock icon is never visible
     }
     
     deinit {
@@ -569,12 +390,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NotificationCenter.default.removeObserver(observer)
         }
         if let observer = windowDidBecomeKeyObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        if let observer = windowDidBecomeMainObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        if let observer = appDidResignActiveObserver {
             NotificationCenter.default.removeObserver(observer)
         }
     }

--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -274,6 +274,12 @@ struct QuotioApp: App {
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private nonisolated(unsafe) var windowWillCloseObserver: NSObjectProtocol?
     private nonisolated(unsafe) var windowDidBecomeKeyObserver: NSObjectProtocol?
+    private nonisolated(unsafe) var windowDidBecomeMainObserver: NSObjectProtocol?
+    private nonisolated(unsafe) var appDidResignActiveObserver: NSObjectProtocol?
+    private var pendingForegroundReassert = false
+    private weak var trackedDashboardWindow: NSWindow?
+    private var lastDashboardActivationDate: Date?
+    private var hasTriggeredAntiDropForCurrentActivation = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Move orphan cleanup off main thread to avoid blocking app launch
@@ -312,9 +318,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             forName: NSWindow.willCloseNotification,
             object: nil,
             queue: .main
-        ) { [weak self] _ in
+        ) { [weak self] notification in
+            let closingWindow = notification.object as? NSWindow
             MainActor.assumeIsolated {
-                self?.handleWindowWillClose()
+                self?.handleWindowWillClose(closingWindow)
             }
         }
 
@@ -327,6 +334,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.handleWindowDidBecomeKey()
             }
         }
+
+        windowDidBecomeMainObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didBecomeMainNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let mainWindow = notification.object as? NSWindow
+            MainActor.assumeIsolated {
+                self?.handleWindowDidBecomeMain(mainWindow)
+            }
+        }
+
+        appDidResignActiveObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didResignActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.handleApplicationDidResignActive()
+            }
+        }
     }
     
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
@@ -334,21 +362,114 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        // When user clicks dock icon or menubar "Open Quotio" and no visible windows
-        if !flag {
-            // Find and show the main window
-            for window in sender.windows {
-                if window.title == "Quotio" {
-                    // Restore minimized window first
-                    if window.isMiniaturized {
-                        window.deminiaturize(nil)
-                    }
-                    window.makeKeyAndOrderFront(nil)
-                    return true
-                }
-            }
-        }
+        _ = bringMainWindowToFront(in: sender)
         return true
+    }
+
+    private var shouldUseAccessoryPolicy: Bool {
+        !UserDefaults.standard.bool(forKey: "showInDock")
+    }
+
+    private func ensureRegularPolicyForMainWindowForeground(in app: NSApplication) -> Bool {
+        guard shouldUseAccessoryPolicy else { return true }
+
+        if app.activationPolicy() == .regular {
+            return true
+        }
+
+        guard app.setActivationPolicy(.regular) else {
+            return false
+        }
+
+        return true
+    }
+
+    private func promoteToRegularPolicyIfNeeded() -> Bool {
+        guard shouldUseAccessoryPolicy else { return true }
+
+        if NSApp.activationPolicy() == .regular {
+            return true
+        }
+
+        _ = NSApp.setActivationPolicy(.regular)
+        return NSApp.activationPolicy() == .regular
+    }
+
+    private func promoteToRegularPolicyWithRetry(reason: String, remainingAttempts: Int = 3) {
+        guard remainingAttempts > 0 else { return }
+
+        if promoteToRegularPolicyIfNeeded() {
+            if let window = mainWindow(in: NSApp) {
+                NSApp.activate(ignoringOtherApps: true)
+                window.makeKeyAndOrderFront(nil)
+            }
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+            self.promoteToRegularPolicyWithRetry(reason: reason, remainingAttempts: remainingAttempts - 1)
+        }
+    }
+
+    private func restoreAccessoryPolicyIfNeeded(in app: NSApplication) {
+        guard shouldUseAccessoryPolicy else { return }
+
+        let hasVisibleMainCapableWindow = app.windows.contains { window in
+            window.canBecomeMain && window.isVisible && !window.isMiniaturized
+        }
+
+        if !hasVisibleMainCapableWindow && app.activationPolicy() != .accessory {
+            app.setActivationPolicy(.accessory)
+        }
+    }
+
+    private func bringMainWindowToFront(in app: NSApplication) -> Bool {
+        guard let window = mainWindow(in: app) else { return false }
+        guard ensureRegularPolicyForMainWindowForeground(in: app) else { return false }
+
+        trackedDashboardWindow = window
+        pendingForegroundReassert = true
+
+        if window.isMiniaturized {
+            window.deminiaturize(nil)
+        }
+
+        window.makeKeyAndOrderFront(nil)
+
+        DispatchQueue.main.async {
+            app.activate(ignoringOtherApps: true)
+            NSRunningApplication.current.activate(options: [.activateAllWindows])
+
+            if let refreshedWindow = self.mainWindow(in: app) {
+                self.trackedDashboardWindow = refreshedWindow
+                refreshedWindow.makeKeyAndOrderFront(nil)
+            }
+
+            if !app.isActive {
+                window.orderFrontRegardless()
+            } else {
+                self.pendingForegroundReassert = false
+            }
+
+        }
+
+        return true
+    }
+
+    private func mainWindow(in app: NSApplication) -> NSWindow? {
+        if let trackedDashboardWindow,
+           app.windows.contains(where: { $0 === trackedDashboardWindow }),
+           isDashboardWindowCandidate(trackedDashboardWindow) {
+            return trackedDashboardWindow
+        }
+
+        let dashboardCandidates = app.windows.filter { isDashboardWindowCandidate($0) }
+        return dashboardCandidates.first
+    }
+
+    private func isDashboardWindowCandidate(_ window: NSWindow) -> Bool {
+        window.canBecomeMain
+            && window.level == .normal
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -375,14 +496,72 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func handleWindowDidBecomeKey() {
-        // Do nothing - activation policy is managed by showInDock setting only
+    func applicationDidBecomeActive(_ notification: Notification) {
+        let keyWindowIsDashboardCandidate = NSApp.keyWindow.map(isDashboardWindowCandidate) ?? false
+
+        if keyWindowIsDashboardCandidate {
+            promoteToRegularPolicyWithRetry(reason: "didBecomeActive")
+            lastDashboardActivationDate = Date()
+            hasTriggeredAntiDropForCurrentActivation = false
+        }
+
+        guard pendingForegroundReassert else { return }
+        guard let window = mainWindow(in: NSApp) else {
+            pendingForegroundReassert = false
+            return
+        }
+
+        window.makeKeyAndOrderFront(nil)
+        pendingForegroundReassert = false
     }
 
-    private func handleWindowWillClose() {
-        // Do nothing - activation policy is managed by showInDock setting only
-        // When showInDock = true, dock icon stays visible even when window is closed
-        // When showInDock = false, dock icon is never visible
+    private func handleWindowDidBecomeMain(_ window: NSWindow?) {
+        guard let window else { return }
+        guard isDashboardWindowCandidate(window) else { return }
+
+        trackedDashboardWindow = window
+    }
+
+    private func handleApplicationDidResignActive() {
+        guard !hasTriggeredAntiDropForCurrentActivation else { return }
+        guard let activationDate = lastDashboardActivationDate else { return }
+
+        let elapsedSinceActivation = Date().timeIntervalSince(activationDate)
+        guard elapsedSinceActivation <= 0.5 else { return }
+        guard let dashboardWindow = mainWindow(in: NSApp), dashboardWindow.isVisible else { return }
+
+        hasTriggeredAntiDropForCurrentActivation = true
+
+        DispatchQueue.main.async {
+            NSApp.activate(ignoringOtherApps: true)
+            dashboardWindow.makeKeyAndOrderFront(nil)
+        }
+    }
+
+    private func handleWindowDidBecomeKey() {
+        guard let keyWindow = NSApp.keyWindow else { return }
+        guard let appMainWindow = mainWindow(in: NSApp), keyWindow === appMainWindow else { return }
+
+        promoteToRegularPolicyWithRetry(reason: "didBecomeKey")
+        guard ensureRegularPolicyForMainWindowForeground(in: NSApp) else { return }
+
+        if !NSApp.isActive {
+            pendingForegroundReassert = true
+            NSApp.activate(ignoringOtherApps: true)
+            keyWindow.makeKeyAndOrderFront(nil)
+        }
+    }
+
+    private func handleWindowWillClose(_ closingWindow: NSWindow?) {
+        let isClosingDashboardWindow = closingWindow.map {
+            ($0 === trackedDashboardWindow) || isDashboardWindowCandidate($0)
+        } ?? false
+
+        guard isClosingDashboardWindow else { return }
+
+        DispatchQueue.main.async {
+            self.restoreAccessoryPolicyIfNeeded(in: NSApp)
+        }
     }
     
     deinit {
@@ -390,6 +569,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NotificationCenter.default.removeObserver(observer)
         }
         if let observer = windowDidBecomeKeyObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = windowDidBecomeMainObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = appDidResignActiveObserver {
             NotificationCenter.default.removeObserver(observer)
         }
     }

--- a/Quotio/Services/ManagementAPIClient.swift
+++ b/Quotio/Services/ManagementAPIClient.swift
@@ -142,7 +142,13 @@ actor ManagementAPIClient {
         session.invalidateAndCancel()
     }
     
-    private func makeRequest(_ endpoint: String, method: String = "GET", body: Data? = nil, retryCount: Int = 0) async throws -> Data {
+    private func makeRequest(
+        _ endpoint: String,
+        method: String = "GET",
+        body: Data? = nil,
+        contentType: String = "application/json",
+        retryCount: Int = 0
+    ) async throws -> Data {
         let requestId = String(UUID().uuidString.prefix(6))
         let activeCount = Self.incrementActiveRequests()
         let startTime = Date()
@@ -162,7 +168,7 @@ actor ManagementAPIClient {
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.addValue("Bearer \(authKey)", forHTTPHeaderField: "Authorization")
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue(contentType, forHTTPHeaderField: "Content-Type")
         // Force new connection to avoid stale connection issues after idle periods
         request.addValue("close", forHTTPHeaderField: "Connection")
         
@@ -195,7 +201,13 @@ actor ManagementAPIClient {
                 
                 // Exponential backoff delay
                 try? await Task.sleep(nanoseconds: UInt64(backoffSeconds * 1_000_000_000))
-                return try await makeRequest(endpoint, method: method, body: body, retryCount: retryCount + 1)
+                return try await makeRequest(
+                    endpoint,
+                    method: method,
+                    body: body,
+                    contentType: contentType,
+                    retryCount: retryCount + 1
+                )
             }
             throw APIError.connectionError(error.localizedDescription)
         } catch {
@@ -433,7 +445,21 @@ actor ManagementAPIClient {
     }
 
     func uploadVertexServiceAccount(data: Data) async throws {
-        _ = try await makeRequest("/vertex/import", method: "POST", body: data)
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var body = Data()
+
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"service-account.json\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: application/json\r\n\r\n".data(using: .utf8)!)
+        body.append(data)
+        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+
+        _ = try await makeRequest(
+            "/vertex/import",
+            method: "POST",
+            body: body,
+            contentType: "multipart/form-data; boundary=\(boundary)"
+        )
     }
     
     func fetchAPIKeys() async throws -> [String] {

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -1623,8 +1623,8 @@ final class QuotaViewModel {
             guard url.startAccessingSecurityScopedResource() else {
                 throw NSError(domain: "Quotio", code: 403, userInfo: [NSLocalizedDescriptionKey: "Permission denied"])
             }
+            defer { url.stopAccessingSecurityScopedResource() }
             let data = try Data(contentsOf: url)
-            url.stopAccessingSecurityScopedResource()
             
             try await client.uploadVertexServiceAccount(data: data)
             await refreshData()

--- a/Quotio/Views/Screens/DashboardScreen.swift
+++ b/Quotio/Views/Screens/DashboardScreen.swift
@@ -17,6 +17,7 @@ struct DashboardScreen: View {
     @State private var selectedAgentForConfig: CLIAgent?
     @State private var sheetPresentationID = UUID()
     @State private var showTunnelSheet = false
+    @State private var showProxyRequiredAlert = false
     
     private var tunnelManager: TunnelManager { TunnelManager.shared }
     
@@ -132,12 +133,39 @@ struct DashboardScreen: View {
             allowedContentTypes: [.json],
             allowsMultipleSelection: false
         ) { result in
-            if case .success(let urls) = result, let url = urls.first {
-                Task {
-                    await viewModel.importVertexServiceAccount(url: url)
-                    await viewModel.refreshData()
+            switch result {
+            case .success(let urls):
+                if let url = urls.first {
+                    Task {
+                        await viewModel.importVertexServiceAccount(url: url)
+                        await viewModel.refreshData()
+                    }
                 }
+            case .failure(let error):
+                if let cocoaError = error as? CocoaError, cocoaError.code == .userCancelled {
+                    return
+                }
+                viewModel.errorMessage = "Import failed: \(error.localizedDescription)"
             }
+        }
+        .alert(
+            "Error",
+            isPresented: Binding(
+                get: { viewModel.errorMessage != nil },
+                set: { if !$0 { viewModel.errorMessage = nil } }
+            )
+        ) {
+            Button("OK") { viewModel.errorMessage = nil }
+        } message: {
+            Text(viewModel.errorMessage ?? "")
+        }
+        .alert("providers.proxyRequired.title".localized(), isPresented: $showProxyRequiredAlert) {
+            Button("action.startProxy".localized()) {
+                Task { await viewModel.startProxy() }
+            }
+            Button("action.cancel".localized(), role: .cancel) {}
+        } message: {
+            Text("providers.proxyRequired.message".localized())
         }
         .task {
             if modeManager.isLocalProxyMode {
@@ -581,6 +609,21 @@ struct DashboardScreen: View {
         }
     }
     
+    private func handleAddProvider(_ provider: AIProvider) {
+        // In Local Proxy Mode, require proxy to be running for OAuth
+        if modeManager.isLocalProxyMode && !viewModel.proxyManager.proxyStatus.running {
+            showProxyRequiredAlert = true
+            return
+        }
+
+        if provider == .vertex {
+            isImporterPresented = true
+        } else {
+            viewModel.oauthState = nil
+            selectedProvider = provider
+        }
+    }
+    
     private func showProviderPicker() {
         let alert = NSAlert()
         alert.messageText = "providers.addProvider".localized()
@@ -596,12 +639,7 @@ struct DashboardScreen: View {
         
         if index >= 0 && index < AIProvider.allCases.count {
             let provider = AIProvider.allCases[index]
-            if provider == .vertex {
-                isImporterPresented = true
-            } else {
-                viewModel.oauthState = nil
-                selectedProvider = provider
-            }
+            handleAddProvider(provider)
         }
     }
     
@@ -665,12 +703,7 @@ struct DashboardScreen: View {
                     
                     ForEach(viewModel.disconnectedProviders.filter { $0.supportsManualAuth }) { provider in
                         Button {
-                            if provider == .vertex {
-                                isImporterPresented = true
-                            } else {
-                                viewModel.oauthState = nil
-                                selectedProvider = provider
-                            }
+                            handleAddProvider(provider)
                         } label: {
                             Label(provider.displayName, systemImage: "plus.circle")
                                 .font(.caption)

--- a/Quotio/Views/Screens/ProvidersScreen.swift
+++ b/Quotio/Views/Screens/ProvidersScreen.swift
@@ -153,13 +153,31 @@ struct ProvidersScreen: View {
             allowedContentTypes: [.json],
             allowsMultipleSelection: false
         ) { result in
-            if case .success(let urls) = result, let url = urls.first {
-                Task { await viewModel.importVertexServiceAccount(url: url) }
+            switch result {
+            case .success(let urls):
+                if let url = urls.first {
+                    Task { await viewModel.importVertexServiceAccount(url: url) }
+                }
+            case .failure(let error):
+                if let cocoaError = error as? CocoaError, cocoaError.code == .userCancelled {
+                    return
+                }
+                viewModel.errorMessage = "Import failed: \(error.localizedDescription)"
             }
-            // Failure case is silently ignored - user can retry via UI
         }
         .task {
             await viewModel.loadDirectAuthFiles()
+        }
+        .alert(
+            "Error",
+            isPresented: Binding(
+                get: { viewModel.errorMessage != nil },
+                set: { if !$0 { viewModel.errorMessage = nil } }
+            )
+        ) {
+            Button("OK") { viewModel.errorMessage = nil }
+        } message: {
+            Text(viewModel.errorMessage ?? "")
         }
         .alert("providers.proxyRequired.title".localized(), isPresented: $showProxyRequiredAlert) {
             Button("action.startProxy".localized()) {


### PR DESCRIPTION
Send Vertex uploads as multipart form-data, preserve the content type across request retries, and ensure security-scoped file access is always released.

Also surface file import errors in the UI and require the local proxy to be running before starting provider auth in proxy mode.