### PR TITLE
Allow custom provider setup with optional SSL verification

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -4071,6 +4071,296 @@
         }
       }
     },
+    "customProviders.allowInsecureHTTP" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allow Insecure HTTP"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autoriser HTTP non sécurisé"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cho phép HTTP không an toàn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许不安全的HTTP"
+          }
+        }
+      }
+    },
+    "customProviders.allowInsecureHTTP.warning" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTTP is unencrypted. Requests to this provider may expose API keys and responses."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTTP n'est pas chiffré. Les requêtes vers ce fournisseur peuvent exposer les clés API et les réponses."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTTP không được mã hóa. Yêu cầu tới nhà cung cấp này có thể làm lộ API key và phản hồi."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTTP未加密。发送到此提供商的请求可能暴露API密钥和响应。"
+          }
+        }
+      }
+    },
+    "customProviders.insecureHTTPWarning.confirm" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allow Insecure HTTP"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autoriser HTTP non sécurisé"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cho phép HTTP không an toàn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许不安全的HTTP"
+          }
+        }
+      }
+    },
+    "customProviders.insecureHTTPWarning.message" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTTP does not encrypt traffic. Anyone on the network may read this provider's API key, model requests, and responses. Only allow HTTP for trusted local or internal endpoints."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTTP ne chiffre pas le trafic. Toute personne sur le réseau peut lire la clé API, les requêtes de modèle et les réponses de ce fournisseur. N'autorisez HTTP que pour les points de terminaison locaux ou internes de confiance."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTTP không mã hóa lưu lượng. Bất kỳ ai trên mạng cũng có thể đọc API key, yêu cầu mô hình và phản hồi của nhà cung cấp này. Chỉ cho phép HTTP với endpoint cục bộ hoặc nội bộ đáng tin cậy."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTTP不会加密流量。同一网络中的任何人都可能读取此提供商的API密钥、模型请求和响应。仅对可信的本地或内部端点允许HTTP。"
+          }
+        }
+      }
+    },
+    "customProviders.insecureHTTPWarning.title" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allow Insecure HTTP?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autoriser HTTP non sécurisé ?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cho phép HTTP không an toàn?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许不安全的HTTP？"
+          }
+        }
+      }
+    },
+    "customProviders.sslWarning.confirm" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable SSL Verification"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactiver la vérification SSL"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tắt xác minh SSL"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "禁用SSL验证"
+          }
+        }
+      }
+    },
+    "customProviders.sslWarning.message" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disabling SSL verification allows attackers to intercept this provider's API key and responses. Only disable it for trusted networks or development endpoints."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactiver la vérification SSL permet aux attaquants d'intercepter la clé API et les réponses de ce fournisseur. Ne désactivez cette option que pour les réseaux de confiance ou les points de terminaison de développement."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tắt xác minh SSL cho phép kẻ tấn công chặn API key và phản hồi của nhà cung cấp này. Chỉ tắt tùy chọn này cho mạng tin cậy hoặc endpoint phát triển."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "禁用SSL验证会让攻击者拦截此提供商的API密钥和响应。仅在可信网络或开发端点中禁用此选项。"
+          }
+        }
+      }
+    },
+    "customProviders.sslWarning.title" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable SSL Verification?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactiver la vérification SSL ?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tắt xác minh SSL?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "禁用SSL验证？"
+          }
+        }
+      }
+    },
+    "customProviders.verifySSL" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verify SSL Certificate"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérifier le certificat SSL"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xác minh chứng chỉ SSL"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "验证SSL证书"
+          }
+        }
+      }
+    },
+    "customProviders.verifySSL.warning" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSL verification is disabled. Requests to this provider may be vulnerable to interception."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La vérification SSL est désactivée. Les requêtes vers ce fournisseur peuvent être vulnérables à l'interception."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xác minh SSL đã bị tắt. Yêu cầu tới nhà cung cấp này có thể bị chặn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSL验证已禁用。发送到此提供商的请求可能容易被拦截。"
+          }
+        }
+      }
+    },
     "customProviders.footer" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Models/CustomProviderModels.swift
+++ b/Quotio/Models/CustomProviderModels.swift
@@ -233,6 +233,12 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
     var headers: [CustomHeader]  // Only used for Gemini-compatible
     var limitToSelectedModels: Bool
     var isEnabled: Bool
