### PR TITLE
fix: OpenAi Copmtile 类型的provider base Url 问题修复

### DIFF
--- a/Quotio/Views/Components/CustomProviderSheet.swift
+++ b/Quotio/Views/Components/CustomProviderSheet.swift
@@ -713,7 +713,7 @@ struct CustomProviderSheet: View {
 
     private func normalizedBaseURL(_ rawValue: String, for type: CustomProviderType) -> String {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard type == .codexCompatibility, !trimmed.isEmpty,
+        guard (type == .openaiCompatibility || type == .codexCompatibility), !trimmed.isEmpty,
               var components = URLComponents(string: trimmed) else {
             return trimmed
         }


### PR DESCRIPTION
base url 携带/v1 fetch models 时报错，但是不携带/v1  fetch models 成功时 ，调用 chat/completions 接口时 完整的url 缺失/v1 导致请求报错