### PR TITLE
fix(proxy): match aarch64 asset names for CLIProxyAPI v6.9.48+

### DIFF
--- a/Quotio/Services/Proxy/CLIProxyManager.swift
+++ b/Quotio/Services/Proxy/CLIProxyManager.swift
@@ -650,27 +650,25 @@ final class CLIProxyManager {
     }
     
     private func findCompatibleAsset(in release: ReleaseInfo) -> CompatibleAsset? {
+        // Upstream renamed assets from `darwin_arm64` -> `darwin_aarch64` starting v6.9.48.
+        // Accept both spellings so we don't get stuck on an old release.
         #if arch(arm64)
-        let arch = "arm64"
+        let targetPatterns = ["darwin_arm64", "darwin_aarch64"]
         #else
-        let arch = "amd64"
+        let targetPatterns = ["darwin_amd64", "darwin_x86_64"]
         #endif
-        
-        let platform = "darwin"
-        let targetPattern = "\(platform)_\(arch)"
-        let skipPatterns = ["windows", "linux", "checksum"]
-        
+        let skipPatterns = ["windows", "linux", "freebsd", "checksum"]
+
         for asset in release.assets {
             let lowercaseName = asset.name.lowercased()
-            
-            let shouldSkip = skipPatterns.contains { lowercaseName.contains($0) }
-            if shouldSkip { continue }
-            
-            if lowercaseName.contains(targetPattern) {
+
+            if skipPatterns.contains(where: { lowercaseName.contains($0) }) { continue }
+
+            if targetPatterns.contains(where: { lowercaseName.contains($0) }) {
                 return CompatibleAsset(name: asset.name, downloadURL: asset.browserDownloadUrl)
             }
         }
-        
+
         return nil
     }
     
@@ -1597,27 +1595,25 @@ extension CLIProxyManager {
     
     /// Find compatible asset from GitHub release.
     private func findCompatibleAsset(from release: GitHubRelease) -> GitHubAsset? {
+        // Upstream renamed assets from `darwin_arm64` -> `darwin_aarch64` starting v6.9.48.
+        // Accept both spellings so we don't get stuck on an old release.
         #if arch(arm64)
-        let arch = "arm64"
+        let targetPatterns = ["darwin_arm64", "darwin_aarch64"]
         #else
-        let arch = "amd64"
+        let targetPatterns = ["darwin_amd64", "darwin_x86_64"]
         #endif
-        
-        let platform = "darwin"
-        let targetPattern = "\(platform)_\(arch)"
-        let skipPatterns = ["windows", "linux", "checksum"]
-        
+        let skipPatterns = ["windows", "linux", "freebsd", "checksum"]
+
         for asset in release.assets {
             let lowercaseName = asset.name.lowercased()
-            
-            let shouldSkip = skipPatterns.contains { lowercaseName.contains($0) }
-            if shouldSkip { continue }
-            
-            if lowercaseName.contains(targetPattern) {
+
+            if skipPatterns.contains(where: { lowercaseName.contains($0) }) { continue }
+
+            if targetPatterns.contains(where: { lowercaseName.contains($0) }) {
                 return asset
             }
         }
-        
+
         return nil
     }
     


### PR DESCRIPTION
## Summary

The Advanced Mode "Available Versions" list and the latest-version installer were silently capped at CLIProxyAPI **v6.9.47** on Apple Silicon, even though v6.9.48 through v6.10.x had been released.

## Root cause

Starting with v6.9.48, upstream renamed the macOS ARM asset:

| Version           | ARM asset                                  |
| ----------------- | ------------------------------------------ |
| v6.9.47 and older | `CLIProxyAPI_<ver>_darwin_arm64.tar.gz`    |
| v6.9.48 and newer | `CLIProxyAPI_<ver>_darwin_aarch64.tar.gz`  |

Both `findCompatibleAsset` overloads in `CLIProxyManager.swift` hard-coded the substring `darwin_arm64` on Apple Silicon. `fetchAvailableUpstreamVersions` does `releases.compactMap { versionInfo(from: $0) }`, so any release without a matching asset was dropped from the installable list. Result: every release >= v6.9.48 disappeared on Apple Silicon and the newest "available" version became v6.9.47.

Intel Macs were unaffected (the `darwin_amd64` name did not change).

The Atom feed update notifier was not affected — it only parses the release tag, not asset names.

## Fix

Both `findCompatibleAsset` overloads now accept either spelling:

- Apple Silicon: `darwin_arm64` or `darwin_aarch64`
- Intel: `darwin_amd64` or `darwin_x86_64` (defensive, in case upstream applies a similar rename later)

`freebsd` was added to the skip list — currently redundant because `darwin_aarch64` is not a substring of `freebsd_aarch64`, but makes the intent explicit now that FreeBSD assets exist.

## Test plan

- On Apple Silicon, open Settings → Proxy → Advanced and confirm v6.9.48 through v6.10.x are listed
- Install the newest version; confirm the `darwin_aarch64` asset is downloaded, extracted, and signed correctly
- Intel build still picks `darwin_amd64`

## Files

- `Quotio/Services/Proxy/CLIProxyManager.swift` — both `findCompatibleAsset` overloads