+
+    /// Whether HTTPS requests should use normal certificate and trust-chain validation.
+    var verifySSL: Bool
+
+    /// Whether this provider may use plain HTTP for setup and connection-test requests.
+    var allowInsecureHTTP: Bool
     var createdAt: Date
     var updatedAt: Date
 
@@ -247,6 +253,8 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
         headers: [CustomHeader] = [],
         limitToSelectedModels: Bool = true,
         isEnabled: Bool = true,
+        verifySSL: Bool = true,
+        allowInsecureHTTP: Bool = false,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
@@ -260,6 +268,8 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
         self.headers = headers
         self.limitToSelectedModels = limitToSelectedModels
         self.isEnabled = isEnabled
+        self.verifySSL = verifySSL
+        self.allowInsecureHTTP = allowInsecureHTTP
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
@@ -271,6 +281,8 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
         case models, headers
         case limitToSelectedModels = "limit-to-selected-models"
         case isEnabled = "is-enabled"
+        case verifySSL = "verify-ssl"
+        case allowInsecureHTTP = "allow-insecure-http"
         case createdAt = "created-at"
         case updatedAt = "updated-at"
     }
@@ -287,6 +299,8 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
         headers = try container.decodeIfPresent([CustomHeader].self, forKey: .headers) ?? []
         limitToSelectedModels = try container.decodeIfPresent(Bool.self, forKey: .limitToSelectedModels) ?? true
         isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
+        verifySSL = try container.decodeIfPresent(Bool.self, forKey: .verifySSL) ?? true
+        allowInsecureHTTP = try container.decodeIfPresent(Bool.self, forKey: .allowInsecureHTTP) ?? false
         createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
         updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt) ?? Date()
     }
@@ -303,6 +317,8 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
         try container.encode(headers, forKey: .headers)
         try container.encode(limitToSelectedModels, forKey: .limitToSelectedModels)
         try container.encode(isEnabled, forKey: .isEnabled)
+        try container.encode(verifySSL, forKey: .verifySSL)
+        try container.encode(allowInsecureHTTP, forKey: .allowInsecureHTTP)
         try container.encode(createdAt, forKey: .createdAt)
         try container.encode(updatedAt, forKey: .updatedAt)
     }

