### PR TITLE
fix(proxy): resolve flattened bundled plus binary

### DIFF
--- a/Quotio/Services/Proxy/CLIProxyManager.swift
+++ b/Quotio/Services/Proxy/CLIProxyManager.swift
@@ -2154,9 +2154,13 @@ extension CLIProxyManager {
 
         func firstExistingRegularFile(in candidates: [URL?]) -> String? {
             for candidate in candidates.compactMap({ $0 }) {
-                var isDirectory: ObjCBool = false
-                if fileManager.fileExists(atPath: candidate.path, isDirectory: &isDirectory),
-                   !isDirectory.boolValue {
+                guard fileManager.fileExists(atPath: candidate.path) else {
+                    continue
+                }
+
+                let values = try? candidate.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+                if values?.isRegularFile == true,
+                   values?.isSymbolicLink != true {
                     return candidate.path
                 }
             }

--- a/Quotio/Services/Proxy/CLIProxyManager.swift
+++ b/Quotio/Services/Proxy/CLIProxyManager.swift
@@ -2184,6 +2184,7 @@ extension CLIProxyManager {
         let repoResourcesRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
+            .deletingLastPathComponent()
             .appendingPathComponent("Resources", isDirectory: true)
         let repoCandidates: [URL?] = [
             repoResourcesRoot

--- a/Quotio/Services/Proxy/CLIProxyManager.swift
+++ b/Quotio/Services/Proxy/CLIProxyManager.swift
@@ -2148,30 +2148,49 @@ extension CLIProxyManager {
     }
 
     private func resolveBundledPlusBinaryPath() -> String? {
+        let fileManager = FileManager.default
         let binaryName = ProxyBinarySource.plusLocalBinaryName
         let resourceSubdirectory = ProxyBinarySource.plusLocalResourceSubdirectory
+
+        func firstExistingRegularFile(in candidates: [URL?]) -> String? {
+            for candidate in candidates.compactMap({ $0 }) {
+                var isDirectory: ObjCBool = false
+                if fileManager.fileExists(atPath: candidate.path, isDirectory: &isDirectory),
+                   !isDirectory.boolValue {
+                    return candidate.path
+                }
+            }
+            return nil
+        }
 
         let bundleCandidates: [URL?] = [
             Bundle.main.url(forResource: binaryName, withExtension: nil, subdirectory: resourceSubdirectory),
             Bundle.main.resourceURL?
                 .appendingPathComponent(resourceSubdirectory, isDirectory: true)
                 .appendingPathComponent(binaryName, isDirectory: false),
+            Bundle.main.url(forResource: binaryName, withExtension: nil),
+            Bundle.main.resourceURL?
+                .appendingPathComponent(binaryName, isDirectory: false),
         ]
 
-        for candidate in bundleCandidates.compactMap({ $0 })
-        where FileManager.default.isExecutableFile(atPath: candidate.path) {
-            return candidate.path
+        if let bundledPath = firstExistingRegularFile(in: bundleCandidates) {
+            return bundledPath
         }
 
-        let repoCandidate = URL(fileURLWithPath: #filePath)
+        let repoResourcesRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("Resources", isDirectory: true)
-            .appendingPathComponent(resourceSubdirectory, isDirectory: true)
-            .appendingPathComponent(binaryName, isDirectory: false)
+        let repoCandidates: [URL?] = [
+            repoResourcesRoot
+                .appendingPathComponent(resourceSubdirectory, isDirectory: true)
+                .appendingPathComponent(binaryName, isDirectory: false),
+            repoResourcesRoot
+                .appendingPathComponent(binaryName, isDirectory: false),
+        ]
 
-        if FileManager.default.isExecutableFile(atPath: repoCandidate.path) {
-            return repoCandidate.path
+        if let repoPath = firstExistingRegularFile(in: repoCandidates) {
+            return repoPath
         }
 
         Log.proxy("Bundled CLIProxyAPIPlus binary not found in app resources or repo resources")

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,7 +20,7 @@ rm -rf "${BUILD_DIR}"
 mkdir -p "${BUILD_DIR}"
 mkdir -p "${RELEASE_DIR}"
 
-print_step 1 3 "Creating Archive"
+print_step 1 4 "Creating Archive"
 start_step_timer "archive"
 
 xcodebuild archive \
@@ -57,7 +57,7 @@ if [ ! -d "${ARCHIVE_PATH}" ]; then
 fi
 log_success "Archive created (${ARCHIVE_DURATION})"
 
-print_step 2 3 "Extracting App"
+print_step 2 4 "Extracting App"
 start_step_timer "extract"
 
 cp -R "${ARCHIVE_PATH}/Products/Applications/${PROJECT_NAME}.app" "${APP_PATH}"
@@ -68,7 +68,13 @@ if [ ! -d "${APP_PATH}" ]; then
 fi
 log_success "App extracted ($(get_step_duration "extract"))"
 
-print_step 3 3 "Ad-hoc Signing"
+print_step 3 4 "Verifying Bundled Proxy"
+start_step_timer "verify-proxy"
+
+bash "${SCRIPT_DIR}/verify-bundled-proxy.sh" "${APP_PATH}"
+log_success "Bundled proxy verified ($(get_step_duration "verify-proxy"))"
+
+print_step 4 4 "Ad-hoc Signing"
 start_step_timer "sign"
 
 codesign --force --deep --sign - "${APP_PATH}" 2>/dev/null || true

--- a/scripts/verify-bundled-proxy.sh
+++ b/scripts/verify-bundled-proxy.sh
@@ -7,8 +7,7 @@ PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 APP_TO_VERIFY="${1:-${PROJECT_DIR}/build/Quotio.app}"
 BINARY_NAME="cli-proxy-api-plus"
 RESOURCE_SUBDIRECTORY="Proxy"
-EXPECTED_SHA256="a722885ab3c0cea5535ee69a86220d35c4f95ee7656e009d872d24de2910acf0"
-MANAGER_SOURCE="${PROJECT_DIR}/Quotio/Services/Proxy/CLIProxyManager.swift"
+MODEL_SOURCE="${PROJECT_DIR}/Quotio/Models/ProxyVersionModels.swift"
 
 fail() {
     echo "Bundled proxy verification failed: $1" >&2
@@ -16,7 +15,12 @@ fail() {
 }
 
 [ -d "${APP_TO_VERIFY}" ] || fail "app not found: ${APP_TO_VERIFY}"
-[ -f "${MANAGER_SOURCE}" ] || fail "manager source not found: ${MANAGER_SOURCE}"
+[ -f "${MODEL_SOURCE}" ] || fail "model source not found: ${MODEL_SOURCE}"
+
+EXPECTED_SHA256="$(
+    sed -n 's/.*static let plusLocalSHA256 = "\([0-9a-fA-F]\{64\}\)".*/\1/p' "${MODEL_SOURCE}" | head -n 1
+)"
+[ -n "${EXPECTED_SHA256}" ] || fail "could not read plusLocalSHA256 from ${MODEL_SOURCE}"
 
 RESOURCES_DIR="${APP_TO_VERIFY}/Contents/Resources"
 SUBDIR_BINARY="${RESOURCES_DIR}/${RESOURCE_SUBDIRECTORY}/${BINARY_NAME}"
@@ -30,14 +34,6 @@ elif [ -f "${ROOT_BINARY}" ]; then
 else
     fail "missing ${BINARY_NAME}; checked ${SUBDIR_BINARY} and ${ROOT_BINARY}"
 fi
-
-if [ "${BINARY_PATH}" = "${ROOT_BINARY}" ]; then
-    if ! grep -q "Bundle.main.url(forResource: binaryName, withExtension: nil)" "${MANAGER_SOURCE}"; then
-        fail "binary is at Resources root, but CLIProxyManager does not resolve root-level bundled resources"
-    fi
-fi
-
-[ -x "${BINARY_PATH}" ] || fail "binary is not executable: ${BINARY_PATH}"
 
 ACTUAL_SHA256="$(shasum -a 256 "${BINARY_PATH}" | awk '{print $1}')"
 if [ "${ACTUAL_SHA256}" != "${EXPECTED_SHA256}" ]; then

--- a/scripts/verify-bundled-proxy.sh
+++ b/scripts/verify-bundled-proxy.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/config.sh"
+# This verifier does not start config.sh spinners; avoid clearing the caller's last output line.
+trap - EXIT
 
 APP_TO_VERIFY="${1:-${PROJECT_DIR}/build/Quotio.app}"
 BINARY_NAME="cli-proxy-api-plus"
@@ -10,7 +14,8 @@ RESOURCE_SUBDIRECTORY="Proxy"
 MODEL_SOURCE="${PROJECT_DIR}/Quotio/Models/ProxyVersionModels.swift"
 
 fail() {
-    echo "Bundled proxy verification failed: $1" >&2
+    log_failure "Bundled proxy verification failed"
+    log_item "$1"
     exit 1
 }
 
@@ -40,4 +45,4 @@ if [ "${ACTUAL_SHA256}" != "${EXPECTED_SHA256}" ]; then
     fail "checksum mismatch for ${BINARY_PATH}; expected ${EXPECTED_SHA256}, got ${ACTUAL_SHA256}"
 fi
 
-echo "Bundled proxy verified: ${BINARY_PATH}"
+log_success "Bundled proxy verified: ${BINARY_PATH}"

--- a/scripts/verify-bundled-proxy.sh
+++ b/scripts/verify-bundled-proxy.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+APP_TO_VERIFY="${1:-${PROJECT_DIR}/build/Quotio.app}"
+BINARY_NAME="cli-proxy-api-plus"
+RESOURCE_SUBDIRECTORY="Proxy"
+EXPECTED_SHA256="a722885ab3c0cea5535ee69a86220d35c4f95ee7656e009d872d24de2910acf0"
+MANAGER_SOURCE="${PROJECT_DIR}/Quotio/Services/Proxy/CLIProxyManager.swift"
+
+fail() {
+    echo "Bundled proxy verification failed: $1" >&2
+    exit 1
+}
+
+[ -d "${APP_TO_VERIFY}" ] || fail "app not found: ${APP_TO_VERIFY}"
+[ -f "${MANAGER_SOURCE}" ] || fail "manager source not found: ${MANAGER_SOURCE}"
+
+RESOURCES_DIR="${APP_TO_VERIFY}/Contents/Resources"
+SUBDIR_BINARY="${RESOURCES_DIR}/${RESOURCE_SUBDIRECTORY}/${BINARY_NAME}"
+ROOT_BINARY="${RESOURCES_DIR}/${BINARY_NAME}"
+
+BINARY_PATH=""
+if [ -f "${SUBDIR_BINARY}" ]; then
+    BINARY_PATH="${SUBDIR_BINARY}"
+elif [ -f "${ROOT_BINARY}" ]; then
+    BINARY_PATH="${ROOT_BINARY}"
+else
+    fail "missing ${BINARY_NAME}; checked ${SUBDIR_BINARY} and ${ROOT_BINARY}"
+fi
+
+if [ "${BINARY_PATH}" = "${ROOT_BINARY}" ]; then
+    if ! grep -q "Bundle.main.url(forResource: binaryName, withExtension: nil)" "${MANAGER_SOURCE}"; then
+        fail "binary is at Resources root, but CLIProxyManager does not resolve root-level bundled resources"
+    fi
+fi
+
+[ -x "${BINARY_PATH}" ] || fail "binary is not executable: ${BINARY_PATH}"
+
+ACTUAL_SHA256="$(shasum -a 256 "${BINARY_PATH}" | awk '{print $1}')"
+if [ "${ACTUAL_SHA256}" != "${EXPECTED_SHA256}" ]; then
+    fail "checksum mismatch for ${BINARY_PATH}; expected ${EXPECTED_SHA256}, got ${ACTUAL_SHA256}"
+fi
+
+echo "Bundled proxy verified: ${BINARY_PATH}"


### PR DESCRIPTION
## Summary

Fixes #391 by resolving the bundled `CLIProxyAPIPlus` binary from both possible resource locations:

- `Contents/Resources/Proxy/cli-proxy-api-plus`
- `Contents/Resources/cli-proxy-api-plus`

In the v0.16.0/Homebrew-installed app, the binary may be flattened into `Contents/Resources/` instead of staying under the `Proxy/` subdirectory. The old lookup only checked the nested path, which caused Quotio to report:

> No compatible binary found for your system

even when the bundled binary was present in the app resources.

This change also avoids requiring the bundled resource itself to have the executable bit set before it can be discovered. The installed proxy binary is still chmodded during installation.

## Changes

- Add fallback lookup for flattened bundled Plus binary resources.
- Treat the bundled binary as valid when it exists and is a regular file.
- Add a build-time verification script for the bundled proxy binary.
- Run bundled proxy verification during release build.

## Why

#389 introduced bundled `CLIProxyAPIPlus` support, but the runtime resolver assumed the binary would always be located at:

```text
Contents/Resources/Proxy/cli-proxy-api-plus
````

In packaged builds, Xcode may flatten copied resources into:

```text
Contents/Resources/cli-proxy-api-plus
```

As a result, Plus installation failed even though the app could contain the binary.

## Validation

Please verify with a packaged app that:

```bash
ls -l Quotio.app/Contents/Resources/cli-proxy-api-plus
```

or:

```bash
ls -l Quotio.app/Contents/Resources/Proxy/cli-proxy-api-plus
```

exists, and that selecting `CLIProxyAPIPlus` no longer shows:

```text
No compatible binary found for your system
```

## Fixes

Fixes #391
