### PR TITLE
fix proxy recovery on unsupported dashboard stats

### DIFF
--- a/Quotio/Services/Proxy/CLIProxyManager.swift
+++ b/Quotio/Services/Proxy/CLIProxyManager.swift
@@ -1004,6 +1004,49 @@ final class CLIProxyManager {
         process = nil
         proxyStatus.running = false
     }
+
+    /// Stop the proxy and wait for process/port cleanup to complete.
+    /// Used by recovery paths that immediately restart, so the detached cleanup in stop()
+    /// cannot race with and kill the newly started process by port.
+    func stopAndWait() async {
+        terminateAuthProcess()
+        stopHealthMonitor()
+        cancelCrashRestart()
+
+        if proxyBridge.isRunning {
+            proxyBridge.stop()
+        }
+
+        let currentProcess = process
+        let userPort = proxyStatus.port
+        let bridgeMode = useBridgeMode
+        let intPort = internalPort
+        markExpectedTermination(currentProcess)
+
+        process = nil
+        proxyStatus.running = false
+
+        await Task.detached(priority: .userInitiated) {
+            if let proc = currentProcess, proc.isRunning {
+                let pid = proc.processIdentifier
+                proc.terminate()
+
+                let deadline = Date().addingTimeInterval(2.0)
+                while proc.isRunning && Date() < deadline {
+                    usleep(100_000)
+                }
+
+                if proc.isRunning {
+                    kill(pid, SIGKILL)
+                }
+            }
+
+            Self.killProcessOnPortSync(userPort)
+            if bridgeMode {
+                Self.killProcessOnPortSync(intPort)
+            }
+        }.value
+    }
     
     // ════════════════════════════════════════════════════════════════════════
     // MARK: - Health Monitoring

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -1099,8 +1099,14 @@ final class QuotaViewModel {
         if proxyManager.proxyStatus.running {
             // Proxy process is running but not responding - likely hung
             // Stop and restart
-            stopProxy()
-            try? await Task.sleep(nanoseconds: 1_000_000_000) // 1 second delay
+            refreshTask?.cancel()
+            refreshTask = nil
+            requestTracker.stop()
+
+            Log.quota("Attempting proxy recovery...")
+            await proxyManager.stopAndWait()
+            Log.quota("Proxy recovery stop completed, starting proxy")
+            try? await Task.sleep(nanoseconds: 300_000_000)
             await startProxy()
         }
     }
@@ -1128,7 +1134,13 @@ final class QuotaViewModel {
 
             self.authFiles = newAuthFiles
 
-            self.usageStats = try await client.fetchUsageStats()
+            do {
+                self.usageStats = try await client.fetchUsageStats()
+            } catch APIError.httpError(404) {
+                self.usageStats = nil
+                Log.quota("Usage stats endpoint is not supported by this CLIProxyAPI version")
+            }
+
             self.apiKeys = try await client.fetchAPIKeys()
             
             // Clear any previous error on success


### PR DESCRIPTION
## Summary
- Treat `/v0/management/usage` returning `404` as an unsupported Dashboard stats endpoint instead of a full proxy refresh failure.
- Prevent false proxy recovery loops when Dashboard stats are unavailable on CLIProxyAPI versions that removed usage tracking.
- Add a recovery-specific `stopAndWait()` path so cleanup completes before restarting, avoiding the documented port-cleanup race that can kill the newly started proxy.

## Issue
This addresses the proxy restart behavior observed while investigating #394.

Dashboard aggregate stats stopped working with CLIProxyAPI v6.10.0+, because CLIProxyAPI removed usage tracking and the management usage endpoints that Quotio still calls to populate those stats.

The v6.10.0 release notes include:
> chore: remove usage tracking and logging functionality

## Root Cause
Quotio still calls `/v0/management/usage` during Dashboard refresh. On CLIProxyAPI v6.10.0+, that endpoint returns `404`.

Quotio interpreted the resulting `404` as a proxy refresh failure. After repeated refresh failures, the recovery loop restarted CLIProxyAPI unnecessarily even though the proxy was healthy.

## Verification
- Ran `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build`
- Ran `./scripts/build.sh`
- Local Release app built successfully at `build/Quotio.app`