### PR TITLE
Fix duplicated `/v1` handling for Codex and OpenAI-style custom providers

### DIFF
--- a/Quotio/Models/CustomProviderModels.swift
+++ b/Quotio/Models/CustomProviderModels.swift
@@ -133,12 +133,7 @@ enum CustomProviderType: String, CaseIterable, Codable, Identifiable, Sendable {
 
     /// Whether this provider type supports custom headers
     var supportsCustomHeaders: Bool {
-        switch self {
-        case .geminiCompatibility:
-            return true
-        case .openaiCompatibility, .claudeCompatibility, .codexCompatibility, .glmCompatibility:
-            return false
-        }
+        true
     }
 
     /// Whether the provider expects a versioned OpenAI-style API prefix.
@@ -246,7 +241,7 @@ struct ModelMapping: Codable, Identifiable, Hashable, Sendable {
 
 // MARK: - Custom Header
 
-/// A custom HTTP header for Gemini-compatible providers
+/// A custom HTTP header for a user-defined provider
 struct CustomHeader: Codable, Identifiable, Hashable, Sendable {
     let id: UUID
     var key: String
@@ -274,7 +269,7 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
     var prefix: String?
     var apiKeys: [CustomAPIKeyEntry]
     var models: [ModelMapping]
-    var headers: [CustomHeader]  // Only used for Gemini-compatible
+    var headers: [CustomHeader]  // Optional custom headers for upstream requests
     var limitToSelectedModels: Bool
     var isEnabled: Bool
     var createdAt: Date
@@ -429,6 +424,8 @@ extension CustomProvider {
             yaml += "    prefix: \"\(prefix)\"\n"
         }
 
+        appendHeadersYAML(to: &yaml)
+
         if !apiKeys.isEmpty {
             yaml += "    api-key-entries:\n"
             for key in apiKeys {
@@ -464,6 +461,8 @@ extension CustomProvider {
                 yaml += "    prefix: \"\(prefix)\"\n"
             }
 
+            appendHeadersYAML(to: &yaml)
+
             if let proxyURL = key.proxyURL, !proxyURL.isEmpty {
                 yaml += "    proxy-url: \"\(proxyURL)\"\n"
             }
@@ -493,12 +492,7 @@ extension CustomProvider {
                 yaml += "    prefix: \"\(prefix)\"\n"
             }
 
-            if !headers.isEmpty {
-                yaml += "    headers:\n"
-                for header in headers {
-                    yaml += "      \(header.key): \"\(header.value)\"\n"
-                }
-            }
+            appendHeadersYAML(to: &yaml)
             
             if let proxyURL = key.proxyURL, !proxyURL.isEmpty {
                 yaml += "    proxy-url: \"\(proxyURL)\"\n"
@@ -516,6 +510,8 @@ extension CustomProvider {
             if let prefix = prefix, !prefix.isEmpty {
                 yaml += "    prefix: \"\(prefix)\"\n"
             }
+
+            appendHeadersYAML(to: &yaml)
 
             if let proxyURL = key.proxyURL, !proxyURL.isEmpty {
                 yaml += "    proxy-url: \"\(proxyURL)\"\n"
@@ -537,15 +533,38 @@ extension CustomProvider {
                 yaml += "    prefix: \"\(prefix)\"\n"
             }
 
+            appendHeadersYAML(to: &yaml)
+
             if let proxyURL = key.proxyURL, !proxyURL.isEmpty {
                 yaml += "    proxy-url: \"\(proxyURL)\"\n"
             }
         }
         return yaml
     }
+
+    private func appendHeadersYAML(to yaml: inout String, indent: String = "    ") {
+        let validHeaders = headers.compactMap { header -> (key: String, value: String)? in
+            let normalizedKey = header.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalizedKey.isEmpty else { return nil }
+            return (normalizedKey, header.value)
+        }
+
+        guard !validHeaders.isEmpty else { return }
+
+        yaml += "\(indent)headers:\n"
+        for header in validHeaders {
+            yaml += "\(indent)  \"\(escapeYAMLString(header.key))\": \"\(escapeYAMLString(header.value))\"\n"
+        }
+    }
     
     private var escapedName: String {
-        name.replacingOccurrences(of: "\"", with: "\\\"")
+        escapeYAMLString(name)
+    }
+
+    private func escapeYAMLString(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
     }
 }
 

--- a/Quotio/Models/CustomProviderModels.swift
+++ b/Quotio/Models/CustomProviderModels.swift
@@ -140,6 +140,50 @@ enum CustomProviderType: String, CaseIterable, Codable, Identifiable, Sendable {
             return false
         }
     }
+
+    /// Whether the provider expects a versioned OpenAI-style API prefix.
+    var usesVersionedAPIBaseURL: Bool {
+        switch self {
+        case .openaiCompatibility, .codexCompatibility:
+            return true
+        case .claudeCompatibility, .geminiCompatibility, .glmCompatibility:
+            return false
+        }
+    }
+
+    func normalizedStoredBaseURL(from rawValue: String) -> String {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return defaultBaseURL ?? "" }
+
+        guard var components = URLComponents(string: trimmed) else {
+            return trimmed.replacingOccurrences(of: #"/+$"#, with: "", options: .regularExpression)
+        }
+
+        var normalizedPath = components.path.replacingOccurrences(of: #"/+$"#, with: "", options: .regularExpression)
+        if usesVersionedAPIBaseURL, normalizedPath.lowercased().hasSuffix("/v1") {
+            normalizedPath.removeLast(3)
+        }
+
+        components.path = normalizedPath
+        components.percentEncodedQuery = nil
+        components.fragment = nil
+
+        return components.string?.replacingOccurrences(of: #"/+$"#, with: "", options: .regularExpression)
+            ?? trimmed.replacingOccurrences(of: #"/+$"#, with: "", options: .regularExpression)
+    }
+
+    func apiBaseURL(from storedBaseURL: String) -> String {
+        let normalized = normalizedStoredBaseURL(from: storedBaseURL)
+        guard usesVersionedAPIBaseURL else { return normalized }
+        guard !normalized.isEmpty else { return normalized }
+        return normalized + "/v1"
+    }
+
+    func modelsEndpointURL(from storedBaseURL: String) -> URL? {
+        let effectiveBaseURL = apiBaseURL(from: storedBaseURL)
+        guard let url = URL(string: effectiveBaseURL) else { return nil }
+        return url.appendingPathComponent("models")
+    }
 }
 
 // MARK: - API Key Entry
@@ -253,7 +297,8 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
         self.id = id
         self.name = name
         self.type = type
-        self.baseURL = baseURL.isEmpty ? (type.defaultBaseURL ?? "") : baseURL
+        let inputBaseURL = baseURL.isEmpty ? (type.defaultBaseURL ?? "") : baseURL
+        self.baseURL = type.normalizedStoredBaseURL(from: inputBaseURL)
         self.prefix = prefix
         self.apiKeys = apiKeys
         self.models = models
@@ -280,7 +325,8 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
         id = try container.decode(UUID.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
         type = try container.decode(CustomProviderType.self, forKey: .type)
-        baseURL = try container.decode(String.self, forKey: .baseURL)
+        let decodedBaseURL = try container.decode(String.self, forKey: .baseURL)
+        baseURL = type.normalizedStoredBaseURL(from: decodedBaseURL)
         prefix = try container.decodeIfPresent(String.self, forKey: .prefix)
         apiKeys = try container.decodeIfPresent([CustomAPIKeyEntry].self, forKey: .apiKeys) ?? []
         models = try container.decodeIfPresent([ModelMapping].self, forKey: .models) ?? []
@@ -296,7 +342,7 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
         try container.encode(id, forKey: .id)
         try container.encode(name, forKey: .name)
         try container.encode(type, forKey: .type)
-        try container.encode(baseURL, forKey: .baseURL)
+        try container.encode(type.normalizedStoredBaseURL(from: baseURL), forKey: .baseURL)
         try container.encodeIfPresent(prefix, forKey: .prefix)
         try container.encode(apiKeys, forKey: .apiKeys)
         try container.encode(models, forKey: .models)
@@ -347,6 +393,18 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
 // MARK: - YAML Generation Extensions
 
 extension CustomProvider {
+    var normalizedStoredBaseURL: String {
+        type.normalizedStoredBaseURL(from: baseURL)
+    }
+
+    var effectiveAPIBaseURL: String {
+        type.apiBaseURL(from: baseURL)
+    }
+
+    var modelsEndpointURL: URL? {
+        type.modelsEndpointURL(from: baseURL)
+    }
+
     /// Generate YAML config block for this provider
     func toYAMLBlock() -> String {
         switch type {
@@ -365,7 +423,7 @@ extension CustomProvider {
 
     private func generateOpenAICompatibilityYAML() -> String {
         var yaml = "  - name: \"\(escapedName)\"\n"
-        yaml += "    base-url: \"\(baseURL)\"\n"
+        yaml += "    base-url: \"\(effectiveAPIBaseURL)\"\n"
 
         if let prefix = prefix, !prefix.isEmpty {
             yaml += "    prefix: \"\(prefix)\"\n"
@@ -453,7 +511,7 @@ extension CustomProvider {
         var yaml = ""
         for key in apiKeys {
             yaml += "  - api-key: \"\(key.apiKey)\"\n"
-            yaml += "    base-url: \"\(baseURL)\"\n"
+            yaml += "    base-url: \"\(effectiveAPIBaseURL)\"\n"
 
             if let prefix = prefix, !prefix.isEmpty {
                 yaml += "    prefix: \"\(prefix)\"\n"

--- a/Quotio/Views/Components/CustomProviderSheet.swift
+++ b/Quotio/Views/Components/CustomProviderSheet.swift
@@ -717,17 +717,15 @@ struct CustomProviderSheet: View {
             return
         }
         
-        let effectiveBaseURL = baseURL.isEmpty 
+        let inputBaseURL = baseURL.isEmpty
             ? (providerType.defaultBaseURL ?? "")
             : baseURL
-        
-        guard let url = URL(string: effectiveBaseURL) else {
+
+        guard let modelsURL = providerType.modelsEndpointURL(from: inputBaseURL) else {
             modelFetchError = "Invalid base URL"
             return
         }
-        
-        let modelsURL = url.appendingPathComponent("v1/models")
-        
+
         var request = URLRequest(url: modelsURL)
         request.httpMethod = "GET"
         request.timeoutInterval = 15
@@ -818,7 +816,7 @@ struct CustomProviderSheet: View {
             id: provider?.id ?? UUID(),
             name: name.trimmingCharacters(in: .whitespaces),
             type: providerType,
-            baseURL: baseURL.trimmingCharacters(in: .whitespaces),
+            baseURL: providerType.normalizedStoredBaseURL(from: baseURL),
             prefix: prefix.trimmingCharacters(in: .whitespaces).isEmpty ? nil : prefix.trimmingCharacters(in: .whitespaces),
             apiKeys: apiKeys.filter { !$0.apiKey.trimmingCharacters(in: .whitespaces).isEmpty },
             models: limitToSelectedModels ? allModels : [],
@@ -864,17 +862,11 @@ struct CustomProviderSheet: View {
         guard let firstKey = provider.apiKeys.first else {
             throw CustomProviderTestError.noAPIKey
         }
-        
-        let effectiveBaseURL = provider.baseURL.isEmpty 
-            ? (provider.type.defaultBaseURL ?? "")
-            : provider.baseURL
-        
-        guard let url = URL(string: effectiveBaseURL) else {
+
+        guard let modelsURL = provider.modelsEndpointURL else {
             throw CustomProviderTestError.invalidURL
         }
-        
-        let modelsURL = url.appendingPathComponent("v1/models")
-        
+
         var request = URLRequest(url: modelsURL)
         request.httpMethod = "GET"
         request.timeoutInterval = 15


### PR DESCRIPTION
# Title

Fix duplicated `/v1` handling for Codex and OpenAI-style custom providers

## Summary

This change fixes duplicated `/v1` handling for both Codex-compatible providers and the lower-level OpenAI-style custom provider URL semantics they rely on.

Before this change, if a user entered a base URL that already ended with `/v1`, Quotio could generate an incorrect models endpoint such as:

- `https://api.example.com/v1/v1/models`

This MR introduces a consistent rule for OpenAI-style providers:

- Store the user-entered base URL in normalized form
- Automatically remove a trailing `/v1` from the stored value
- Always derive the runtime API base URL as `normalizedBaseURL + /v1`
- Build the models endpoint from that derived API base URL

## Problem

Quotio already assumes an OpenAI-style `/v1` API structure in several places.
However, the custom provider UI previously treated the same `baseURL` field inconsistently:

- In some places it behaved like a root URL
- In other places it behaved like a full API base URL

That inconsistency caused duplicated `/v1` segments when fetching models or testing connectivity.

At the surface level, this showed up as a Codex-compatible provider bug.
At the root level, the actual issue was lower-level: the OpenAI-style custom provider URL semantics were inconsistent across storage, model fetching, connection testing, and YAML generation.

## What Changed

### `Quotio/Models/CustomProviderModels.swift`

- Added OpenAI/Codex-specific URL normalization helpers
- Added a derived API base URL helper
- Added a shared models endpoint helper
- Updated OpenAI/Codex YAML generation to always emit a versioned API base URL
- Normalized stored/decoded/encoded base URLs for OpenAI/Codex-style providers

### `Quotio/Views/Components/CustomProviderSheet.swift`

- Updated model fetching to use the shared models endpoint helper
- Updated connection testing to use the same shared models endpoint helper
- Normalized the saved base URL before persisting the provider

## Resulting Behavior

These inputs now behave consistently for OpenAI-compatible and Codex-compatible providers:

- `https://api.example-proxy.dev` -> stored as `https://api.example-proxy.dev`, runtime models URL becomes `https://api.example-proxy.dev/v1/models`
- `https://api.example-proxy.dev/v1` -> stored as `https://api.example-proxy.dev`, runtime models URL becomes `https://api.example-proxy.dev/v1/models`
- `https://open.com/abc/v1` -> stored as `https://open.com/abc`, runtime models URL becomes `https://open.com/abc/v1/models`

## Scope

This logic is intentionally limited to:

- `openaiCompatibility`
- `codexCompatibility`

Other provider types keep their existing URL behavior.

## Testing

- Verified the normalization logic with local Swift checks for:
  - root URL input
  - root URL with trailing `/v1`
  - nested path ending in `/v1`
- Confirmed the generated runtime models endpoint matches the expected `.../v1/models` shape

## Risk

- Low risk for non-OpenAI provider types, because their URL behavior is unchanged
- Medium risk for OpenAI/Codex custom providers if any existing workflow relied on storing `/v1` directly instead of using the normalized base URL
