### PR TITLE
fix: detect aarch64 CLIProxyAPI releases

### DIFF
--- a/Quotio/Services/Proxy/CLIProxyManager.swift
+++ b/Quotio/Services/Proxy/CLIProxyManager.swift
@@ -651,13 +651,10 @@ final class CLIProxyManager {
     
     private func findCompatibleAsset(in release: ReleaseInfo) -> CompatibleAsset? {
         #if arch(arm64)
-        let arch = "arm64"
+        let targetPatterns = ["darwin_arm64", "darwin_aarch64"]
         #else
-        let arch = "amd64"
+        let targetPatterns = ["darwin_amd64"]
         #endif
-        
-        let platform = "darwin"
-        let targetPattern = "\(platform)_\(arch)"
         let skipPatterns = ["windows", "linux", "checksum"]
         
         for asset in release.assets {
@@ -666,7 +663,7 @@ final class CLIProxyManager {
             let shouldSkip = skipPatterns.contains { lowercaseName.contains($0) }
             if shouldSkip { continue }
             
-            if lowercaseName.contains(targetPattern) {
+            if targetPatterns.contains(where: { lowercaseName.contains($0) }) {
                 return CompatibleAsset(name: asset.name, downloadURL: asset.browserDownloadUrl)
             }
         }
@@ -1598,13 +1595,10 @@ extension CLIProxyManager {
     /// Find compatible asset from GitHub release.
     private func findCompatibleAsset(from release: GitHubRelease) -> GitHubAsset? {
         #if arch(arm64)
-        let arch = "arm64"
+        let targetPatterns = ["darwin_arm64", "darwin_aarch64"]
         #else
-        let arch = "amd64"
+        let targetPatterns = ["darwin_amd64"]
         #endif
-        
-        let platform = "darwin"
-        let targetPattern = "\(platform)_\(arch)"
         let skipPatterns = ["windows", "linux", "checksum"]
         
         for asset in release.assets {
@@ -1613,7 +1607,7 @@ extension CLIProxyManager {
             let shouldSkip = skipPatterns.contains { lowercaseName.contains($0) }
             if shouldSkip { continue }
             
-            if lowercaseName.contains(targetPattern) {
+            if targetPatterns.contains(where: { lowercaseName.contains($0) }) {
                 return asset
             }
         }


### PR DESCRIPTION
## Summary
- detect upstream CLIProxyAPI macOS Apple Silicon assets published as `darwin_aarch64`
- keep legacy `darwin_arm64` matching and Intel `darwin_amd64` matching
- apply the same matching rule to both release lookup paths

## Root cause
The upstream CLIProxyAPI release assets now use `darwin_aarch64`, while Quotio only searched for `darwin_arm64`, so update checks found the latest tag but failed to find a compatible asset and displayed Up to date.

## Verification
- confirmed latest CLIProxyAPI release `v6.10.4` includes `CLIProxyAPI_6.10.4_darwin_aarch64.tar.gz` with a SHA256 digest
- `git diff --check`
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build CODE_SIGNING_ALLOWED=NO`