### PR TITLE
fix(kiro): add litellmProxy option to fix compact failure with Kiro Claude models

### DIFF
--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -1284,7 +1284,8 @@ actor AgentConfigurationService {
             "npm": "@ai-sdk/anthropic",
             "options": [
                 "apiKey": config.apiKey,
-                "baseURL": "\(baseURL)/v1"
+                "baseURL": "\(baseURL)/v1",
+                "litellmProxy": true
             ]
         ]
 


### PR DESCRIPTION
## Background

When running opencode's `/compact` command with **Kiro Claude models** (e.g., `kiro-claude-opus-4-6`), Kiro API returns `400 Bad Request - "Improperly formed request"`.

This issue is specific to **Kiro Claude models** because the underlying Anthropic/Bedrock API enforces strict validation: if conversation history contains `toolUses`, the request must also include a `tools` parameter. Other Kiro model families (Gemini, GPT) do not have this restriction.

Root cause: `/compact` sends conversation history (containing `toolUses` in assistant messages) with an empty `tools` parameter. During the CLIProxyAPIPlus → Kiro API translation, the mismatch between `toolUses` in history and empty `tools` triggers a validation error on the Anthropic/Bedrock backend.

opencode already has a workaround for this exact scenario — a dummy tool insertion mechanism in `llm.ts` that activates when `provider.options.litellmProxy === true`. This was originally built for LiteLLM proxy compatibility ([opencode#2915](https://github.com/anomalyco/opencode/issues/2915)), but the underlying problem is identical: Anthropic-compatible APIs with strict validation reject requests containing tool call history without active tool definitions.

Verified that `isLiteLLMProxy` is used in exactly one place in opencode source (`packages/opencode/src/session/llm.ts`, lines 158-170) — only for dummy tool insertion. No other code paths are affected.

Related: [#268](https://github.com/nguyenphutrong/quotio/issues/268) (Claude Code 无法清理上下文 — same root cause)

## Problem

- Quotio's generated `opencode.json` does not include the `litellmProxy` option
- CLIProxyAPIPlus is not a LiteLLM proxy, so opencode's `isLiteLLMProxy` condition doesn't match
- Result: when using Kiro Claude models, compact sends `toolUses` in history without `tools` → Anthropic/Bedrock backend rejects the request
- Kiro Gemini/GPT models are **not affected** — their backends accept tool call history without active tool definitions

## Solution

Add `litellmProxy: true` to the provider options in `generateOpenCodeConfig()`. This activates opencode's existing `isLiteLLMProxy` workaround, which inserts a `_noop` dummy tool when:
1. `tools` is empty, AND
2. Message history contains tool calls

This satisfies the Anthropic/Bedrock backend's requirement that `toolUses` in history must have corresponding `tools` in the request. The dummy tool is harmless for non-Claude Kiro models as it only activates when both conditions above are met.

### Code Change

**Before:**
```swift
"options": [
    "apiKey": config.apiKey,
    "baseURL": "\(baseURL)/v1"
]
```

**After:**
```swift
"options": [
    "apiKey": config.apiKey,
    "baseURL": "\(baseURL)/v1",
    "litellmProxy": true
]
```

## Changes

- Modified `Quotio/Services/AgentConfigurationService.swift`
  - `generateOpenCodeConfig()`: added `"litellmProxy": true` to provider options dictionary

## Testing

- ✅ Quotio OpenCode configure → `opencode.json` contains `litellmProxy: true`
- ✅ opencode normal conversation with Kiro Claude model works without regression
- ✅ opencode `/compact` with Kiro Claude model succeeds without "Improperly formed request" error
- ✅ Kiro Gemini/GPT models unaffected (no dummy tool inserted when history has no tool calls)

## Related

- Fixes #268 (Claude Code 无法清理上下文)
- Related: [opencode#2915](https://github.com/anomalyco/opencode/issues/2915) (LiteLLM dummy tool workaround — same mechanism)
- Related: [CLIProxyAPIPlus#212](https://github.com/router-for-me/CLIProxyAPIPlus/pull/212) (orphaned tool_result filtering — related compact fix)
- Affects opencode `/compact` with **Kiro Claude models** via CLIProxyAPIPlus