--- a/Quotio/Services/CustomProviderHTTPClient.swift
+++ b/Quotio/Services/CustomProviderHTTPClient.swift
@@ -1,0 +1,372 @@
+//
+//  CustomProviderHTTPClient.swift
+//  Quotio - Custom provider setup HTTP transport
+//
+
+import Foundation
+import Network
+
+/// A lightweight HTTP response used by custom provider setup and connection testing.
+struct CustomProviderHTTPResponse: Sendable {
+    /// The numeric HTTP status code returned by the provider.
+    let statusCode: Int
+
+    /// The response body after any supported transfer decoding has been applied.
+    let data: Data
+}
+
+/// Errors raised by the custom provider setup transport.
+enum CustomProviderHTTPClientError: LocalizedError {
+    /// The request URL is missing, malformed, or unsuitable for the selected transport.
+    case invalidHTTPURL
+
+    /// The request uses a URL scheme other than HTTP or HTTPS.
+    case unsupportedScheme(String)
+
+    /// The plain HTTP request could not be serialized into bytes.
+    case requestEncodingFailed
+
+    /// The provider did not complete the request before the configured timeout.
+    case timedOut
+
+    /// The provider returned bytes that could not be parsed as an HTTP response.
+    case invalidResponse
+
+    /// The provider returned malformed chunked transfer encoding.
+    case malformedChunkedResponse
+
+    /// The provider URL uses HTTP but the user has not opted into insecure HTTP.
+    case insecureHTTPNotAllowed
+
+    /// A user-facing description suitable for validation and connection-test failures.
+    var errorDescription: String? {
+        switch self {
+        case .invalidHTTPURL:
+            return "Invalid HTTP URL"
+        case .unsupportedScheme(let scheme):
+            return "Unsupported URL scheme: \(scheme)"
+        case .requestEncodingFailed:
+            return "Failed to encode HTTP request"
+        case .timedOut:
+            return "HTTP request timed out"
+        case .invalidResponse:
+            return "Invalid HTTP response"
+        case .malformedChunkedResponse:
+            return "Invalid chunked HTTP response"
+        case .insecureHTTPNotAllowed:
+            return "Insecure HTTP is blocked. Enable Allow Insecure HTTP for this custom provider to use an http:// endpoint."
+        }
+    }
+}
+
+/// Transport for custom provider setup requests.
+///
+/// HTTPS uses URLSession so system TLS policy remains the default. Plain HTTP uses a scoped
+/// Network.framework transport only when the provider explicitly opts into insecure HTTP.
+nonisolated enum CustomProviderHTTPClient {
+    /// Executes a custom provider request using the transport required by the request URL scheme.
+    /// - Parameters:
+    ///   - request: The fully prepared provider request.
+    ///   - allowInsecureHTTP: Whether `http://` URLs are allowed for this provider.
+    ///   - verifySSL: Whether HTTPS requests should verify certificates normally.
+    /// - Returns: The provider response status code and body data.
+    static func data(for request: URLRequest, allowInsecureHTTP: Bool, verifySSL: Bool) async throws -> CustomProviderHTTPResponse {
+        guard let url = request.url, let scheme = url.scheme?.lowercased() else {
+            throw CustomProviderHTTPClientError.invalidHTTPURL
+        }
+
+        switch scheme {
+        case "https":
+            let session = makeCustomProviderURLSession(verifySSL: verifySSL)
+            defer { session.finishTasksAndInvalidate() }
+            let (data, response) = try await session.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw CustomProviderHTTPClientError.invalidResponse
+            }
+
+            return CustomProviderHTTPResponse(statusCode: httpResponse.statusCode, data: data)
+
+        case "http":
+            guard allowInsecureHTTP else {
+                throw CustomProviderHTTPClientError.insecureHTTPNotAllowed
+            }
+
+            return try await dataForPlainHTTPRequest(request)
+
+        default:
+            throw CustomProviderHTTPClientError.unsupportedScheme(scheme)
+        }
+    }
+
+    /// Sends a plain HTTP request over TCP without using URLSession, which ATS would block.
+    private static func dataForPlainHTTPRequest(_ request: URLRequest) async throws -> CustomProviderHTTPResponse {
+        guard let url = request.url,
+              url.scheme?.lowercased() == "http",
+              let host = url.host else {
+            throw CustomProviderHTTPClientError.invalidHTTPURL
+        }
+
+        let port = UInt16(url.port ?? 80)
+        guard let nwPort = NWEndpoint.Port(rawValue: port),
+              let requestData = makePlainHTTPRequestData(from: request, host: host, port: port) else {
+            throw CustomProviderHTTPClientError.requestEncodingFailed
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let connection = NWConnection(host: NWEndpoint.Host(host), port: nwPort, using: .tcp)
+            let state = PlainHTTPRequestState(connection: connection, continuation: continuation)
+
+            connection.stateUpdateHandler = { connectionState in
+                switch connectionState {
+                case .ready:
+                    connection.send(content: requestData, completion: .contentProcessed { error in
+                        if let error = error {
+                            state.finish(.failure(error))
+                            return
+                        }
+
+                        state.receiveNext()
+                    })
+                case .failed(let error):
+                    state.finish(.failure(error))
+                default:
+                    break
+                }
+            }
+
+            Task {
+                try? await Task.sleep(nanoseconds: UInt64((request.timeoutInterval > 0 ? request.timeoutInterval : 15) * 1_000_000_000))
+                state.finish(.failure(CustomProviderHTTPClientError.timedOut))
+            }
+
+            connection.start(queue: .global(qos: .userInitiated))
+        }
+    }
+
+    /// Serializes a URLRequest into an HTTP/1.1 request suitable for a direct TCP connection.
+    private static func makePlainHTTPRequestData(from request: URLRequest, host: String, port: UInt16) -> Data? {
+        guard let url = request.url else { return nil }
+
+        let method = request.httpMethod ?? "GET"
+        let path = url.path.isEmpty ? "/" : url.path
+        let target = url.query.map { "\(path)?\($0)" } ?? path
+        let hostHeader = port == 80 ? host : "\(host):\(port)"
+
+        var lines = [
+            "\(method) \(target) HTTP/1.1",
+            "Host: \(hostHeader)",
+            "Connection: close"
+        ]
+
+        let headers = request.allHTTPHeaderFields ?? [:]
+        for (key, value) in headers where key.caseInsensitiveCompare("Host") != .orderedSame && key.caseInsensitiveCompare("Connection") != .orderedSame {
+            lines.append("\(key): \(value)")
+        }
+
+        let body = request.httpBody ?? Data()
+        if !body.isEmpty && headers.keys.first(where: { $0.caseInsensitiveCompare("Content-Length") == .orderedSame }) == nil {
+            lines.append("Content-Length: \(body.count)")
+        }
+
+        lines.append("")
+        lines.append("")
+
+        guard var data = lines.joined(separator: "\r\n").data(using: .utf8) else {
+            return nil
+        }
+
+        data.append(body)
+        return data
+    }
+
+    /// Parses an HTTP/1.1 response returned by the plain HTTP transport.
+    fileprivate static func parseHTTPResponse(_ response: Data) throws -> CustomProviderHTTPResponse {
+        let headerSeparator = Data("\r\n\r\n".utf8)
+        guard let headerRange = response.range(of: headerSeparator),
+              let headerText = String(data: response.subdata(in: response.startIndex..<headerRange.lowerBound), encoding: .utf8) else {
+            throw CustomProviderHTTPClientError.invalidResponse
+        }
+
+        let headerLines = headerText.components(separatedBy: "\r\n")
+        guard let statusLine = headerLines.first else {
+            throw CustomProviderHTTPClientError.invalidResponse
+        }
+
+        let statusParts = statusLine.split(separator: " ", maxSplits: 2, omittingEmptySubsequences: true)
+        guard statusParts.count >= 2, let statusCode = Int(statusParts[1]) else {
+            throw CustomProviderHTTPClientError.invalidResponse
+        }
+
+        var headers: [String: String] = [:]
+        for line in headerLines.dropFirst() {
+            guard let separatorIndex = line.firstIndex(of: ":") else { continue }
+            let key = String(line[..<separatorIndex]).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let valueStart = line.index(after: separatorIndex)
+            let value = String(line[valueStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
+            headers[key] = value
+        }
+
+        let bodyStart = headerRange.upperBound
+        let body = response.subdata(in: bodyStart..<response.endIndex)
+        let decodedBody = headers["transfer-encoding"]?.lowercased().contains("chunked") == true
+            ? try decodeChunkedBody(body)
+            : body
+
+        return CustomProviderHTTPResponse(statusCode: statusCode, data: decodedBody)
+    }
+
+    /// Decodes a body using HTTP chunked transfer encoding.
+    private static func decodeChunkedBody(_ body: Data) throws -> Data {
+        var offset = body.startIndex
+        var decoded = Data()
+        let lineSeparator = Data("\r\n".utf8)
+
+        while offset < body.endIndex {
+            guard let lineRange = body[offset..<body.endIndex].range(of: lineSeparator),
+                  let line = String(data: body.subdata(in: offset..<lineRange.lowerBound), encoding: .utf8) else {
+                throw CustomProviderHTTPClientError.malformedChunkedResponse
+            }
+
+            offset = lineRange.upperBound
+
+            let chunkSizeText = line.split(separator: ";", maxSplits: 1, omittingEmptySubsequences: false)[0]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            guard let chunkSize = Int(chunkSizeText, radix: 16) else {
+                throw CustomProviderHTTPClientError.malformedChunkedResponse
+            }
+
+            if chunkSize == 0 {
+                return decoded
+            }
+
+            guard offset + chunkSize <= body.endIndex else {
+                throw CustomProviderHTTPClientError.malformedChunkedResponse
+            }
+
+            decoded.append(body.subdata(in: offset..<(offset + chunkSize)))
+            offset += chunkSize
+
+            if offset + lineSeparator.count <= body.endIndex {
+                offset += lineSeparator.count
+            }
+        }
+
+        return decoded
+    }
+}
+
+/// Thread-safe state shared by Network.framework callbacks for one plain HTTP request.
+nonisolated private final class PlainHTTPRequestState: @unchecked Sendable {
+    /// The active TCP connection to the provider.
+    private let connection: NWConnection
+
+    /// The continuation that completes the async request.
+    private let continuation: CheckedContinuation<CustomProviderHTTPResponse, Error>
+
+    /// Guards response accumulation and one-shot continuation completion.
+    private let lock = NSLock()
+
+    /// Tracks whether the continuation has already been resumed.
+    private var didResume = false
+
+    /// Accumulates response bytes until the provider closes the connection.
+    private var responseData = Data()
+
+    /// Creates state for one plain HTTP request.
+    init(connection: NWConnection, continuation: CheckedContinuation<CustomProviderHTTPResponse, Error>) {
+        self.connection = connection
+        self.continuation = continuation
+    }
+
+    /// Completes the request exactly once and closes the underlying connection.
+    func finish(_ result: Result<CustomProviderHTTPResponse, Error>) {
+        lock.lock()
+        guard !didResume else {
+            lock.unlock()
+            return
+        }
+        didResume = true
+        lock.unlock()
+
+        connection.cancel()
+        continuation.resume(with: result)
+    }
+
+    /// Starts or continues receiving response bytes from the provider.
+    func receiveNext() {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { [self] data, _, isComplete, error in
+            if let error = error {
+                finish(.failure(error))
+                return
+            }
+
+            if let data = data, !data.isEmpty {
+                append(data)
+            }
+
+            if isComplete {
+                do {
+                    finish(.success(try CustomProviderHTTPClient.parseHTTPResponse(snapshot())))
+                } catch {
+                    finish(.failure(error))
+                }
+                return
+            }
+
+            receiveNext()
+        }
+    }
+
+    /// Appends bytes to the accumulated response buffer.
+    private func append(_ data: Data) {
+        lock.lock()
+        responseData.append(data)
+        lock.unlock()
+    }
+
+    /// Returns a stable copy of the accumulated response data.
+    private func snapshot() -> Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return responseData
+    }
+}
+
+// MARK: - Custom Provider URLSession
+
+/// Builds the URLSession used for HTTPS custom provider setup requests.
+nonisolated private func makeCustomProviderURLSession(verifySSL: Bool) -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.timeoutIntervalForRequest = 15
+    configuration.timeoutIntervalForResource = 30
+
+    guard !verifySSL else {
+        return URLSession(configuration: configuration)
+    }
+
+    return URLSession(
+        configuration: configuration,
+        delegate: CustomProviderURLSessionDelegate(),
+        delegateQueue: nil
+    )
+}
+
+/// URLSession delegate that can opt out of HTTPS trust validation for a custom provider request.
+nonisolated private final class CustomProviderURLSessionDelegate: NSObject, URLSessionDelegate, Sendable {
+    /// Handles HTTPS server-trust challenges when SSL verification has been disabled by the user.
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let serverTrust = challenge.protectionSpace.serverTrust else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+
+        completionHandler(.useCredential, URLCredential(trust: serverTrust))
+    }
+}

