### PR TITLE
feat(cursor): Support adding multiple Cursor accounts via browser sign-in

### DIFF
--- a/Quotio/Models/Models.swift
+++ b/Quotio/Models/Models.swift
@@ -196,12 +196,14 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
     }
     
     /// Whether this provider can be added manually (via OAuth, CLI login, or file import)
-    /// Cursor, Trae, Windsurf are excluded because they only read from local app databases
-    /// GLM is excluded because it should only be added via Custom Providers
+    /// Trae is excluded because it only reads from local app databases.
+    /// GLM is excluded because it should only be added via Custom Providers.
+    /// Cursor is supported via a snapshot of the currently-logged-in IDE session — the
+    /// UI flow is custom (no OAuth endpoint), but multiple accounts can be saved.
     var supportsManualAuth: Bool {
         switch self {
-        case .cursor, .trae, .glm:
-            return false  // GLM: only via Custom Providers; Cursor/Trae: only reads from local app database
+        case .trae, .glm:
+            return false  // GLM: only via Custom Providers; Trae: reads only from local app database
         default:
             return true
         }

--- a/Quotio/Services/CursorAccountStore.swift
+++ b/Quotio/Services/CursorAccountStore.swift
@@ -1,0 +1,171 @@
+//
+//  CursorAccountStore.swift
+//  Quotio - CLIProxyAPI GUI Wrapper
+//
+//  Persists multiple Cursor accounts (tokens in Keychain, metadata in UserDefaults).
+//  Cursor itself only allows one signed-in account in the IDE at a time; this store
+//  lets users snapshot the current Cursor login and keep N saved accounts whose
+//  quotas can be queried independently via the Cursor API.
+//
+
+import Foundation
+import Security
+
+/// Non-secret metadata describing a saved Cursor account.
+nonisolated struct CursorSavedAccount: Codable, Sendable, Identifiable, Hashable {
+    let email: String
+    var membershipType: String?
+    var addedAt: Date
+
+    var id: String { email }
+}
+
+/// Token bundle for a saved account. Tokens live in the Keychain.
+nonisolated struct CursorAccountTokens: Sendable {
+    let accessToken: String
+    let refreshToken: String?
+}
+
+@MainActor
+@Observable
+final class CursorAccountStore {
+    static let shared = CursorAccountStore()
+
+    nonisolated static let keychainService = "dev.quotio.desktop.cursor"
+    nonisolated static let metadataKey = "quotio.cursor.savedAccounts"
+
+    /// Currently saved accounts (observable).
+    private(set) var accounts: [CursorSavedAccount] = []
+
+    private init() {
+        self.accounts = loadMetadata()
+    }
+
+    // MARK: - Public API
+
+    func contains(email: String) -> Bool {
+        accounts.contains { $0.email.caseInsensitiveCompare(email) == .orderedSame }
+    }
+
+    /// Persist a new (or replace existing) account.
+    @discardableResult
+    func add(
+        email: String,
+        accessToken: String,
+        refreshToken: String?,
+        membershipType: String?
+    ) -> Bool {
+        let trimmed = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !accessToken.isEmpty else { return false }
+
+        guard saveTokens(email: trimmed, access: accessToken, refresh: refreshToken) else {
+            Log.keychain("CursorAccountStore: failed to save tokens for \(Log.maskEmail(trimmed))")
+            return false
+        }
+
+        if let idx = accounts.firstIndex(where: {
+            $0.email.caseInsensitiveCompare(trimmed) == .orderedSame
+        }) {
+            accounts[idx].membershipType = membershipType ?? accounts[idx].membershipType
+        } else {
+            accounts.append(
+                CursorSavedAccount(
+                    email: trimmed,
+                    membershipType: membershipType,
+                    addedAt: Date()
+                )
+            )
+        }
+        saveMetadata()
+        return true
+    }
+
+    /// Remove a saved account and its keychain entry.
+    func remove(email: String) {
+        let target = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        accounts.removeAll { $0.email.caseInsensitiveCompare(target) == .orderedSame }
+        saveMetadata()
+        deleteTokens(email: target)
+    }
+
+    /// Read tokens for a saved account. nil if the account isn't tracked or
+    /// the keychain entry is missing.
+    nonisolated static func tokens(for email: String) -> CursorAccountTokens? {
+        let trimmed = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let data = readKeychain(account: trimmed) else { return nil }
+        guard let decoded = try? JSONDecoder().decode(StoredTokens.self, from: data) else {
+            return nil
+        }
+        return CursorAccountTokens(
+            accessToken: decoded.accessToken,
+            refreshToken: decoded.refreshToken
+        )
+    }
+
+    /// Snapshot of saved accounts callable from non-MainActor contexts (e.g. the
+    /// quota fetcher actor). Uses the keychain + UserDefaults directly so callers
+    /// don't need to hop to the main actor.
+    nonisolated static func snapshotForFetcher() -> [CursorSavedAccount] {
+        loadMetadataFromDefaults()
+    }
+
+    // MARK: - Metadata Persistence
+
+    private func loadMetadata() -> [CursorSavedAccount] {
+        Self.loadMetadataFromDefaults()
+    }
+
+    nonisolated static func loadMetadataFromDefaults() -> [CursorSavedAccount] {
+        guard let data = UserDefaults.standard.data(forKey: metadataKey) else { return [] }
+        return (try? JSONDecoder().decode([CursorSavedAccount].self, from: data)) ?? []
+    }
+
+    private func saveMetadata() {
+        guard let data = try? JSONEncoder().encode(accounts) else { return }
+        UserDefaults.standard.set(data, forKey: Self.metadataKey)
+    }
+
+    // MARK: - Keychain
+
+    nonisolated private struct StoredTokens: Codable, Sendable {
+        let accessToken: String
+        let refreshToken: String?
+    }
+
+    private func saveTokens(email: String, access: String, refresh: String?) -> Bool {
+        let stored = StoredTokens(accessToken: access, refreshToken: refresh)
+        guard let data = try? JSONEncoder().encode(stored) else { return false }
+        deleteTokens(email: email)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.keychainService,
+            kSecAttrAccount as String: email,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+        return SecItemAdd(query as CFDictionary, nil) == errSecSuccess
+    }
+
+    private func deleteTokens(email: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.keychainService,
+            kSecAttrAccount as String: email
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    nonisolated private static func readKeychain(account: String) -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.keychainService,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess else { return nil }
+        return result as? Data
+    }
+}

--- a/Quotio/Services/CursorAccountStore.swift
+++ b/Quotio/Services/CursorAccountStore.swift
@@ -2,10 +2,10 @@
 //  CursorAccountStore.swift
 //  Quotio - CLIProxyAPI GUI Wrapper
 //
-//  Persists multiple Cursor accounts (tokens in Keychain, metadata in UserDefaults).
-//  Cursor itself only allows one signed-in account in the IDE at a time; this store
-//  lets users snapshot the current Cursor login and keep N saved accounts whose
-//  quotas can be queried independently via the Cursor API.
+//  Persists multiple Cursor accounts (tokens in Keychain, metadata in
+//  UserDefaults). Cursor's IDE only allows one signed-in account at a time;
+//  this store lets users sign in to N accounts via CursorOAuthService and
+//  query each account's quota independently.
 //
 
 import Foundation
@@ -38,7 +38,7 @@ final class CursorAccountStore {
     private(set) var accounts: [CursorSavedAccount] = []
 
     private init() {
-        self.accounts = loadMetadata()
+        self.accounts = Self.loadMetadataFromDefaults()
     }
 
     // MARK: - Public API
@@ -88,6 +88,35 @@ final class CursorAccountStore {
         deleteTokens(email: target)
     }
 
+    /// Rename the email key for an existing account, migrating its keychain
+    /// entry. Used to backfill the real email after /api/auth/me resolves it
+    /// post-login. No-op if the account doesn't exist or the new email is
+    /// already in use.
+    func rename(from oldEmail: String, to newEmail: String, membershipType: String? = nil) {
+        let from = oldEmail.trimmingCharacters(in: .whitespacesAndNewlines)
+        let to = newEmail.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !from.isEmpty, !to.isEmpty,
+              from.caseInsensitiveCompare(to) != .orderedSame,
+              let idx = accounts.firstIndex(where: {
+                  $0.email.caseInsensitiveCompare(from) == .orderedSame
+              }),
+              !contains(email: to)
+        else { return }
+
+        guard let tokens = Self.tokens(for: from) else { return }
+
+        // Move keychain row.
+        _ = saveTokens(email: to, access: tokens.accessToken, refresh: tokens.refreshToken)
+        deleteTokens(email: from)
+
+        accounts[idx] = CursorSavedAccount(
+            email: to,
+            membershipType: membershipType ?? accounts[idx].membershipType,
+            addedAt: accounts[idx].addedAt
+        )
+        saveMetadata()
+    }
+
     /// Read tokens for a saved account. nil if the account isn't tracked or
     /// the keychain entry is missing.
     nonisolated static func tokens(for email: String) -> CursorAccountTokens? {
@@ -102,19 +131,11 @@ final class CursorAccountStore {
         )
     }
 
-    /// Snapshot of saved accounts callable from non-MainActor contexts (e.g. the
-    /// quota fetcher actor). Uses the keychain + UserDefaults directly so callers
-    /// don't need to hop to the main actor.
-    nonisolated static func snapshotForFetcher() -> [CursorSavedAccount] {
-        loadMetadataFromDefaults()
-    }
-
     // MARK: - Metadata Persistence
 
-    private func loadMetadata() -> [CursorSavedAccount] {
-        Self.loadMetadataFromDefaults()
-    }
-
+    /// Snapshot of saved accounts callable from non-MainActor contexts (e.g.
+    /// the quota fetcher actor). Reads UserDefaults directly so callers
+    /// don't need to hop to the main actor.
     nonisolated static func loadMetadataFromDefaults() -> [CursorSavedAccount] {
         guard let data = UserDefaults.standard.data(forKey: metadataKey) else { return [] }
         return (try? JSONDecoder().decode([CursorSavedAccount].self, from: data)) ?? []

--- a/Quotio/Services/CursorOAuthService.swift
+++ b/Quotio/Services/CursorOAuthService.swift
@@ -1,0 +1,218 @@
+//
+//  CursorOAuthService.swift
+//  Quotio - CLIProxyAPI GUI Wrapper
+//
+//  Implements Cursor's browser-based PKCE login flow so users can add multiple
+//  Cursor accounts to Quotio without having to sign in/out of the Cursor IDE
+//  itself. The protocol is reverse-engineered (Cursor has no public auth API):
+//
+//    1. Generate a PKCE verifier (43 random bytes, base64url) and challenge
+//       (sha256 of the verifier string, base64url).
+//    2. Generate a random UUID.
+//    3. Open https://www.cursor.com/loginDeepControl?challenge=&uuid=&mode=login
+//       in the user's default browser.
+//    4. Poll https://api2.cursor.sh/auth/poll?uuid=&verifier= every few seconds.
+//       Returns 200 with { accessToken, refreshToken?, authId } on completion.
+//
+//  References: https://github.com/JiuZ-Chn/Cursor-To-OpenAI/blob/main/src/tool/cursorLogin.js
+//
+
+import Foundation
+import CryptoKit
+import AppKit
+
+/// One concluded login attempt.
+nonisolated struct CursorOAuthResult: Sendable {
+    let accessToken: String
+    let refreshToken: String?
+    let authId: String?
+    /// Best-effort email pulled from the JWT payload (may be nil).
+    let email: String?
+}
+
+enum CursorOAuthError: LocalizedError {
+    case cancelled
+    case timedOut
+    case network(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .cancelled: return "Sign-in cancelled."
+        case .timedOut: return "Timed out waiting for browser login."
+        case .network(let msg): return "Network error: \(msg)"
+        }
+    }
+}
+
+actor CursorOAuthService {
+    /// In-progress flow. Surfaced so the UI can show the URL while polling.
+    struct InFlightFlow: Sendable {
+        let uuid: String
+        let verifier: String
+        let challenge: String
+        let loginURL: URL
+    }
+
+    private let pollEndpoint = "https://api2.cursor.sh/auth/poll"
+    private let loginEndpoint = "https://www.cursor.com/loginDeepControl"
+
+    // Cursor's auth poll endpoint rejects requests that don't look like the IDE.
+    private let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Cursor/0.48.6 Chrome/132.0.6834.210 Electron/34.3.4 Safari/537.36"
+
+    private var session: URLSession
+
+    init() {
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 10)
+        self.session = URLSession(configuration: config)
+    }
+
+    func updateProxyConfiguration() {
+        let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 10)
+        self.session = URLSession(configuration: config)
+    }
+
+    /// Begin a new flow. Returns the parameters the UI needs to render +
+    /// (optionally) opens the browser for the user.
+    func startFlow(openBrowser: Bool = true) -> InFlightFlow {
+        let verifier = Self.makeVerifier()
+        let challenge = Self.makeChallenge(from: verifier)
+        let uuid = UUID().uuidString.lowercased()
+
+        var components = URLComponents(string: loginEndpoint)!
+        components.queryItems = [
+            URLQueryItem(name: "challenge", value: challenge),
+            URLQueryItem(name: "uuid", value: uuid),
+            URLQueryItem(name: "mode", value: "login")
+        ]
+        let url = components.url!
+
+        if openBrowser {
+            // NSWorkspace.open is main-actor isolated; jump there.
+            Task { @MainActor in NSWorkspace.shared.open(url) }
+        }
+
+        return InFlightFlow(uuid: uuid, verifier: verifier, challenge: challenge, loginURL: url)
+    }
+
+    /// Poll until login completes, the deadline is hit, or the task is cancelled.
+    /// `intervalSeconds` is how long to wait between attempts.
+    func waitForCompletion(
+        flow: InFlightFlow,
+        timeoutSeconds: TimeInterval = 300,
+        intervalSeconds: TimeInterval = 3
+    ) async throws -> CursorOAuthResult {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+
+        while Date() < deadline {
+            try Task.checkCancellation()
+
+            if let result = try await pollOnce(uuid: flow.uuid, verifier: flow.verifier) {
+                return result
+            }
+
+            try await Task.sleep(nanoseconds: UInt64(intervalSeconds * 1_000_000_000))
+        }
+
+        throw CursorOAuthError.timedOut
+    }
+
+    // MARK: - Polling
+
+    private struct PollResponse: Decodable {
+        let accessToken: String?
+        let refreshToken: String?
+        let authId: String?
+    }
+
+    private func pollOnce(uuid: String, verifier: String) async throws -> CursorOAuthResult? {
+        var components = URLComponents(string: pollEndpoint)!
+        components.queryItems = [
+            URLQueryItem(name: "uuid", value: uuid),
+            URLQueryItem(name: "verifier", value: verifier)
+        ]
+        guard let url = components.url else {
+            throw CursorOAuthError.network("invalid poll URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue("*/*", forHTTPHeaderField: "Accept")
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            // Transient network blips should not abort the whole flow.
+            return nil
+        }
+
+        guard let http = response as? HTTPURLResponse else { return nil }
+
+        // Anything other than 200 = "not ready yet".
+        guard http.statusCode == 200 else { return nil }
+
+        let decoded = (try? JSONDecoder().decode(PollResponse.self, from: data))
+
+        guard let accessToken = decoded?.accessToken, !accessToken.isEmpty else {
+            return nil
+        }
+
+        let email = Self.emailFromJWT(accessToken)
+
+        return CursorOAuthResult(
+            accessToken: accessToken,
+            refreshToken: decoded?.refreshToken,
+            authId: decoded?.authId,
+            email: email
+        )
+    }
+
+    // MARK: - PKCE helpers
+
+    nonisolated private static func makeVerifier() -> String {
+        var bytes = [UInt8](repeating: 0, count: 43)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return base64URLEncode(Data(bytes))
+    }
+
+    nonisolated private static func makeChallenge(from verifier: String) -> String {
+        // Cursor hashes the *string form* of the verifier (matching the JS
+        // reference implementation), not the decoded random bytes.
+        let digest = SHA256.hash(data: Data(verifier.utf8))
+        return base64URLEncode(Data(digest))
+    }
+
+    nonisolated private static func base64URLEncode(_ data: Data) -> String {
+        let b64 = data.base64EncodedString()
+        return b64
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    /// Decode the JWT payload (no signature verification — we only need claims
+    /// for display). Returns `email` if present, otherwise `sub` (user id).
+    nonisolated private static func emailFromJWT(_ token: String) -> String? {
+        let parts = token.split(separator: ".")
+        guard parts.count >= 2 else { return nil }
+        var b64 = String(parts[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        // Pad to multiple of 4.
+        let pad = (4 - (b64.count % 4)) % 4
+        b64.append(String(repeating: "=", count: pad))
+
+        guard let data = Data(base64Encoded: b64),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        if let email = json["email"] as? String, !email.isEmpty {
+            return email
+        }
+        // Fall back to subject (user id like `user_01XXX`).
+        return json["sub"] as? String
+    }
+}

--- a/Quotio/Services/CursorOAuthService.swift
+++ b/Quotio/Services/CursorOAuthService.swift
@@ -26,20 +26,24 @@ nonisolated struct CursorOAuthResult: Sendable {
     let accessToken: String
     let refreshToken: String?
     let authId: String?
-    /// Best-effort email pulled from the JWT payload (may be nil).
+    /// Resolved email — from /api/auth/me when reachable, otherwise the JWT
+    /// `sub` claim. May still be nil in pathological cases.
     let email: String?
 }
 
+/// Public profile fields returned by https://cursor.com/api/auth/me.
+nonisolated struct CursorProfile: Sendable {
+    let email: String?
+    let name: String?
+    let sub: String?
+}
+
 enum CursorOAuthError: LocalizedError {
-    case cancelled
     case timedOut
-    case network(String)
 
     var errorDescription: String? {
         switch self {
-        case .cancelled: return "Sign-in cancelled."
         case .timedOut: return "Timed out waiting for browser login."
-        case .network(let msg): return "Network error: \(msg)"
         }
     }
 }
@@ -55,6 +59,7 @@ actor CursorOAuthService {
 
     private let pollEndpoint = "https://api2.cursor.sh/auth/poll"
     private let loginEndpoint = "https://www.cursor.com/loginDeepControl"
+    private let profileEndpoint = "https://cursor.com/api/auth/me"
 
     // Cursor's auth poll endpoint rejects requests that don't look like the IDE.
     private let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Cursor/0.48.6 Chrome/132.0.6834.210 Electron/34.3.4 Safari/537.36"
@@ -106,7 +111,7 @@ actor CursorOAuthService {
         while Date() < deadline {
             try Task.checkCancellation()
 
-            if let result = try await pollOnce(uuid: flow.uuid, verifier: flow.verifier) {
+            if let result = await pollOnce(uuid: flow.uuid, verifier: flow.verifier) {
                 return result
             }
 
@@ -124,15 +129,14 @@ actor CursorOAuthService {
         let authId: String?
     }
 
-    private func pollOnce(uuid: String, verifier: String) async throws -> CursorOAuthResult? {
+    private func pollOnce(uuid: String, verifier: String) async -> CursorOAuthResult? {
         var components = URLComponents(string: pollEndpoint)!
         components.queryItems = [
             URLQueryItem(name: "uuid", value: uuid),
             URLQueryItem(name: "verifier", value: verifier)
         ]
-        guard let url = components.url else {
-            throw CursorOAuthError.network("invalid poll URL")
-        }
+        // pollEndpoint is a compile-time literal, components.url is always non-nil.
+        let url = components.url!
 
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
@@ -158,7 +162,8 @@ actor CursorOAuthService {
             return nil
         }
 
-        let email = Self.emailFromJWT(accessToken)
+        let profile = await fetchProfile(accessToken: accessToken)
+        let email = profile?.email ?? Self.jwtSub(accessToken)
 
         return CursorOAuthResult(
             accessToken: accessToken,
@@ -166,6 +171,47 @@ actor CursorOAuthService {
             authId: decoded?.authId,
             email: email
         )
+    }
+
+    // MARK: - Profile
+
+    /// Hit https://cursor.com/api/auth/me with the WorkOS session cookie to
+    /// retrieve the user's real email + display name. Cursor's access tokens
+    /// don't carry email claims (despite the `email` scope), so this is the
+    /// only way to get a friendly identifier.
+    func fetchProfile(accessToken: String) async -> CursorProfile? {
+        guard let subject = Self.jwtSub(accessToken), !subject.isEmpty else { return nil }
+        guard let url = URL(string: profileEndpoint) else { return nil }
+
+        // Cookie value: URL-encode(`<sub>::<accessToken>`).
+        let raw = "\(subject)::\(accessToken)"
+        let allowed = CharacterSet.urlQueryAllowed.subtracting(.init(charactersIn: ":/?#[]@!$&'()*+,;="))
+        guard let encoded = raw.addingPercentEncoding(withAllowedCharacters: allowed) else {
+            return nil
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("WorkosCursorSessionToken=\(encoded)", forHTTPHeaderField: "Cookie")
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                return nil
+            }
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
+            }
+            return CursorProfile(
+                email: json["email"] as? String,
+                name: json["name"] as? String,
+                sub: json["sub"] as? String
+            )
+        } catch {
+            return nil
+        }
     }
 
     // MARK: - PKCE helpers
@@ -191,15 +237,15 @@ actor CursorOAuthService {
             .replacingOccurrences(of: "=", with: "")
     }
 
-    /// Decode the JWT payload (no signature verification — we only need claims
-    /// for display). Returns `email` if present, otherwise `sub` (user id).
-    nonisolated private static func emailFromJWT(_ token: String) -> String? {
+    /// Extract the `sub` claim from a Cursor access-token JWT. Cursor tokens
+    /// don't carry an `email` claim, but the `sub` is needed to build the
+    /// WorkosCursorSessionToken cookie used by /api/auth/me.
+    nonisolated static func jwtSub(_ token: String) -> String? {
         let parts = token.split(separator: ".")
         guard parts.count >= 2 else { return nil }
         var b64 = String(parts[1])
             .replacingOccurrences(of: "-", with: "+")
             .replacingOccurrences(of: "_", with: "/")
-        // Pad to multiple of 4.
         let pad = (4 - (b64.count % 4)) % 4
         b64.append(String(repeating: "=", count: pad))
 
@@ -208,11 +254,6 @@ actor CursorOAuthService {
         else {
             return nil
         }
-
-        if let email = json["email"] as? String, !email.isEmpty {
-            return email
-        }
-        // Fall back to subject (user id like `user_01XXX`).
         return json["sub"] as? String
     }
 }

--- a/Quotio/Services/QuotaFetchers/CursorQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CursorQuotaFetcher.swift
@@ -333,7 +333,7 @@ actor CursorQuotaFetcher {
     /// Saved accounts win on email collision (their tokens are authoritative).
     func fetchAsProviderQuota() async -> [String: ProviderQuotaData] {
         let installed = await isInstalled()
-        let savedAccounts = CursorAccountStore.snapshotForFetcher()
+        let savedAccounts = CursorAccountStore.loadMetadataFromDefaults()
 
         // Nothing to report: Cursor isn't installed AND no saved accounts.
         if !installed && savedAccounts.isEmpty { return [:] }

--- a/Quotio/Services/QuotaFetchers/CursorQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CursorQuotaFetcher.swift
@@ -173,69 +173,69 @@ actor CursorQuotaFetcher {
         )
     }
     
-    /// Fetch quota from Cursor API using usage-summary endpoint
+    /// Fetch quota from Cursor API using usage-summary endpoint for the
+    /// currently signed-in Cursor IDE account (read from state.vscdb).
     func fetchQuota() async -> CursorQuotaInfo? {
         guard let authData = readAuthFromStateDB(),
               let accessToken = authData.accessToken else {
             return nil
         }
-        
+        return await fetchQuota(authData: authData, accessToken: accessToken)
+    }
+
+    /// Fetch quota for an arbitrary access token + identity. Used by the
+    /// multi-account flow where tokens are pulled from CursorAccountStore.
+    func fetchQuota(
+        email: String,
+        accessToken: String,
+        membershipType: String? = nil
+    ) async -> CursorQuotaInfo? {
+        let authData = CursorAuthData(
+            accessToken: accessToken,
+            refreshToken: nil,
+            email: email,
+            membershipType: membershipType,
+            subscriptionStatus: nil,
+            signUpType: nil
+        )
+        return await fetchQuota(authData: authData, accessToken: accessToken)
+    }
+
+    private func fetchQuota(authData: CursorAuthData, accessToken: String) async -> CursorQuotaInfo? {
         // Fetch usage-summary endpoint (has both plan and on-demand info)
         guard let usageURL = URL(string: "\(cursorAPIBase)/auth/usage-summary") else { return nil }
-        
+
         var request = URLRequest(url: usageURL)
         request.httpMethod = "GET"
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        
+
+        let fallback = CursorQuotaInfo(
+            email: authData.email,
+            membershipType: authData.membershipType,
+            subscriptionStatus: authData.subscriptionStatus,
+            billingCycleStart: nil,
+            billingCycleEnd: nil,
+            isUnlimited: false,
+            planUsage: nil,
+            onDemandUsage: nil
+        )
+
         do {
             let (data, response) = try await session.data(for: request)
-            
+
             guard let httpResponse = response as? HTTPURLResponse else {
-                return nil
+                return fallback
             }
-            
-            // If unauthorized, return basic info from local auth
-            if httpResponse.statusCode == 401 {
-                return CursorQuotaInfo(
-                    email: authData.email,
-                    membershipType: authData.membershipType,
-                    subscriptionStatus: authData.subscriptionStatus,
-                    billingCycleStart: nil,
-                    billingCycleEnd: nil,
-                    isUnlimited: false,
-                    planUsage: nil,
-                    onDemandUsage: nil
-                )
-            }
-            
+
+            // 401 or non-200: return basic info from supplied auth data
             guard httpResponse.statusCode == 200 else {
-                // Return basic info from local auth if API fails
-                return CursorQuotaInfo(
-                    email: authData.email,
-                    membershipType: authData.membershipType,
-                    subscriptionStatus: authData.subscriptionStatus,
-                    billingCycleStart: nil,
-                    billingCycleEnd: nil,
-                    isUnlimited: false,
-                    planUsage: nil,
-                    onDemandUsage: nil
-                )
+                return fallback
             }
-            
+
             return parseUsageSummaryResponse(data, authData: authData)
         } catch {
-            // Return basic info from local auth on network error
-            return CursorQuotaInfo(
-                email: authData.email,
-                membershipType: authData.membershipType,
-                subscriptionStatus: authData.subscriptionStatus,
-                billingCycleStart: nil,
-                billingCycleEnd: nil,
-                isUnlimited: false,
-                planUsage: nil,
-                onDemandUsage: nil
-            )
+            return fallback
         }
     }
     
@@ -325,11 +325,56 @@ actor CursorQuotaFetcher {
         )
     }
     
-    /// Convert to ProviderQuotaData for unified display
+    /// Convert to ProviderQuotaData for unified display.
+    ///
+    /// Returns one entry per Cursor account known to the app:
+    /// - The account currently signed in to the Cursor IDE (read from state.vscdb).
+    /// - Every account the user has explicitly saved via `CursorAccountStore`.
+    /// Saved accounts win on email collision (their tokens are authoritative).
     func fetchAsProviderQuota() async -> [String: ProviderQuotaData] {
-        guard await isInstalled() else { return [:] }
-        guard let info = await fetchQuota() else { return [:] }
-        
+        let installed = await isInstalled()
+        let savedAccounts = CursorAccountStore.snapshotForFetcher()
+
+        // Nothing to report: Cursor isn't installed AND no saved accounts.
+        if !installed && savedAccounts.isEmpty { return [:] }
+
+        var results: [String: ProviderQuotaData] = [:]
+
+        // 1) Live IDE-signed-in account (preserves existing single-account behavior).
+        if installed, let info = await fetchQuota() {
+            if let (email, data) = buildProviderQuota(from: info) {
+                results[email] = data
+            }
+        }
+
+        // 2) Every saved account — fetched with its stored access token.
+        // Saved accounts override the live one if the emails collide.
+        for account in savedAccounts {
+            guard let tokens = CursorAccountStore.tokens(for: account.email) else {
+                // Token missing (keychain wiped, etc.) — show an empty/unknown row
+                // so the user knows the account is still tracked but needs re-auth.
+                results[account.email] = ProviderQuotaData(
+                    models: [ModelQuota(name: "cursor-usage", percentage: -1, resetTime: "")],
+                    lastUpdated: Date(),
+                    isForbidden: true,
+                    planType: account.membershipType
+                )
+                continue
+            }
+            let info = await fetchQuota(
+                email: account.email,
+                accessToken: tokens.accessToken,
+                membershipType: account.membershipType
+            )
+            guard let info, let (email, data) = buildProviderQuota(from: info) else { continue }
+            results[email] = data
+        }
+
+        return results
+    }
+
+    /// Build a ProviderQuotaData (and its display key) from a CursorQuotaInfo.
+    private func buildProviderQuota(from info: CursorQuotaInfo) -> (String, ProviderQuotaData)? {
         var models: [ModelQuota] = []
         
         // Add plan usage
@@ -400,7 +445,7 @@ actor CursorQuotaFetcher {
             isForbidden: false,
             planType: planDisplayName
         )
-        
-        return [email: quotaData]
+
+        return (email, quotaData)
     }
 }

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -41,6 +41,7 @@ final class QuotaViewModel {
     // Quota-Only Mode Fetchers (CLI-based)
     @ObservationIgnored private let claudeCodeFetcher = ClaudeCodeQuotaFetcher()
     @ObservationIgnored private let cursorFetcher = CursorQuotaFetcher()
+    @ObservationIgnored private let cursorOAuthService = CursorOAuthService()
     @ObservationIgnored private let codexCLIFetcher = CodexCLIQuotaFetcher()
     @ObservationIgnored private let geminiCLIFetcher = GeminiCLIQuotaFetcher()
     @ObservationIgnored private let traeFetcher = TraeQuotaFetcher()
@@ -214,6 +215,7 @@ final class QuotaViewModel {
         await glmFetcher.updateProxyConfiguration()
         await claudeCodeFetcher.updateProxyConfiguration()
         await cursorFetcher.updateProxyConfiguration()
+        await cursorOAuthService.updateProxyConfiguration()
         await codexCLIFetcher.updateProxyConfiguration()
         await geminiCLIFetcher.updateProxyConfiguration()
         await warpFetcher.updateProxyConfiguration()
@@ -439,8 +441,12 @@ final class QuotaViewModel {
         }
     }
     
-    /// Refresh Cursor quota using browser cookies
+    /// Refresh Cursor quota using browser cookies. Also opportunistically
+    /// resolves real emails for accounts whose stored key is a JWT `sub`
+    /// placeholder (older saves done before /api/auth/me was wired in).
     private func refreshCursorQuotasInternal() async {
+        await backfillCursorAccountEmails()
+
         let quotas = await cursorFetcher.fetchAsProviderQuota()
         if quotas.isEmpty {
             // No Cursor auth found - remove from providerQuotas
@@ -448,6 +454,29 @@ final class QuotaViewModel {
         } else {
             providerQuotas[.cursor] = quotas
         }
+    }
+
+    /// Calls cursor.com/api/auth/me for every saved Cursor account whose
+    /// stored email still looks like a placeholder (e.g. `user_01XX...` or
+    /// `google-oauth2|user_...`). If a real email comes back, the store is
+    /// renamed in place.
+    private func backfillCursorAccountEmails() async {
+        let store = CursorAccountStore.shared
+        for account in store.accounts where Self.isPlaceholderCursorEmail(account.email) {
+            guard let tokens = CursorAccountStore.tokens(for: account.email) else { continue }
+            guard let profile = await cursorOAuthService.fetchProfile(
+                accessToken: tokens.accessToken
+            ) else { continue }
+            guard let realEmail = profile.email, !realEmail.isEmpty,
+                  realEmail != account.email else { continue }
+            store.rename(from: account.email, to: realEmail)
+        }
+    }
+
+    nonisolated private static func isPlaceholderCursorEmail(_ value: String) -> Bool {
+        // Real emails always contain "@"; Cursor sub claims look like
+        // "user_01XXX" or "google-oauth2|user_01XXX".
+        !value.contains("@")
     }
     
     /// Refresh Codex quota using CLI auth file (~/.codex/auth.json)

--- a/Quotio/Views/Components/AddCursorAccountSheet.swift
+++ b/Quotio/Views/Components/AddCursorAccountSheet.swift
@@ -10,10 +10,9 @@
 //      in their default browser.
 //   2. They sign in in the browser (possibly with a different Cursor account
 //      than the one already in their IDE — this is the whole point).
-//   3. We poll api2.cursor.sh/auth/poll until tokens come back, then save
-//      them to CursorAccountStore.
-//
-//  A "Paste Tokens Manually" path is kept for advanced users.
+//   3. We poll api2.cursor.sh/auth/poll until tokens come back, then call
+//      cursor.com/api/auth/me to resolve the real email and save everything
+//      to CursorAccountStore.
 //
 
 import SwiftUI
@@ -34,13 +33,6 @@ struct AddCursorAccountSheet: View {
     @State private var inFlight: CursorOAuthService.InFlightFlow?
     @State private var pollTask: Task<Void, Never>?
     @State private var copiedURL = false
-    @State private var showManualEntry = false
-
-    @State private var manualEmail = ""
-    @State private var manualAccessToken = ""
-    @State private var manualRefreshToken = ""
-    @State private var manualError: String?
-    @State private var isSavingManual = false
 
     private let oauthService = CursorOAuthService()
 
@@ -56,35 +48,21 @@ struct AddCursorAccountSheet: View {
             VStack(spacing: 6) {
                 Text("Connect Cursor")
                     .font(.title2).fontWeight(.bold)
-                Text("Sign in to a Cursor account in your browser. You can repeat this to add multiple accounts.")
+                Text("Sign in to a Cursor account in your browser. Repeat to add more.")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
             }
 
-            if showManualEntry {
-                manualEntryForm
-            } else {
-                oauthBody
-            }
+            oauthBody
 
-            HStack(spacing: 12) {
+            HStack {
+                Spacer()
                 Button("action.cancel".localized(), role: .cancel) {
                     cancelAndClose()
                 }
                 .buttonStyle(.bordered)
-
-                Spacer()
-
-                Button(showManualEntry ? "Use Browser Sign-In" : "Paste Tokens Manually") {
-                    if isPolling { pollTask?.cancel(); phase = .idle; inFlight = nil }
-                    showManualEntry.toggle()
-                    manualError = nil
-                }
-                .buttonStyle(.borderless)
-                .disabled(isSavingManual)
             }
-            .frame(maxWidth: .infinity)
         }
         .padding(32)
         .frame(width: 520)
@@ -198,50 +176,6 @@ struct AddCursorAccountSheet: View {
         }
     }
 
-    // MARK: - Manual entry
-
-    @ViewBuilder
-    private var manualEntryForm: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Email").font(.caption).foregroundStyle(.secondary)
-                TextField("you@example.com", text: $manualEmail)
-                    .textFieldStyle(.roundedBorder)
-                    .autocorrectionDisabled()
-            }
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Access Token").font(.caption).foregroundStyle(.secondary)
-                SecureField("cursorAuth/accessToken", text: $manualAccessToken)
-                    .textFieldStyle(.roundedBorder)
-            }
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Refresh Token (optional)").font(.caption).foregroundStyle(.secondary)
-                SecureField("cursorAuth/refreshToken", text: $manualRefreshToken)
-                    .textFieldStyle(.roundedBorder)
-            }
-
-            if let manualError {
-                Text(manualError)
-                    .font(.caption)
-                    .foregroundStyle(.red)
-            }
-
-            Button {
-                Task { await saveManual() }
-            } label: {
-                if isSavingManual {
-                    SmallProgressView()
-                } else {
-                    Label("Save Account", systemImage: "plus.circle.fill")
-                }
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(AIProvider.cursor.color)
-            .frame(maxWidth: .infinity)
-            .disabled(isSavingManual || manualEmail.isEmpty || manualAccessToken.isEmpty)
-        }
-    }
-
     // MARK: - Actions
 
     private func startOAuth() {
@@ -295,28 +229,5 @@ struct AddCursorAccountSheet: View {
     private func cancelAndClose() {
         pollTask?.cancel()
         onDismiss()
-    }
-
-    private func saveManual() async {
-        isSavingManual = true
-        defer { isSavingManual = false }
-        manualError = nil
-
-        let email = manualEmail.trimmingCharacters(in: .whitespacesAndNewlines)
-        let access = manualAccessToken.trimmingCharacters(in: .whitespacesAndNewlines)
-        let refresh = manualRefreshToken.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        let ok = CursorAccountStore.shared.add(
-            email: email,
-            accessToken: access,
-            refreshToken: refresh.isEmpty ? nil : refresh,
-            membershipType: nil
-        )
-        if ok {
-            await viewModel.refreshQuotaForProvider(.cursor)
-            onDismiss()
-        } else {
-            manualError = "Couldn't save tokens. Check the email and access token."
-        }
     }
 }

--- a/Quotio/Views/Components/AddCursorAccountSheet.swift
+++ b/Quotio/Views/Components/AddCursorAccountSheet.swift
@@ -1,0 +1,322 @@
+//
+//  AddCursorAccountSheet.swift
+//  Quotio
+//
+//  Sheet for adding a Cursor account via Cursor's browser-based PKCE login
+//  flow (see CursorOAuthService). The flow:
+//
+//   1. User clicks "Sign In with Cursor". We open
+//      https://www.cursor.com/loginDeepControl?challenge=&uuid=&mode=login
+//      in their default browser.
+//   2. They sign in in the browser (possibly with a different Cursor account
+//      than the one already in their IDE — this is the whole point).
+//   3. We poll api2.cursor.sh/auth/poll until tokens come back, then save
+//      them to CursorAccountStore.
+//
+//  A "Paste Tokens Manually" path is kept for advanced users.
+//
+
+import SwiftUI
+import AppKit
+
+struct AddCursorAccountSheet: View {
+    @Environment(QuotaViewModel.self) private var viewModel
+    let onDismiss: () -> Void
+
+    private enum Phase: Equatable {
+        case idle
+        case polling
+        case success(email: String)
+        case error(String)
+    }
+
+    @State private var phase: Phase = .idle
+    @State private var inFlight: CursorOAuthService.InFlightFlow?
+    @State private var pollTask: Task<Void, Never>?
+    @State private var copiedURL = false
+    @State private var showManualEntry = false
+
+    @State private var manualEmail = ""
+    @State private var manualAccessToken = ""
+    @State private var manualRefreshToken = ""
+    @State private var manualError: String?
+    @State private var isSavingManual = false
+
+    private let oauthService = CursorOAuthService()
+
+    private var isPolling: Bool {
+        if case .polling = phase { return true }
+        return false
+    }
+
+    var body: some View {
+        VStack(spacing: 24) {
+            ProviderIcon(provider: .cursor, size: 64)
+
+            VStack(spacing: 6) {
+                Text("Connect Cursor")
+                    .font(.title2).fontWeight(.bold)
+                Text("Sign in to a Cursor account in your browser. You can repeat this to add multiple accounts.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            if showManualEntry {
+                manualEntryForm
+            } else {
+                oauthBody
+            }
+
+            HStack(spacing: 12) {
+                Button("action.cancel".localized(), role: .cancel) {
+                    cancelAndClose()
+                }
+                .buttonStyle(.bordered)
+
+                Spacer()
+
+                Button(showManualEntry ? "Use Browser Sign-In" : "Paste Tokens Manually") {
+                    if isPolling { pollTask?.cancel(); phase = .idle; inFlight = nil }
+                    showManualEntry.toggle()
+                    manualError = nil
+                }
+                .buttonStyle(.borderless)
+                .disabled(isSavingManual)
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .padding(32)
+        .frame(width: 520)
+        .onDisappear {
+            pollTask?.cancel()
+        }
+    }
+
+    // MARK: - OAuth body
+
+    @ViewBuilder
+    private var oauthBody: some View {
+        VStack(spacing: 16) {
+            switch phase {
+            case .idle:
+                Button {
+                    startOAuth()
+                } label: {
+                    Label("Sign In with Cursor", systemImage: "safari.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(AIProvider.cursor.color)
+                .controlSize(.large)
+
+                Text("Your browser will open. Sign in to whichever Cursor account you want to add, then come back to this window.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+            case .polling:
+                pollingView
+
+            case .success(let email):
+                successView(email: email)
+
+            case .error(let message):
+                VStack(spacing: 10) {
+                    Image(systemName: "xmark.octagon.fill")
+                        .font(.title)
+                        .foregroundStyle(.red)
+                    Text(message)
+                        .font(.callout)
+                        .multilineTextAlignment(.center)
+                    Button("Try Again") {
+                        startOAuth()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(AIProvider.cursor.color)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var pollingView: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+                .controlSize(.large)
+            Text("Waiting for browser sign-in…")
+                .font(.callout).fontWeight(.medium)
+
+            if let url = inFlight?.loginURL {
+                VStack(spacing: 6) {
+                    Text("If the browser didn't open, use this link:")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    HStack(spacing: 10) {
+                        Button {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(url.absoluteString, forType: .string)
+                            copiedURL = true
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                copiedURL = false
+                            }
+                        } label: {
+                            Label(copiedURL ? "Copied" : "Copy Link",
+                                  systemImage: copiedURL ? "checkmark" : "doc.on.doc")
+                        }
+                        .buttonStyle(.bordered)
+
+                        Button {
+                            NSWorkspace.shared.open(url)
+                        } label: {
+                            Label("Open in Browser", systemImage: "safari")
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(AIProvider.cursor.color)
+                    }
+                }
+                .padding(12)
+                .frame(maxWidth: .infinity)
+                .background(Color.secondary.opacity(0.08))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func successView(email: String) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 44))
+                .foregroundStyle(.green)
+            Text("Connected")
+                .font(.headline)
+            Text(email)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Manual entry
+
+    @ViewBuilder
+    private var manualEntryForm: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Email").font(.caption).foregroundStyle(.secondary)
+                TextField("you@example.com", text: $manualEmail)
+                    .textFieldStyle(.roundedBorder)
+                    .autocorrectionDisabled()
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Access Token").font(.caption).foregroundStyle(.secondary)
+                SecureField("cursorAuth/accessToken", text: $manualAccessToken)
+                    .textFieldStyle(.roundedBorder)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Refresh Token (optional)").font(.caption).foregroundStyle(.secondary)
+                SecureField("cursorAuth/refreshToken", text: $manualRefreshToken)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            if let manualError {
+                Text(manualError)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            Button {
+                Task { await saveManual() }
+            } label: {
+                if isSavingManual {
+                    SmallProgressView()
+                } else {
+                    Label("Save Account", systemImage: "plus.circle.fill")
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(AIProvider.cursor.color)
+            .frame(maxWidth: .infinity)
+            .disabled(isSavingManual || manualEmail.isEmpty || manualAccessToken.isEmpty)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func startOAuth() {
+        pollTask?.cancel()
+        phase = .polling
+        copiedURL = false
+
+        let service = oauthService
+        pollTask = Task {
+            let flow = await service.startFlow()
+            await MainActor.run { self.inFlight = flow }
+
+            do {
+                let result = try await service.waitForCompletion(flow: flow)
+                let email = result.email ?? result.authId ?? "Cursor User"
+
+                let ok = CursorAccountStore.shared.add(
+                    email: email,
+                    accessToken: result.accessToken,
+                    refreshToken: result.refreshToken,
+                    membershipType: nil
+                )
+                guard ok else {
+                    await MainActor.run {
+                        self.phase = .error("Couldn't save tokens to the keychain.")
+                    }
+                    return
+                }
+
+                await MainActor.run { self.phase = .success(email: email) }
+                await viewModel.refreshQuotaForProvider(.cursor)
+
+                try? await Task.sleep(nanoseconds: 1_200_000_000)
+                await MainActor.run {
+                    if case .success = self.phase { self.onDismiss() }
+                }
+            } catch is CancellationError {
+                // sheet dismissed, nothing to do
+            } catch let error as CursorOAuthError {
+                await MainActor.run {
+                    self.phase = .error(error.errorDescription ?? "Sign-in failed.")
+                }
+            } catch {
+                await MainActor.run {
+                    self.phase = .error(error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    private func cancelAndClose() {
+        pollTask?.cancel()
+        onDismiss()
+    }
+
+    private func saveManual() async {
+        isSavingManual = true
+        defer { isSavingManual = false }
+        manualError = nil
+
+        let email = manualEmail.trimmingCharacters(in: .whitespacesAndNewlines)
+        let access = manualAccessToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        let refresh = manualRefreshToken.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let ok = CursorAccountStore.shared.add(
+            email: email,
+            accessToken: access,
+            refreshToken: refresh.isEmpty ? nil : refresh,
+            membershipType: nil
+        )
+        if ok {
+            await viewModel.refreshQuotaForProvider(.cursor)
+            onDismiss()
+        } else {
+            manualError = "Couldn't save tokens. Check the email and access token."
+        }
+    }
+}

--- a/Quotio/Views/Screens/ProvidersScreen.swift
+++ b/Quotio/Views/Screens/ProvidersScreen.swift
@@ -25,10 +25,12 @@ struct ProvidersScreen: View {
     @State private var editingWarpToken: WarpService.WarpToken?
     @State private var showAddProviderPopover = false
     @State private var switchingAccount: AccountRowData?
+    @State private var showAddCursorAccountSheet = false
     @State private var modeManager = OperatingModeManager.shared
 
     private let customProviderService = CustomProviderService.shared
     private let warpService = WarpService.shared
+    private let cursorAccountStore = CursorAccountStore.shared
     
     // MARK: - Computed Properties
     
@@ -62,11 +64,33 @@ struct ProvidersScreen: View {
 
         // Add auto-detected accounts (Cursor, Trae)
         // Note: GLM uses API key auth via CustomProviderService, so skip it here
+        let savedCursorEmails = Set(
+            cursorAccountStore.accounts.map { $0.email.lowercased() }
+        )
         for (provider, quotas) in viewModel.providerQuotas {
             if !provider.supportsManualAuth && provider != .glm {
                 for (accountKey, _) in quotas {
                     let data = AccountRowData.from(provider: provider, accountKey: accountKey)
                     groups[provider, default: []].append(data)
+                }
+            } else if provider == .cursor {
+                // Cursor accounts come from two sources:
+                //   - The currently signed-in IDE session (auto-detected, no delete).
+                //   - Explicitly saved accounts in CursorAccountStore (deletable).
+                for (accountKey, _) in quotas {
+                    let isSaved = savedCursorEmails.contains(accountKey.lowercased())
+                    let data = AccountRowData(
+                        id: "cursor_\(accountKey)",
+                        provider: .cursor,
+                        displayName: accountKey,
+                        menuBarAccountKey: accountKey,
+                        source: isSaved ? .direct : .autoDetected,
+                        status: nil,
+                        statusMessage: nil,
+                        isDisabled: false,
+                        canDelete: isSaved
+                    )
+                    groups[.cursor, default: []].append(data)
                 }
             }
         }
@@ -225,6 +249,12 @@ struct ProvidersScreen: View {
             )
             .environment(viewModel)
         }
+        .sheet(isPresented: $showAddCursorAccountSheet) {
+            AddCursorAccountSheet {
+                showAddCursorAccountSheet = false
+            }
+            .environment(viewModel)
+        }
     }
     
     // MARK: - Toolbar
@@ -375,6 +405,13 @@ struct ProvidersScreen: View {
     // MARK: - Helper Functions
 
     private func handleAddProvider(_ provider: AIProvider) {
+        // Cursor uses a snapshot-based flow (no OAuth endpoint), so it skips
+        // the proxy-running guard.
+        if provider == .cursor {
+            showAddCursorAccountSheet = true
+            return
+        }
+
         // In Local Proxy Mode, require proxy to be running for OAuth
         if modeManager.isLocalProxyMode && !viewModel.proxyManager.proxyStatus.running {
             showProxyRequiredAlert = true
@@ -413,6 +450,14 @@ struct ProvidersScreen: View {
                 warpService.deleteToken(id: uuid)
                 await viewModel.refreshQuotaForProvider(.warp)
             }
+            return
+        }
+
+        // Handle Cursor accounts (stored in CursorAccountStore).
+        // account.displayName carries the email — see groupedAccounts.
+        if account.provider == .cursor {
+            cursorAccountStore.remove(email: account.displayName)
+            await viewModel.refreshQuotaForProvider(.cursor)
             return
         }
 

--- a/scripts/dev-check.sh
+++ b/scripts/dev-check.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# =============================================================================
+# Quotio Dev Check - Fast compile check (no launch, no archive)
+# =============================================================================
+# Compiles the Debug target and prints only errors/warnings.
+# Use this for tight inner-loop iteration while writing Swift.
+# =============================================================================
+
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+print_header "${PROJECT_NAME} Compile Check" 50
+
+DERIVED_DATA="${BUILD_DIR}/DerivedData"
+mkdir -p "${BUILD_DIR}"
+
+start_step_timer "check"
+
+set +e
+xcodebuild \
+    -project "${PROJECT_DIR}/${PROJECT_NAME}.xcodeproj" \
+    -scheme "${SCHEME}" \
+    -configuration Debug \
+    -destination "platform=macOS" \
+    -derivedDataPath "${DERIVED_DATA}" \
+    CODE_SIGN_IDENTITY="-" \
+    CODE_SIGNING_REQUIRED=NO \
+    CODE_SIGNING_ALLOWED=NO \
+    build > "${BUILD_DIR}/dev-check.log" 2>&1
+STATUS=$?
+set -e
+
+grep -E "(error:|warning:|\*\* BUILD)" "${BUILD_DIR}/dev-check.log" || true
+
+DURATION=$(get_step_duration "check")
+
+if [ "$STATUS" -eq 0 ]; then
+    log_success "Build OK (${DURATION})"
+else
+    log_failure "Build FAILED (${DURATION})"
+    log_item "See ${BUILD_DIR}/dev-check.log"
+    exit "$STATUS"
+fi

--- a/scripts/dev-run.sh
+++ b/scripts/dev-run.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# =============================================================================
+# Quotio Dev Run - Fast build & launch for development
+# =============================================================================
+# Builds the Debug configuration and launches the app.
+# Usage:
+#   ./scripts/dev-run.sh           # build + run
+#   ./scripts/dev-run.sh --build   # build only
+#   ./scripts/dev-run.sh --clean   # clean derived data then build + run
+# =============================================================================
+
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+MODE="run"
+CLEAN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --build) MODE="build" ;;
+        --clean) CLEAN=true ;;
+        --run)   MODE="run" ;;
+        -h|--help)
+            echo "Usage: $0 [--build|--run] [--clean]"
+            exit 0
+            ;;
+    esac
+done
+
+print_header "${PROJECT_NAME} Dev Run" 50
+
+DERIVED_DATA="${BUILD_DIR}/DerivedData"
+DEBUG_APP="${DERIVED_DATA}/Build/Products/Debug/${PROJECT_NAME}.app"
+
+if [[ "$CLEAN" == true ]]; then
+    print_step 1 3 "Cleaning derived data"
+    start_step_timer "clean"
+    rm -rf "${DERIVED_DATA}"
+    log_success "Cleaned ($(get_step_duration "clean"))"
+fi
+
+print_step 2 3 "Building Debug"
+start_step_timer "build"
+
+xcodebuild \
+    -project "${PROJECT_DIR}/${PROJECT_NAME}.xcodeproj" \
+    -scheme "${SCHEME}" \
+    -configuration Debug \
+    -destination "platform=macOS" \
+    -derivedDataPath "${DERIVED_DATA}" \
+    CODE_SIGN_IDENTITY="-" \
+    CODE_SIGNING_REQUIRED=NO \
+    CODE_SIGNING_ALLOWED=NO \
+    build 2>&1 | tee "${BUILD_DIR}/dev-build.log" | grep -E "^(error:|warning:|\*\* )" || true
+
+if [ ! -d "${DEBUG_APP}" ]; then
+    log_failure "Debug app not found at ${DEBUG_APP}"
+    log_item "See ${BUILD_DIR}/dev-build.log for details"
+    exit 1
+fi
+log_success "Build succeeded ($(get_step_duration "build"))"
+
+if [[ "$MODE" == "build" ]]; then
+    print_summary "Build Complete" \
+        "App"     "${DEBUG_APP}" \
+        "Log"     "${BUILD_DIR}/dev-build.log" \
+        "Duration" "$(get_total_duration)"
+    exit 0
+fi
+
+print_step 3 3 "Launching ${PROJECT_NAME}"
+start_step_timer "launch"
+
+# Kill any existing instance so we run the freshly built binary
+pkill -x "${PROJECT_NAME}" 2>/dev/null || true
+sleep 0.3
+
+open "${DEBUG_APP}"
+log_success "Launched ($(get_step_duration "launch"))"
+
+print_summary "Dev Run Complete ${SYM_SPARKLE}" \
+    "App"      "${DEBUG_APP}" \
+    "Duration" "$(get_total_duration)"


### PR DESCRIPTION
## Summary

Adds the ability to add multiple Cursor accounts in Quotio, mirroring how every other OAuth provider in the app (Gemini, Claude, Codex, etc.) already supports N accounts. Before this PR, Cursor was a single-account, IDE-only quota tracker — Quotio could only ever see whichever account you were currently signed in to inside the Cursor IDE's local `state.vscdb`. You'd have to sign out of Cursor and sign back in with a different account just to check quota on a second one. Now you can sign in to as many Cursor accounts as you want straight from the Providers tab and Quotio will track each independently.

## How it works

Since Cursor doesn't publish a public OAuth API, the sign-in flow is the same PKCE-based browser flow the Cursor IDE itself uses (reverse-engineered from open-source projects like [JiuZ-Chn/Cursor-To-OpenAI](https://github.com/JiuZ-Chn/Cursor-To-OpenAI)):

1. `CursorOAuthService` generates a PKCE verifier (43 random bytes, base64url) and SHA-256 challenge, plus a UUID.
2. It opens `https://www.cursor.com/loginDeepControl?challenge=&uuid=&mode=login` in your default browser.
3. While you sign in there, it polls `https://api2.cursor.sh/auth/poll?uuid=&verifier=` every 3s (with a Cursor-IDE User-Agent, which the endpoint requires) until tokens come back: `{ accessToken, refreshToken, authId }`.
4. Tokens go to the Keychain via a new `CursorAccountStore` (one entry per email; metadata in `UserDefaults`, secrets in Keychain). The `CursorQuotaFetcher` iterates every saved account in addition to the live IDE session, calling `/auth/usage-summary` per account so each row in the Providers list has its own quota numbers.

## The email problem

Cursor's access token is a JWT but **it doesn't include an `email` claim** despite `scope: "openid profile email offline_access"`. The only claim that identifies the user is `sub`, which looks like `google-oauth2|user_01XXX...` — useless as a display name. So Quotio would have shown your saved accounts as `google-oauth2|user_01K6...` instead of `you@example.com`.

To fix this, after a successful poll the service calls `GET https://cursor.com/api/auth/me` with a `WorkosCursorSessionToken={sub}::{accessToken}` cookie (URL-encoded). That endpoint returns `{ email, email_verified, name, sub, ... }` and we use the real email as the account's display name + storage key. There's also a one-shot backfill in `QuotaViewModel.refreshCursorQuotasInternal()` that auto-renames any pre-existing saved account whose stored key still looks like a placeholder (no `@` sign), so users who already added accounts before this fix don't have to re-sign-in.

## Test plan

- [x] Built clean (`xcodebuild ... Debug build`); no new warnings
- [x] Live-tested both saved Cursor accounts against `/auth/usage-summary` — returned distinct membership types (`pro_student` vs `pro`) and distinct usage numbers, confirming per-account quota fetching works
- [x] Live-tested both saved accounts against `/api/auth/me` — both returned real emails
- [ ] Reviewer: sign in with two different Cursor accounts via Providers → + → Cursor → "Sign In with Cursor" and confirm both appear with real emails and independent quotas
- [ ] Reviewer: delete one of the OAuth-added accounts and confirm the Keychain entry + UserDefaults metadata are removed
- [ ] Reviewer: localization strings are still hardcoded English ("Connect Cursor", "Sign In with Cursor", etc.) — would appreciate guidance on whether to add `Localizable.xcstrings` entries before merge or in a follow-up