--- a/Quotio/Services/CustomProviderService.swift
+++ b/Quotio/Services/CustomProviderService.swift
@@ -44,6 +44,8 @@ final class CustomProviderService {
             headers: provider.headers,
             limitToSelectedModels: provider.limitToSelectedModels,
             isEnabled: provider.isEnabled,
+            verifySSL: provider.verifySSL,
+            allowInsecureHTTP: provider.allowInsecureHTTP,
             createdAt: Date(),
             updatedAt: Date()
         )
@@ -70,6 +72,8 @@ final class CustomProviderService {
             headers: provider.headers,
             limitToSelectedModels: provider.limitToSelectedModels,
             isEnabled: provider.isEnabled,
+            verifySSL: provider.verifySSL,
+            allowInsecureHTTP: provider.allowInsecureHTTP,
             createdAt: providers[index].createdAt,
             updatedAt: Date()
         )
@@ -99,6 +103,8 @@ final class CustomProviderService {
             headers: provider.headers,
             limitToSelectedModels: provider.limitToSelectedModels,
             isEnabled: !provider.isEnabled,
+            verifySSL: provider.verifySSL,
+            allowInsecureHTTP: provider.allowInsecureHTTP,
             createdAt: provider.createdAt,
             updatedAt: Date()
         )

--- a/Quotio/Views/Components/CustomProviderSheet.swift
+++ b/Quotio/Views/Components/CustomProviderSheet.swift
@@ -21,9 +21,15 @@ struct CustomProviderSheet: View {
     @State private var models: [ModelMapping] = []
     @State private var headers: [CustomHeader] = []
     @State private var isEnabled: Bool = true
+    @State private var verifySSL: Bool = true
+    @State private var allowInsecureHTTP: Bool = false
     
     @State private var validationErrors: [String] = []
     @State private var showValidationAlert = false
+    @State private var showSSLWarning = false
+    @State private var showInsecureHTTPWarning = false
+    @State private var pendingSSLValue = true
+    @State private var pendingInsecureHTTPValue = false
     @State private var isTestingConnection = false
     @State private var testError: String?
     
@@ -63,7 +69,10 @@ struct CustomProviderSheet: View {
                         customHeadersSection
                     }
                     
-                    // Step 5: Enable toggle
+                    // Step 5: TLS verification
+                    securitySection
+
+                    // Step 6: Enable toggle
                     enabledSection
                 }
                 .padding(20)
@@ -87,6 +96,26 @@ struct CustomProviderSheet: View {
             } else {
                 Text(validationErrors.joined(separator: "\n"))
             }
+        }
+        .alert("customProviders.sslWarning.title".localized(), isPresented: $showSSLWarning) {
+            Button("action.cancel".localized(), role: .cancel) {
+                pendingSSLValue = verifySSL
+            }
+            Button("customProviders.sslWarning.confirm".localized(), role: .destructive) {
+                verifySSL = pendingSSLValue
+            }
+        } message: {
+            Text("customProviders.sslWarning.message".localized())
+        }
+        .alert("customProviders.insecureHTTPWarning.title".localized(), isPresented: $showInsecureHTTPWarning) {
+            Button("action.cancel".localized(), role: .cancel) {
+                pendingInsecureHTTPValue = allowInsecureHTTP
+            }
+            Button("customProviders.insecureHTTPWarning.confirm".localized(), role: .destructive) {
+                allowInsecureHTTP = pendingInsecureHTTPValue
+            }
+        } message: {
+            Text("customProviders.insecureHTTPWarning.message".localized())
         }
     }
     
@@ -641,6 +670,51 @@ struct CustomProviderSheet: View {
         }
     }
     
+    // MARK: - Security Section
+
+    private var securitySection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Toggle("customProviders.verifySSL".localized(), isOn: Binding(
+                get: { verifySSL },
+                set: { newValue in
+                    if !newValue {
+                        pendingSSLValue = newValue
+                        showSSLWarning = true
+                    } else {
+                        verifySSL = newValue
+                    }
+                }
+            ))
+
+            if !verifySSL {
+                Label("customProviders.verifySSL.warning".localized(), systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
+            Toggle("customProviders.allowInsecureHTTP".localized(), isOn: Binding(
+                get: { allowInsecureHTTP },
+                set: { newValue in
+                    if newValue {
+                        pendingInsecureHTTPValue = newValue
+                        showInsecureHTTPWarning = true
+                    } else {
+                        allowInsecureHTTP = newValue
+                    }
+                }
+            ))
+
+            if allowInsecureHTTP {
+                Label("customProviders.allowInsecureHTTP.warning".localized(), systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        }
+        .padding(16)
+        .background(Color(.controlBackgroundColor).opacity(0.5))
+        .cornerRadius(8)
+    }
+
     // MARK: - Enabled Section
     
     private var enabledSection: some View {
@@ -706,6 +780,8 @@ struct CustomProviderSheet: View {
         headers = provider.headers
         limitToSelectedModels = provider.limitToSelectedModels
         isEnabled = provider.isEnabled
+        verifySSL = provider.verifySSL
+        allowInsecureHTTP = provider.allowInsecureHTTP
         
         // Set selected models from existing provider
         selectedModelIds = Set(provider.models.map { $0.name })
@@ -803,25 +879,21 @@ struct CustomProviderSheet: View {
         
         Task {
             do {
-                let (data, response) = try await URLSession.shared.data(for: request)
-                
-                guard let httpResponse = response as? HTTPURLResponse else {
+                let response = try await CustomProviderHTTPClient.data(
+                    for: request,
+                    allowInsecureHTTP: allowInsecureHTTP,
+                    verifySSL: verifySSL
+                )
+
+                guard response.statusCode == 200 else {
                     await MainActor.run {
                         isLoadingModels = false
-                        modelFetchError = "Invalid response"
+                        modelFetchError = "Failed to fetch models: HTTP \(response.statusCode)"
                     }
                     return
                 }
                 
-                guard httpResponse.statusCode == 200 else {
-                    await MainActor.run {
-                        isLoadingModels = false
-                        modelFetchError = "Failed to fetch models: HTTP \(httpResponse.statusCode)"
-                    }
-                    return
-                }
-                
-                let modelsResponse = try JSONDecoder().decode(ModelsListResponse.self, from: data)
+                let modelsResponse = try JSONDecoder().decode(ModelsListResponse.self, from: response.data)
                 let fetchedModels = modelsResponse.allModels.map { $0.toAvailableModel() }
                 
                 await MainActor.run {
@@ -869,6 +941,8 @@ struct CustomProviderSheet: View {
             headers: headers.filter { !$0.key.trimmingCharacters(in: .whitespaces).isEmpty },
             limitToSelectedModels: limitToSelectedModels,
             isEnabled: isEnabled,
+            verifySSL: verifySSL,
+            allowInsecureHTTP: allowInsecureHTTP,
             createdAt: provider?.createdAt ?? Date(),
             updatedAt: Date()
         )
@@ -944,13 +1018,13 @@ struct CustomProviderSheet: View {
             request.setValue(header.value, forHTTPHeaderField: header.key)
         }
         
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let response = try await CustomProviderHTTPClient.data(
+            for: request,
+            allowInsecureHTTP: provider.allowInsecureHTTP,
+            verifySSL: provider.verifySSL
+        )
         
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CustomProviderTestError.invalidResponse
-        }
-        
-        switch httpResponse.statusCode {
+        switch response.statusCode {
         case 200..<300:
             return true
         case 401, 403:
@@ -958,10 +1032,10 @@ struct CustomProviderSheet: View {
         case 404:
             throw CustomProviderTestError.endpointNotFound
         default:
-            if let errorMessage = String(data: data, encoding: .utf8) {
-                throw CustomProviderTestError.serverError(httpResponse.statusCode, errorMessage)
+            if let errorMessage = String(data: response.data, encoding: .utf8) {
+                throw CustomProviderTestError.serverError(response.statusCode, errorMessage)
             }
-            throw CustomProviderTestError.serverError(httpResponse.statusCode, "Unknown error")
+            throw CustomProviderTestError.serverError(response.statusCode, "Unknown error")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add per-custom-provider settings for trusted insecure endpoints.
- Keep HTTPS certificate verification enabled by default, with a warning before disabling it.
- Keep insecure HTTP blocked by default, with a separate warning before allowing it.
- Use the selected settings for Custom Provider model fetching and connection testing without globally relaxing ATS.
- Document the new transport and provider security fields for docstring coverage.

## Background
Custom Provider setup can fail in Quotio even when the same endpoint works from Claude Code or Codex CLI. There are two distinct macOS networking failures involved:

1. HTTPS endpoints can fail during URLSession trust evaluation when Apple TLS policy rejects a certificate that other CLI stacks accept. One concrete case from #376 is an internal endpoint whose certificate chain can be trusted manually but whose leaf certificate exceeds the maximum allowed validity period. That produces the app-level error: "A TLS error caused the secure connection to fail."

2. HTTP endpoints fail earlier. For `http://model.mify.ai.srv/v1`, URLSession is blocked by App Transport Security before any request is sent, producing: "The resource could not be loaded because the App Transport Security policy requires the use of a secure connection."

## Approach
This keeps secure behavior as the default and scopes the unsafe behavior to Custom Provider setup/test requests only.

- HTTPS still uses URLSession. If SSL verification is disabled for that provider, the setup/test session accepts the server trust challenge.
- HTTP does not use URLSession, because ATS blocks arbitrary `http://` URLs before request handling. If insecure HTTP is explicitly allowed for that provider, setup/test requests use a small plain HTTP transport for the model list request.

I intentionally did not set `NSAllowsArbitraryLoads`, because that would weaken every network request in the app. I also did not hard-code an ATS exception for `model.mify.ai.srv`, because custom provider hosts are user-entered at runtime and upstream should not carry a private host exception.

I also did not emit `verify-ssl` or `allow-insecure-http` into generated CLIProxyAPI YAML because this repository does not show a supported custom-provider YAML contract for those options.

## Testing
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('Quotio/Localizable.xcstrings','utf8')); console.log('Localizable.xcstrings JSON OK')"`
- `swiftc -parse Quotio/Models/CustomProviderModels.swift Quotio/Services/CustomProviderService.swift Quotio/Services/CustomProviderHTTPClient.swift Quotio/Views/Components/CustomProviderSheet.swift`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swiftc -typecheck -swift-version 6 -default-isolation MainActor Quotio/Services/CustomProviderHTTPClient.swift`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug -destination 'platform=macOS' build`

Xcode: 26.5 (build 17F42)

Fixes #376
