### PR TITLE
Show Codex quota analytics in menu bar

### DIFF
--- a/Quotio/Models/QuotaAnalytics.swift
+++ b/Quotio/Models/QuotaAnalytics.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+nonisolated struct QuotaAnalytics: Codable, Equatable, Sendable {
+    var trend: [QuotaAnalyticsPoint]
+    var rows: [QuotaAnalyticsRow]
+    var note: String?
+
+    init(
+        trend: [QuotaAnalyticsPoint] = [],
+        rows: [QuotaAnalyticsRow] = [],
+        note: String? = nil
+    ) {
+        self.trend = trend
+        self.rows = rows
+        self.note = note
+    }
+
+    var isEmpty: Bool {
+        trend.isEmpty && rows.isEmpty && (note?.isEmpty ?? true)
+    }
+
+    func merging(_ other: QuotaAnalytics?) -> QuotaAnalytics {
+        guard let other, !other.isEmpty else { return self }
+        var mergedRows = rows
+        var seen = Set(rows.map(\.id))
+        for row in other.rows where seen.insert(row.id).inserted {
+            mergedRows.append(row)
+        }
+        return QuotaAnalytics(
+            trend: other.trend.isEmpty ? trend : other.trend,
+            rows: mergedRows,
+            note: other.note ?? note
+        )
+    }
+}
+
+nonisolated struct QuotaAnalyticsPoint: Codable, Equatable, Identifiable, Sendable {
+    var id: String { date }
+    var date: String
+    var value: Double
+    var label: String
+    var valueLabel: String
+
+    init(date: String, value: Double, label: String, valueLabel: String) {
+        self.date = date
+        self.value = value
+        self.label = label
+        self.valueLabel = valueLabel
+    }
+}
+
+nonisolated struct QuotaAnalyticsRow: Codable, Equatable, Identifiable, Sendable {
+    var id: String
+    var title: String
+    var value: String
+    var isAvailable: Bool
+
+    init(id: String, title: String, value: String, isAvailable: Bool = true) {
+        self.id = id
+        self.title = title
+        self.value = value
+        self.isAvailable = isAvailable
+    }
+
+    static func noData(id: String, title: String) -> QuotaAnalyticsRow {
+        QuotaAnalyticsRow(id: id, title: title, value: "No data", isAvailable: false)
+    }
+}

--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -188,6 +188,13 @@ nonisolated struct ModelQuota: Codable, Identifiable, Sendable {
         // Codex quota names
         case "codex-session": return "Session"
         case "codex-weekly": return "Weekly"
+        case "codex-spark": return "Codex Spark"
+        case "codex-spark-weekly": return "Codex Spark Weekly"
+        case let name where name.hasPrefix("codex-"):
+            return name.dropFirst("codex-".count)
+                .split(separator: "-")
+                .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+                .joined(separator: " ")
         // Copilot quota names
         case "copilot-chat": return "Chat"
         case "copilot-completions": return "Completions"
@@ -273,13 +280,22 @@ nonisolated struct ProviderQuotaData: Codable, Sendable {
     var isForbidden: Bool
     var planType: String?
     var tokenExpiresAt: Date?  // For Kiro: token expiry time
+    var analytics: QuotaAnalytics?
 
-    init(models: [ModelQuota] = [], lastUpdated: Date = Date(), isForbidden: Bool = false, planType: String? = nil, tokenExpiresAt: Date? = nil) {
+    init(
+        models: [ModelQuota] = [],
+        lastUpdated: Date = Date(),
+        isForbidden: Bool = false,
+        planType: String? = nil,
+        tokenExpiresAt: Date? = nil,
+        analytics: QuotaAnalytics? = nil
+    ) {
         self.models = models
         self.lastUpdated = lastUpdated
         self.isForbidden = isForbidden
         self.planType = planType
         self.tokenExpiresAt = tokenExpiresAt
+        self.analytics = analytics
     }
 
     /// Format token expiry time in user's local timezone

--- a/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
@@ -46,24 +46,6 @@ nonisolated struct CodexJWTClaims: Sendable {
     let subscriptionActiveUntil: Date?
 }
 
-/// Quota data from Codex CLI
-nonisolated struct CodexCLIQuotaInfo: Sendable {
-    let email: String
-    let planType: String?
-    let organizationName: String?
-    let subscriptionActiveUntil: Date?
-    
-    /// Session (3-hour window) usage
-    let sessionUsedPercent: Int
-    let sessionResetAt: Date?
-    
-    /// Weekly usage
-    let weeklyUsedPercent: Int
-    let weeklyResetAt: Date?
-    
-    let limitReached: Bool
-}
-
 /// Fetches quota from Codex CLI auth file
 actor CodexCLIQuotaFetcher {
     private let authFilePath = "~/.codex/auth.json"
@@ -168,7 +150,7 @@ actor CodexCLIQuotaFetcher {
     }
     
     /// Fetch quota from ChatGPT usage API
-    func fetchQuota(accessToken: String, accountId: String?) async throws -> CodexCLIQuotaInfo {
+    func fetchQuota(accessToken: String, accountId: String?, identity: CodexQuotaIdentity) async throws -> ProviderQuotaData {
         guard let url = URL(string: usageURL) else {
             throw CodexCLIQuotaError.invalidURL
         }
@@ -193,59 +175,26 @@ actor CodexCLIQuotaFetcher {
             throw CodexCLIQuotaError.httpError(httpResponse.statusCode)
         }
         
-        // Parse the usage response
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            throw CodexCLIQuotaError.invalidResponse
-        }
-        
-        let quotaInfo = parseUsageResponse(json)
+        var quotaData = try CodexUsageMapper.map(data: data, identity: identity)
 #if DEBUG
-        Log.quota("plan_type=\(quotaInfo.planType ?? "<nil>")")
+        Log.quota("plan_type=\(quotaData.planType ?? "<nil>")")
 #endif
-        return quotaInfo
-    }
-    
-    /// Parse usage API response
-    private func parseUsageResponse(_ json: [String: Any]) -> CodexCLIQuotaInfo {
-        let planType = json["plan_type"] as? String
-        
-        var sessionUsedPercent = 0
-        var sessionResetAt: Date? = nil
-        var weeklyUsedPercent = 0
-        var weeklyResetAt: Date? = nil
-        var limitReached = false
-        
-        if let rateLimit = json["rate_limit"] as? [String: Any] {
-            limitReached = rateLimit["limit_reached"] as? Bool ?? false
-            
-            // Primary window = session (3h)
-            if let primaryWindow = rateLimit["primary_window"] as? [String: Any] {
-                sessionUsedPercent = primaryWindow["used_percent"] as? Int ?? 0
-                if let resetAt = primaryWindow["reset_at"] as? Int {
-                    sessionResetAt = Date(timeIntervalSince1970: TimeInterval(resetAt))
-                }
-            }
-            
-            // Secondary window = weekly
-            if let secondaryWindow = rateLimit["secondary_window"] as? [String: Any] {
-                weeklyUsedPercent = secondaryWindow["used_percent"] as? Int ?? 0
-                if let resetAt = secondaryWindow["reset_at"] as? Int {
-                    weeklyResetAt = Date(timeIntervalSince1970: TimeInterval(resetAt))
-                }
-            }
+        if let profileAnalytics = await fetchProfileAnalytics(accessToken: accessToken, accountId: accountId) {
+            quotaData.analytics = quotaData.analytics?.merging(profileAnalytics) ?? profileAnalytics
         }
-        
-        return CodexCLIQuotaInfo(
-            email: "Codex User",
-            planType: planType,
-            organizationName: nil,
-            subscriptionActiveUntil: nil,
-            sessionUsedPercent: sessionUsedPercent,
-            sessionResetAt: sessionResetAt,
-            weeklyUsedPercent: weeklyUsedPercent,
-            weeklyResetAt: weeklyResetAt,
-            limitReached: limitReached
-        )
+        return quotaData
+    }
+
+    private func fetchProfileAnalytics(accessToken: String, accountId: String?) async -> QuotaAnalytics? {
+        do {
+            return try await CodexProfileAnalyticsFetcher(urlSession: session).fetch(
+                accessToken: accessToken,
+                accountID: accountId
+            )
+        } catch {
+            Log.quota("Failed to fetch Codex profile analytics: \(error)")
+            return nil
+        }
     }
     
     /// Refresh access token using refresh token
@@ -332,45 +281,13 @@ actor CodexCLIQuotaFetcher {
         
         // Fetch quota from API
         do {
-            let quotaInfo = try await fetchQuota(accessToken: currentAccessToken, accountId: accountId)
-            
-            // Build model quotas
-            var models: [ModelQuota] = []
-            
-            // Session quota (3-hour window)
-            let sessionResetStr: String
-            if let resetAt = quotaInfo.sessionResetAt {
-                sessionResetStr = ISO8601DateFormatter().string(from: resetAt)
-            } else {
-                sessionResetStr = ""
-            }
-            models.append(ModelQuota(
-                name: "codex-session",
-                percentage: Double(100 - quotaInfo.sessionUsedPercent),
-                resetTime: sessionResetStr
-            ))
-            
-            // Weekly quota
-            let weeklyResetStr: String
-            if let resetAt = quotaInfo.weeklyResetAt {
-                weeklyResetStr = ISO8601DateFormatter().string(from: resetAt)
-            } else {
-                weeklyResetStr = ""
-            }
-            models.append(ModelQuota(
-                name: "codex-weekly",
-                percentage: Double(100 - quotaInfo.weeklyUsedPercent),
-                resetTime: weeklyResetStr
-            ))
-            
-            let providerQuota = ProviderQuotaData(
-                models: models,
-                lastUpdated: Date(),
-                isForbidden: quotaInfo.limitReached,
-                planType: quotaInfo.planType ?? planType
+            let providerQuota = try await fetchQuota(
+                accessToken: currentAccessToken,
+                accountId: accountId,
+                identity: CodexQuotaIdentity(planType: planType)
             )
 #if DEBUG
-            Log.quota("finalPlan=\(providerQuota.planType ?? "<nil>") usage=\(quotaInfo.planType ?? "<nil>") jwt=\(planType ?? "<nil>")")
+            Log.quota("finalPlan=\(providerQuota.planType ?? "<nil>") jwt=\(planType ?? "<nil>")")
 #endif
             
             return [email: providerQuota]

--- a/Quotio/Services/QuotaFetchers/CodexUsageMapper.swift
+++ b/Quotio/Services/QuotaFetchers/CodexUsageMapper.swift
@@ -1,0 +1,588 @@
+import Foundation
+
+nonisolated struct CodexQuotaIdentity: Sendable {
+    var planType: String?
+}
+
+nonisolated enum CodexUsageMapper {
+    static func map(
+        data: Data,
+        identity: CodexQuotaIdentity = CodexQuotaIdentity(),
+        updatedAt: Date = Date()
+    ) throws -> ProviderQuotaData {
+        let response = try JSONDecoder().decode(CodexUsageResponseV2.self, from: data)
+        let rawJSON = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+
+        var models: [ModelQuota] = []
+        if let primary = modelQuota(name: "codex-session", from: response.rateLimit?.primaryWindow) {
+            models.append(primary)
+        }
+        if let secondary = modelQuota(name: "codex-weekly", from: response.rateLimit?.secondaryWindow) {
+            models.append(secondary)
+        }
+        models.append(contentsOf: extraModels(from: response.additionalRateLimits))
+
+        let planType = response.planType ?? identity.planType
+        return ProviderQuotaData(
+            models: models,
+            lastUpdated: updatedAt,
+            isForbidden: response.rateLimit?.limitReached ?? false,
+            planType: planType,
+            analytics: analytics(from: rawJSON)
+        )
+    }
+
+    private static func modelQuota(name: String, from snapshot: CodexUsageResponseV2.WindowSnapshot?) -> ModelQuota? {
+        guard let snapshot else { return nil }
+        return ModelQuota(
+            name: name,
+            percentage: Double(100 - snapshot.usedPercent),
+            resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? ""
+        )
+    }
+
+    private static func extraModels(from limits: [CodexUsageResponseV2.AdditionalRateLimit]?) -> [ModelQuota] {
+        guard let limits, !limits.isEmpty else { return [] }
+        var usedIDs = Set<String>()
+        return limits.flatMap { limit in
+            if isSpark(limit) {
+                return sparkModels(from: limit, usedIDs: &usedIDs)
+            }
+
+            guard let snapshot = limit.rateLimit?.primaryWindow ?? limit.rateLimit?.secondaryWindow,
+                  let id = modelID(for: limit),
+                  usedIDs.insert(id).inserted
+            else {
+                return []
+            }
+            return [ModelQuota(
+                name: id,
+                percentage: Double(100 - snapshot.usedPercent),
+                resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? ""
+            )]
+        }
+    }
+
+    private static func sparkModels(
+        from limit: CodexUsageResponseV2.AdditionalRateLimit,
+        usedIDs: inout Set<String>
+    ) -> [ModelQuota] {
+        [
+            (limit.rateLimit?.primaryWindow, sparkKind(for: limit.rateLimit?.primaryWindow, fallback: .fiveHour)),
+            (limit.rateLimit?.secondaryWindow, sparkKind(for: limit.rateLimit?.secondaryWindow, fallback: .weekly))
+        ].compactMap { snapshot, kind in
+            guard let snapshot, usedIDs.insert(kind.id).inserted else { return nil }
+            return ModelQuota(
+                name: kind.id,
+                percentage: Double(100 - snapshot.usedPercent),
+                resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? ""
+            )
+        }
+    }
+
+    private static func sparkKind(
+        for snapshot: CodexUsageResponseV2.WindowSnapshot?,
+        fallback: SparkWindowKind
+    ) -> SparkWindowKind {
+        guard let minutes = snapshot?.windowMinutes else { return fallback }
+        if minutes <= 6 * 60 { return .fiveHour }
+        if minutes >= 6 * 24 * 60 { return .weekly }
+        return fallback
+    }
+
+    private static func modelID(for limit: CodexUsageResponseV2.AdditionalRateLimit) -> String? {
+        guard let source = firstNonEmpty(limit.meteredFeature, limit.limitName) else { return nil }
+        let slug = slug(source)
+        return slug.isEmpty ? nil : "codex-\(slug)"
+    }
+
+    private static func isSpark(_ limit: CodexUsageResponseV2.AdditionalRateLimit) -> Bool {
+        [limit.limitName, limit.meteredFeature]
+            .compactMap { $0?.lowercased() }
+            .contains { $0.contains("spark") }
+    }
+
+    private static func analytics(from json: [String: Any]?) -> QuotaAnalytics? {
+        guard let json else { return nil }
+        var rows: [QuotaAnalyticsRow] = []
+        if let credits = creditsRemaining(from: json) {
+            let creditCount = Int(max(0, credits.rounded(.down)))
+            rows.append(QuotaAnalyticsRow(
+                id: "codex-extra-usage",
+                title: "Extra Usage",
+                value: "\(formatDollars(Double(creditCount) * 0.04)) - \(creditCount) credits"
+            ))
+        }
+        if let count = resetCreditsCount(from: json) {
+            rows.append(QuotaAnalyticsRow(
+                id: "codex-rate-limit-resets",
+                title: "Rate Limit Resets",
+                value: "\(count) available"
+            ))
+        }
+        return rows.isEmpty ? nil : QuotaAnalytics(rows: rows)
+    }
+
+    private static func creditsRemaining(from json: [String: Any]) -> Double? {
+        guard let credits = json["credits"] as? [String: Any] else { return nil }
+        if let balance = doubleValue(credits["balance"]) {
+            return max(0, balance)
+        }
+        if credits["has_credits"] as? Bool == false {
+            return 0
+        }
+        return nil
+    }
+
+    private static func resetCreditsCount(from json: [String: Any]) -> Int? {
+        guard let resets = json["rate_limit_reset_credits"] as? [String: Any],
+              let count = doubleValue(resets["available_count"]),
+              count >= 0
+        else {
+            return nil
+        }
+        return Int(count.rounded(.down))
+    }
+
+    private static func formatDollars(_ value: Double) -> String {
+        if value >= 1000 {
+            return String(format: "$%.1fK", value / 1000)
+        }
+        return String(format: "$%.2f", value)
+    }
+
+    private static func firstNonEmpty(_ values: String?...) -> String? {
+        for value in values {
+            if let value = trimmedNonEmpty(value) {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private static func slug(_ value: String) -> String {
+        var result = ""
+        var lastWasDash = false
+        for scalar in value.lowercased().unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) {
+                result.unicodeScalars.append(scalar)
+                lastWasDash = false
+            } else if !lastWasDash {
+                result.append("-")
+                lastWasDash = true
+            }
+        }
+        return result.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+
+    private enum SparkWindowKind {
+        case fiveHour
+        case weekly
+
+        var id: String {
+            switch self {
+            case .fiveHour: "codex-spark"
+            case .weekly: "codex-spark-weekly"
+            }
+        }
+    }
+}
+
+nonisolated struct CodexUsageResponseV2: Decodable {
+    var planType: String?
+    var rateLimit: RateLimitDetails?
+    var additionalRateLimits: [AdditionalRateLimit]?
+
+    enum CodingKeys: String, CodingKey {
+        case planType = "plan_type"
+        case rateLimit = "rate_limit"
+        case additionalRateLimits = "additional_rate_limits"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        planType = try? container.decodeIfPresent(String.self, forKey: .planType)
+        rateLimit = try? container.decodeIfPresent(RateLimitDetails.self, forKey: .rateLimit)
+        if let decoded = try? container.decodeIfPresent([LossyAdditionalRateLimit].self, forKey: .additionalRateLimits) {
+            additionalRateLimits = decoded.compactMap(\.value)
+        }
+    }
+
+    struct RateLimitDetails: Decodable {
+        var limitReached: Bool?
+        var primaryWindow: WindowSnapshot?
+        var secondaryWindow: WindowSnapshot?
+
+        enum CodingKeys: String, CodingKey {
+            case limitReached = "limit_reached"
+            case primaryWindow = "primary_window"
+            case secondaryWindow = "secondary_window"
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            limitReached = try? container.decodeIfPresent(Bool.self, forKey: .limitReached)
+            primaryWindow = try? container.decodeIfPresent(WindowSnapshot.self, forKey: .primaryWindow)
+            secondaryWindow = try? container.decodeIfPresent(WindowSnapshot.self, forKey: .secondaryWindow)
+        }
+    }
+
+    struct WindowSnapshot: Decodable {
+        var usedPercent: Int
+        var resetAt: Int?
+        var limitWindowSeconds: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case usedPercent = "used_percent"
+            case resetAt = "reset_at"
+            case limitWindowSeconds = "limit_window_seconds"
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            usedPercent = (try Self.flexibleInt(container, forKey: .usedPercent)).clamped(to: 0...100)
+            resetAt = try? Self.flexibleInt(container, forKey: .resetAt)
+            limitWindowSeconds = try? Self.flexibleInt(container, forKey: .limitWindowSeconds)
+        }
+
+        var resetDate: Date? {
+            guard let resetAt, resetAt > 0 else { return nil }
+            return Date(timeIntervalSince1970: TimeInterval(resetAt))
+        }
+
+        var windowMinutes: Int? {
+            guard let limitWindowSeconds, limitWindowSeconds > 0 else { return nil }
+            return limitWindowSeconds / 60
+        }
+
+        private static func flexibleInt(
+            _ container: KeyedDecodingContainer<CodingKeys>,
+            forKey key: CodingKeys
+        ) throws -> Int {
+            if let int = try? container.decode(Int.self, forKey: key) {
+                return int
+            }
+            if let double = try? container.decode(Double.self, forKey: key) {
+                return Int(double.rounded())
+            }
+            if let string = try? container.decode(String.self, forKey: key), let double = Double(string) {
+                return Int(double.rounded())
+            }
+            throw DecodingError.dataCorrupted(.init(codingPath: [key], debugDescription: "Expected number"))
+        }
+    }
+
+    struct AdditionalRateLimit: Decodable {
+        var limitName: String?
+        var meteredFeature: String?
+        var rateLimit: RateLimitDetails?
+
+        enum CodingKeys: String, CodingKey {
+            case limitName = "limit_name"
+            case meteredFeature = "metered_feature"
+            case rateLimit = "rate_limit"
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            limitName = try? container.decodeIfPresent(String.self, forKey: .limitName)
+            meteredFeature = try? container.decodeIfPresent(String.self, forKey: .meteredFeature)
+            rateLimit = try? container.decodeIfPresent(RateLimitDetails.self, forKey: .rateLimit)
+        }
+    }
+
+    private struct LossyAdditionalRateLimit: Decodable {
+        var value: AdditionalRateLimit?
+
+        init(from decoder: Decoder) throws {
+            value = try? AdditionalRateLimit(from: decoder)
+        }
+    }
+}
+
+nonisolated enum CodexProfileAnalyticsError: Error, Equatable {
+    case authenticationRequired
+}
+
+nonisolated struct CodexProfileAnalyticsFetcher: Sendable {
+    private static let profileURL = URL(string: "https://chatgpt.com/backend-api/wham/profiles/me")!
+
+    let urlSession: URLSession
+    var now: @Sendable () -> Date = Date.init
+
+    init(urlSession: URLSession = .shared, now: @escaping @Sendable () -> Date = Date.init) {
+        self.urlSession = urlSession
+        self.now = now
+    }
+
+    func fetch(accessToken: String, accountID: String?) async throws -> QuotaAnalytics? {
+        var request = URLRequest(url: Self.profileURL)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Codex Desktop", forHTTPHeaderField: "Originator")
+        if let accountID, !accountID.isEmpty {
+            request.setValue(accountID, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+
+        let (data, response) = try await urlSession.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+        if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+            throw CodexProfileAnalyticsError.authenticationRequired
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            return nil
+        }
+
+        let profile = try CodexProfileAnalyticsResponse(data: data)
+        return Self.analytics(from: profile, now: now())
+    }
+
+    static func analytics(from response: CodexProfileAnalyticsResponse, now: Date = Date()) -> QuotaAnalytics? {
+        guard let stats = response.stats else { return nil }
+
+        var rows: [QuotaAnalyticsRow] = []
+        let calendar = Calendar.current
+        let today = dayString(now, calendar: calendar)
+        let yesterday = dayString(calendar.date(byAdding: .day, value: -1, to: now) ?? now, calendar: calendar)
+        let bucketsByDate = Dictionary(uniqueKeysWithValues: stats.dailyUsageBuckets.map { ($0.date, $0.tokens) })
+
+        rows.append(dayRow(id: "today", title: "Today", tokens: bucketsByDate[today]))
+        rows.append(dayRow(id: "yesterday", title: "Yesterday", tokens: bucketsByDate[yesterday]))
+
+        let latest30 = stats.dailyUsageBuckets.sorted { $0.date > $1.date }.prefix(30)
+        let last30Tokens = latest30.reduce(0) { $0 + $1.tokens }
+        rows.append(last30Tokens > 0
+            ? QuotaAnalyticsRow(id: "last-30-days", title: "Last 30 Days", value: tokenLabel(last30Tokens))
+            : .noData(id: "last-30-days", title: "Last 30 Days"))
+
+        appendTokenRow(&rows, id: "codex-lifetime-tokens", title: "Lifetime Tokens", value: stats.lifetimeTokens)
+        appendTokenRow(&rows, id: "codex-peak-daily", title: "Peak Daily", value: stats.peakDailyTokens)
+        appendDurationRow(&rows, id: "codex-longest-task", title: "Longest Task", seconds: stats.longestRunningTurnSeconds)
+        appendDaysRow(&rows, id: "codex-current-streak", title: "Current Streak", value: stats.currentStreakDays)
+        appendDaysRow(&rows, id: "codex-longest-streak", title: "Longest Streak", value: stats.longestStreakDays)
+
+        let trend = stats.dailyUsageBuckets
+            .sorted { $0.date < $1.date }
+            .suffix(371)
+            .map {
+                QuotaAnalyticsPoint(
+                    date: $0.date,
+                    value: Double($0.tokens),
+                    label: $0.date,
+                    valueLabel: tokenLabel($0.tokens)
+                )
+            }
+
+        let analytics = QuotaAnalytics(trend: trend, rows: rows, note: "Account analytics from Codex")
+        return analytics.isEmpty ? nil : analytics
+    }
+
+    private static func dayRow(id: String, title: String, tokens: Int?) -> QuotaAnalyticsRow {
+        guard let tokens, tokens > 0 else {
+            return .noData(id: id, title: title)
+        }
+        return QuotaAnalyticsRow(id: id, title: title, value: tokenLabel(tokens))
+    }
+
+    private static func appendTokenRow(_ rows: inout [QuotaAnalyticsRow], id: String, title: String, value: Int?) {
+        guard let value, value > 0 else { return }
+        rows.append(QuotaAnalyticsRow(id: id, title: title, value: tokenLabel(value)))
+    }
+
+    private static func appendDaysRow(_ rows: inout [QuotaAnalyticsRow], id: String, title: String, value: Int?) {
+        guard let value, value >= 0 else { return }
+        rows.append(QuotaAnalyticsRow(id: id, title: title, value: "\(intLabel(value)) \(value == 1 ? "day" : "days")"))
+    }
+
+    private static func appendDurationRow(_ rows: inout [QuotaAnalyticsRow], id: String, title: String, seconds: Int?) {
+        guard let seconds, seconds > 0 else { return }
+        rows.append(QuotaAnalyticsRow(id: id, title: title, value: durationLabel(seconds)))
+    }
+
+    private static func dayString(_ date: Date, calendar: Calendar) -> String {
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", components.year ?? 0, components.month ?? 0, components.day ?? 0)
+    }
+
+    private static func tokenLabel(_ value: Int) -> String {
+        "\(compactNumber(Double(value))) tokens"
+    }
+
+    private static func durationLabel(_ seconds: Int) -> String {
+        let hours = seconds / 3_600
+        let minutes = (seconds % 3_600) / 60
+        let remainingSeconds = seconds % 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        if minutes > 0 {
+            return "\(minutes)m \(remainingSeconds)s"
+        }
+        return "\(remainingSeconds)s"
+    }
+
+    private static func compactNumber(_ value: Double) -> String {
+        let absValue = abs(value)
+        if absValue >= 1_000_000_000 {
+            return String(format: "%.1fB", value / 1_000_000_000).replacingOccurrences(of: ".0B", with: "B")
+        }
+        if absValue >= 1_000_000 {
+            return String(format: "%.1fM", value / 1_000_000).replacingOccurrences(of: ".0M", with: "M")
+        }
+        if absValue >= 1_000 {
+            return String(format: "%.1fK", value / 1_000).replacingOccurrences(of: ".0K", with: "K")
+        }
+        return intLabel(Int(value))
+    }
+
+    private static func intLabel(_ value: Int) -> String {
+        NumberFormatter.localizedString(from: NSNumber(value: value), number: .decimal)
+    }
+}
+
+nonisolated struct CodexProfileAnalyticsResponse: Equatable, Sendable {
+    var stats: Stats?
+
+    init(data: Data) throws {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Expected object"))
+        }
+        self.init(json: json)
+    }
+
+    init(json: [String: Any]) {
+        stats = (json["stats"] as? [String: Any]).map(Stats.init(json:))
+    }
+
+    nonisolated struct Stats: Equatable, Sendable {
+        var lifetimeTokens: Int?
+        var peakDailyTokens: Int?
+        var currentStreakDays: Int?
+        var longestStreakDays: Int?
+        var longestRunningTurnSeconds: Int?
+        var dailyUsageBuckets: [UsageBucket]
+
+        init(json: [String: Any]) {
+            lifetimeTokens = intValue(json["lifetime_tokens"] ?? json["lifetimeTokens"])
+            peakDailyTokens = intValue(json["peak_daily_tokens"] ?? json["peakDailyTokens"])
+            currentStreakDays = intValue(json["current_streak_days"] ?? json["currentStreakDays"])
+            longestStreakDays = intValue(json["longest_streak_days"] ?? json["longestStreakDays"])
+            longestRunningTurnSeconds = intValue(json["longest_running_turn_sec"] ?? json["longestRunningTurnSec"])
+            dailyUsageBuckets = UsageBucket.decodeBuckets(json["daily_usage_buckets"] ?? json["dailyUsageBuckets"])
+        }
+    }
+
+    nonisolated struct UsageBucket: Equatable, Sendable {
+        var date: String
+        var tokens: Int
+
+        static func decodeBuckets(_ value: Any?) -> [UsageBucket] {
+            if let array = value as? [Any] {
+                return array.compactMap(bucket(from:))
+            }
+            if let object = value as? [String: Any] {
+                return object.compactMap { key, value in
+                    guard let tokens = tokenCount(from: value) else { return nil }
+                    return UsageBucket(date: normalizeDate(key), tokens: tokens)
+                }
+            }
+            return []
+        }
+
+        private static func bucket(from value: Any) -> UsageBucket? {
+            guard let object = value as? [String: Any] else { return nil }
+            guard let date = stringValue(
+                object["date"]
+                    ?? object["day"]
+                    ?? object["start_date"]
+                    ?? object["startDate"]
+                    ?? object["bucket"]
+                    ?? object["bucket_start"]
+                    ?? object["bucketStart"]
+            ) else {
+                return nil
+            }
+            guard let tokens = tokenCount(from: object) else { return nil }
+            return UsageBucket(date: normalizeDate(date), tokens: tokens)
+        }
+
+        private static func tokenCount(from value: Any?) -> Int? {
+            if let object = value as? [String: Any] {
+                if let total = intValue(
+                    object["tokens"]
+                        ?? object["token_count"]
+                        ?? object["tokenCount"]
+                        ?? object["total_tokens"]
+                        ?? object["totalTokens"]
+                        ?? object["value"]
+                        ?? object["count"]
+                ) {
+                    return total
+                }
+                let input = intValue(object["input_tokens"] ?? object["inputTokens"]) ?? 0
+                let output = intValue(object["output_tokens"] ?? object["outputTokens"]) ?? 0
+                return input + output > 0 ? input + output : nil
+            }
+            return intValue(value)
+        }
+
+        private static func normalizeDate(_ value: String) -> String {
+            if value.count >= 10 {
+                return String(value.prefix(10))
+            }
+            return value
+        }
+    }
+}
+
+nonisolated func stringValue(_ value: Any?) -> String? {
+    switch value {
+    case let value as String:
+        value
+    case let value as CustomStringConvertible:
+        value.description
+    default:
+        nil
+    }
+}
+
+nonisolated func doubleValue(_ value: Any?) -> Double? {
+    switch value {
+    case let value as Double:
+        value
+    case let value as Int:
+        Double(value)
+    case let value as String:
+        Double(value)
+    default:
+        nil
+    }
+}
+
+nonisolated func intValue(_ value: Any?) -> Int? {
+    switch value {
+    case let value as Int:
+        value
+    case let value as Double:
+        Int(value)
+    case let value as String:
+        Int(value) ?? Double(value).map(Int.init)
+    default:
+        nil
+    }
+}
+
+nonisolated func trimmedNonEmpty(_ value: String?) -> String? {
+    guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+        return nil
+    }
+    return value
+}
+
+extension Comparable {
+    nonisolated func clamped(to range: ClosedRange<Self>) -> Self {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/Quotio/Services/QuotaFetchers/OpenAIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/OpenAIQuotaFetcher.swift
@@ -86,6 +86,15 @@ actor OpenAIQuotaFetcher {
         return trimmedNonEmpty(json["email"] as? String)
     }
 
+    private func decodePlanType(fromJWT token: String) -> String? {
+        guard let json = decodeJWTPayload(token: token) else { return nil }
+        if let authInfo = json["https://api.openai.com/auth"] as? [String: Any],
+           let planType = trimmedNonEmpty(authInfo["chatgpt_plan_type"] as? String) {
+            return planType
+        }
+        return trimmedNonEmpty(json["chatgpt_plan_type"] as? String)
+    }
+
     private func fallbackKey(fromFilename filename: String) -> String {
         filename.codexFilenameKey
     }
@@ -112,7 +121,7 @@ actor OpenAIQuotaFetcher {
         */
     }
     
-    func fetchQuota(accessToken: String, accountId: String?) async throws -> CodexQuotaData {
+    func fetchQuota(accessToken: String, accountId: String?, identity: CodexQuotaIdentity) async throws -> ProviderQuotaData {
         guard let url = URL(string: usageURL) else {
             throw CodexQuotaError.invalidURL
         }
@@ -137,14 +146,17 @@ actor OpenAIQuotaFetcher {
             throw CodexQuotaError.httpError(httpResponse.statusCode)
         }
         
-        let quotaResponse = try JSONDecoder().decode(CodexUsageResponse.self, from: data)
+        var quotaData = try CodexUsageMapper.map(data: data, identity: identity)
 #if DEBUG
-        Log.quota("plan_type=\(quotaResponse.planType ?? "<nil>")")
+        Log.quota("plan_type=\(quotaData.planType ?? "<nil>")")
 #endif
-        return CodexQuotaData(from: quotaResponse)
+        if let profileAnalytics = await fetchProfileAnalytics(accessToken: accessToken, accountId: accountId) {
+            quotaData.analytics = quotaData.analytics?.merging(profileAnalytics) ?? profileAnalytics
+        }
+        return quotaData
     }
     
-    func fetchQuotaForAuthFile(at path: String) async throws -> (accountKey: String, quota: CodexQuotaData) {
+    func fetchQuotaForAuthFile(at path: String) async throws -> (accountKey: String, quota: ProviderQuotaData) {
         let url = URL(fileURLWithPath: path)
         let data = try Data(contentsOf: url)
         let authFile = try JSONDecoder().decode(CodexAuthFile.self, from: data)
@@ -157,6 +169,9 @@ actor OpenAIQuotaFetcher {
         )
 
         var accessToken = authFile.accessToken
+        let identity = CodexQuotaIdentity(
+            planType: authFile.idToken.flatMap(decodePlanType)
+        )
 
         if authFile.isExpired, let refreshToken = authFile.refreshToken {
             do {
@@ -167,8 +182,20 @@ actor OpenAIQuotaFetcher {
             }
         }
 
-        let quota = try await fetchQuota(accessToken: accessToken, accountId: accountId)
+        let quota = try await fetchQuota(accessToken: accessToken, accountId: accountId, identity: identity)
         return (accountKey: accountKey, quota: quota)
+    }
+
+    private func fetchProfileAnalytics(accessToken: String, accountId: String?) async -> QuotaAnalytics? {
+        do {
+            return try await CodexProfileAnalyticsFetcher(urlSession: session).fetch(
+                accessToken: accessToken,
+                accountID: accountId
+            )
+        } catch {
+            Log.quota("Failed to fetch Codex profile analytics: \(error)")
+            return nil
+        }
     }
     
     private func refreshAccessToken(refreshToken: String) async throws -> String {
@@ -227,128 +254,13 @@ actor OpenAIQuotaFetcher {
             
             do {
                 let result = try await fetchQuotaForAuthFile(at: filePath)
-                results[result.accountKey] = result.quota.toProviderQuotaData()
+                results[result.accountKey] = result.quota
             } catch {
                 Log.quota("Failed to fetch Codex quota for \(file): \(error)")
             }
         }
         
         return results
-    }
-}
-
-nonisolated struct CodexUsageResponse: Codable, Sendable {
-    let planType: String?
-    let rateLimit: RateLimitInfo?
-    let codeReviewRateLimit: RateLimitInfo?
-    let credits: CreditsInfo?
-    
-    enum CodingKeys: String, CodingKey {
-        case planType = "plan_type"
-        case rateLimit = "rate_limit"
-        case codeReviewRateLimit = "code_review_rate_limit"
-        case credits
-    }
-}
-
-nonisolated struct RateLimitInfo: Codable, Sendable {
-    let allowed: Bool?
-    let limitReached: Bool?
-    let primaryWindow: WindowInfo?
-    let secondaryWindow: WindowInfo?
-    
-    enum CodingKeys: String, CodingKey {
-        case allowed
-        case limitReached = "limit_reached"
-        case primaryWindow = "primary_window"
-        case secondaryWindow = "secondary_window"
-    }
-}
-
-nonisolated struct WindowInfo: Codable, Sendable {
-    let usedPercent: Int?
-    let limitWindowSeconds: Int?
-    let resetAfterSeconds: Int?
-    let resetAt: Int?
-    
-    enum CodingKeys: String, CodingKey {
-        case usedPercent = "used_percent"
-        case limitWindowSeconds = "limit_window_seconds"
-        case resetAfterSeconds = "reset_after_seconds"
-        case resetAt = "reset_at"
-    }
-}
-
-nonisolated struct CreditsInfo: Codable, Sendable {
-    let hasCredits: Bool?
-    let unlimited: Bool?
-    let balance: String?
-    
-    enum CodingKeys: String, CodingKey {
-        case hasCredits = "has_credits"
-        case unlimited
-        case balance
-    }
-}
-
-nonisolated struct CodexQuotaData: Codable, Sendable {
-    let planType: String
-    let sessionUsedPercent: Int
-    let sessionResetAt: Date?
-    let weeklyUsedPercent: Int
-    let weeklyResetAt: Date?
-    let limitReached: Bool
-    let lastUpdated: Date
-    
-    init(from response: CodexUsageResponse) {
-        self.planType = response.planType ?? "unknown"
-        self.sessionUsedPercent = response.rateLimit?.primaryWindow?.usedPercent ?? 0
-        self.weeklyUsedPercent = response.rateLimit?.secondaryWindow?.usedPercent ?? 0
-        self.limitReached = response.rateLimit?.limitReached ?? false
-        self.lastUpdated = Date()
-        
-        if let resetAt = response.rateLimit?.primaryWindow?.resetAt {
-            self.sessionResetAt = Date(timeIntervalSince1970: TimeInterval(resetAt))
-        } else {
-            self.sessionResetAt = nil
-        }
-        
-        if let resetAt = response.rateLimit?.secondaryWindow?.resetAt {
-            self.weeklyResetAt = Date(timeIntervalSince1970: TimeInterval(resetAt))
-        } else {
-            self.weeklyResetAt = nil
-        }
-    }
-    
-    nonisolated var sessionRemainingPercent: Double {
-        Double(100 - sessionUsedPercent)
-    }
-    
-    nonisolated var weeklyRemainingPercent: Double {
-        Double(100 - weeklyUsedPercent)
-    }
-    
-    nonisolated func toProviderQuotaData() -> ProviderQuotaData {
-        var models: [ModelQuota] = []
-        
-        models.append(ModelQuota(
-            name: "codex-session",
-            percentage: sessionRemainingPercent,
-            resetTime: sessionResetAt.map { ISO8601DateFormatter().string(from: $0) } ?? ""
-        ))
-        
-        models.append(ModelQuota(
-            name: "codex-weekly",
-            percentage: weeklyRemainingPercent,
-            resetTime: weeklyResetAt.map { ISO8601DateFormatter().string(from: $0) } ?? ""
-        ))
-        
-        return ProviderQuotaData(
-            models: models,
-            lastUpdated: lastUpdated,
-            isForbidden: limitReached,
-            planType: planType
-        )
     }
 }
 

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -261,12 +261,22 @@ final class StatusBarMenuBuilder {
 
         let item = viewItem(for: cardView)
 
-        if provider == .antigravity && !data.models.isEmpty {
+        if provider == .codex, let analytics = data.analytics, !analytics.isEmpty {
+            let submenu = buildCodexAnalyticsSubmenu(analytics: analytics)
+            item.submenu = submenu
+        } else if provider == .antigravity && !data.models.isEmpty {
             let submenu = buildAntigravitySubmenu(data: data)
             item.submenu = submenu
         }
 
         return item
+    }
+
+    private func buildCodexAnalyticsSubmenu(analytics: QuotaAnalytics) -> NSMenu {
+        let submenu = NSMenu()
+        submenu.autoenablesItems = false
+        submenu.addItem(viewItem(for: AnalyticsDetailSection(analytics: analytics), width: 640))
+        return submenu
     }
 
     // MARK: - Antigravity Submenu
@@ -749,8 +759,43 @@ private struct MenuAccountCardView: View {
             return (info.tierDisplayName, .secondary.opacity(0.1), .secondary)
         }
         
-        guard let planName = data.planDisplayName else { return nil }
+        guard let planName = provider == .codex ? codexPlanDisplayName(data.planType) : data.planDisplayName else { return nil }
         return planConfig(for: planName)
+    }
+
+    private func codexPlanDisplayName(_ raw: String?) -> String? {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+
+        let exact = [
+            "pro": "Pro 20x",
+            "prolite": "Pro 5x",
+            "pro_lite": "Pro 5x",
+            "pro-lite": "Pro 5x",
+            "pro lite": "Pro 5x"
+        ]
+        if let value = exact[trimmed.lowercased()] {
+            return value
+        }
+
+        let cleaned = trimmed
+            .replacingOccurrences(of: #"(?i)\b(claude|codex|account|plan)\b"#, with: " ", options: .regularExpression)
+            .replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: "-", with: " ")
+            .split(separator: " ")
+            .joined(separator: " ")
+        if let value = exact[cleaned.lowercased()] {
+            return value
+        }
+
+        let display = cleaned.split(separator: " ").map { word -> String in
+            let lower = word.lowercased()
+            if lower == "cbp" || lower == "k12" { return lower.uppercased() }
+            if word == word.uppercased(), word.contains(where: { $0.isLetter }) { return String(word) }
+            return word.prefix(1).uppercased() + word.dropFirst()
+        }.joined(separator: " ")
+        return display.isEmpty ? trimmed : display
     }
     
     private func planConfig(for planName: String) -> (name: String, bgColor: Color, textColor: Color) {
@@ -1000,6 +1045,656 @@ private struct MenuAccountCardView: View {
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
         return formatter.string(from: date)
+    }
+}
+
+private struct AnalyticsDetailSection: View {
+    let analytics: QuotaAnalytics
+
+    @State private var trendMode: AnalyticsTrendMode = .daily
+
+    private static let primaryMetricRowIDs = [
+        "codex-lifetime-tokens",
+        "codex-peak-daily",
+        "codex-longest-task",
+        "codex-current-streak",
+        "codex-longest-streak"
+    ]
+
+    private static let usageMetricRowIDs = [
+        "codex-extra-usage",
+        "codex-rate-limit-resets",
+        "today",
+        "yesterday",
+        "last-30-days"
+    ]
+
+    private static let hiddenRowIDs = Set(primaryMetricRowIDs + usageMetricRowIDs)
+
+    private var metricRows: [QuotaAnalyticsRow] {
+        metricRows(for: Self.primaryMetricRowIDs)
+    }
+
+    private var usageRows: [QuotaAnalyticsRow] {
+        metricRows(for: Self.usageMetricRowIDs)
+    }
+
+    private var shouldShowNote: Bool {
+        metricRows.isEmpty && usageRows.isEmpty
+    }
+
+    private func metricRows(for ids: [String]) -> [QuotaAnalyticsRow] {
+        let rowsByID = analytics.rows.reduce(into: [String: QuotaAnalyticsRow]()) { result, row in
+            result[row.id] = result[row.id] ?? row
+        }
+        return ids.compactMap { rowsByID[$0] }
+    }
+
+    private var detailRows: [QuotaAnalyticsRow] {
+        analytics.rows.filter { !Self.hiddenRowIDs.contains($0.id) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 11) {
+            if !metricRows.isEmpty {
+                AnalyticsMetricStripView(rows: metricRows)
+            }
+
+            if !usageRows.isEmpty {
+                AnalyticsMetricStripView(rows: usageRows)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text("Usage Trend")
+                        .font(.system(size: 11, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.primary)
+
+                    Spacer()
+
+                    if analytics.trend.isEmpty {
+                        Text("No data")
+                            .font(.system(size: 10, weight: .medium, design: .rounded))
+                            .foregroundStyle(.secondary)
+                    } else {
+                        AnalyticsTrendModePicker(selection: $trendMode)
+                    }
+                }
+
+                if !analytics.trend.isEmpty {
+                    UsageTrendHeatmap(points: analytics.trend, mode: trendMode)
+                        .id(trendMode)
+                }
+            }
+
+            ForEach(detailRows) { row in
+                AnalyticsRowView(row: row)
+            }
+
+            if shouldShowNote, let note = analytics.note, !note.isEmpty {
+                Text(note)
+                    .font(.system(size: 9, design: .rounded))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(10)
+    }
+}
+
+private struct AnalyticsMetricStripView: View {
+    let rows: [QuotaAnalyticsRow]
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                AnalyticsMetricTileView(row: row)
+                    .frame(maxWidth: .infinity)
+
+                if index < rows.count - 1 {
+                    Rectangle()
+                        .fill(.separator.opacity(0.45))
+                        .frame(width: 1, height: 34)
+                }
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.primary.opacity(0.025))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(.separator.opacity(0.45), lineWidth: 1)
+        )
+    }
+}
+
+private struct AnalyticsMetricTileView: View {
+    let row: QuotaAnalyticsRow
+
+    private var displayValue: String {
+        switch row.id {
+        case "codex-lifetime-tokens", "codex-peak-daily":
+            row.value.replacingOccurrences(of: " tokens", with: "")
+        default:
+            row.value
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text(displayValue)
+                .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                .foregroundStyle(row.isAvailable ? .primary : .secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+
+            Text(row.title)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, 6)
+        .frame(minWidth: 82)
+    }
+}
+
+private enum AnalyticsTrendMode: String, CaseIterable, Identifiable {
+    case daily
+    case weekly
+    case cumulative
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .daily: "Daily"
+        case .weekly: "Weekly"
+        case .cumulative: "Cumulative"
+        }
+    }
+}
+
+private struct AnalyticsTrendModePicker: View {
+    @Binding var selection: AnalyticsTrendMode
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(AnalyticsTrendMode.allCases) { mode in
+                Button {
+                    selection = mode
+                } label: {
+                    Text(mode.title)
+                        .font(.system(size: 10, weight: .medium, design: .rounded))
+                        .foregroundStyle(selection == mode ? .primary : .tertiary)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+private enum AnalyticsTrendSeries {
+    typealias ParsedPoint = (date: Date, point: QuotaAnalyticsPoint)
+
+    static func dailyPoints(from points: [QuotaAnalyticsPoint]) -> [QuotaAnalyticsPoint] {
+        parsedPoints(from: points).map { item in
+            QuotaAnalyticsPoint(
+                date: dayLabel(for: item.date),
+                value: item.point.value,
+                label: "on \(shortDateLabel(for: item.date))",
+                valueLabel: item.point.valueLabel.isEmpty ? tokenLabel(item.point.value) : item.point.valueLabel
+            )
+        }
+    }
+
+    static func weeklyBuckets(from points: [QuotaAnalyticsPoint], mode: AnalyticsTrendMode) -> [AnalyticsTrendBucket] {
+        let parsed = parsedPoints(from: points)
+        let grouped = Dictionary(grouping: parsed) { item in
+            startOfWeek(containing: item.date)
+        }
+        switch mode {
+        case .daily, .weekly:
+            return grouped.keys.sorted().map { weekStart in
+                let weeklyValue = grouped[weekStart, default: []].reduce(0) { total, item in
+                    total + item.point.value
+                }
+                return AnalyticsTrendBucket(
+                    weekStart: weekStart,
+                    value: weeklyValue,
+                    valueLabel: tokenLabel(weeklyValue),
+                    tooltipLabel: "on week of \(longDateLabel(for: weekStart))"
+                )
+            }
+        case .cumulative:
+            let sortedWeeks = grouped.keys.sorted()
+            guard let first = sortedWeeks.first, let last = sortedWeeks.last else {
+                return []
+            }
+
+            var buckets: [AnalyticsTrendBucket] = []
+            var runningTotal = 0.0
+            var weekStart = first
+
+            while weekStart <= last {
+                runningTotal += grouped[weekStart, default: []].reduce(0) { total, item in
+                    total + item.point.value
+                }
+                buckets.append(AnalyticsTrendBucket(
+                    weekStart: weekStart,
+                    value: runningTotal,
+                    valueLabel: tokenLabel(runningTotal),
+                    tooltipLabel: "through week of \(longDateLabel(for: weekStart))"
+                ))
+
+                guard let nextWeek = calendar.date(byAdding: .day, value: 7, to: weekStart) else {
+                    break
+                }
+                weekStart = nextWeek
+            }
+
+            return buckets
+        }
+    }
+
+    static var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = 1
+        return calendar
+    }
+
+    static func dayLabel(for date: Date) -> String {
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        guard let year = components.year, let month = components.month, let day = components.day else {
+            return "Unknown"
+        }
+        return String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    private static func parsedPoints(from points: [QuotaAnalyticsPoint]) -> [ParsedPoint] {
+        points.compactMap { point in
+            guard let date = date(from: point.date) else { return nil }
+            return (calendar.startOfDay(for: date), point)
+        }
+        .sorted { $0.date < $1.date }
+    }
+
+    private static func startOfWeek(containing date: Date) -> Date {
+        let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)
+        return calendar.date(from: components).map { calendar.startOfDay(for: $0) } ?? date
+    }
+
+    private static func date(from string: String) -> Date? {
+        let day = String(string.prefix(10))
+        let parts = day.split(separator: "-").compactMap { Int($0) }
+        guard parts.count == 3 else { return nil }
+        return calendar.date(from: DateComponents(year: parts[0], month: parts[1], day: parts[2]))
+    }
+
+    private static func shortDateLabel(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "MMM d"
+        return formatter.string(from: date)
+    }
+
+    private static func longDateLabel(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "MMM d, yyyy"
+        return formatter.string(from: date)
+    }
+
+    private static func tokenLabel(_ value: Double) -> String {
+        let absoluteValue = abs(value)
+        if absoluteValue >= 1_000_000_000 {
+            return "\(compactNumber(value / 1_000_000_000))B tokens"
+        }
+        if absoluteValue >= 1_000_000 {
+            return "\(compactNumber(value / 1_000_000))M tokens"
+        }
+        if absoluteValue >= 1_000 {
+            return "\(compactNumber(value / 1_000))K tokens"
+        }
+        return "\(Int(value.rounded())) tokens"
+    }
+
+    private static func compactNumber(_ value: Double) -> String {
+        let rounded = (value * 10).rounded() / 10
+        if rounded.truncatingRemainder(dividingBy: 1) == 0 {
+            return "\(Int(rounded))"
+        }
+        return String(format: "%.1f", rounded)
+    }
+}
+
+private struct AnalyticsTrendBucket: Identifiable {
+    var id: String { AnalyticsTrendSeries.dayLabel(for: weekStart) }
+    let weekStart: Date
+    let value: Double
+    let valueLabel: String
+    let tooltipLabel: String
+}
+
+private struct UsageTrendHeatmap: View {
+    let points: [QuotaAnalyticsPoint]
+    let mode: AnalyticsTrendMode
+
+    @State private var hoveredCellID: String?
+    @State private var hoveredText: String?
+
+    private let cellSize: CGFloat = 9
+    private let spacing: CGFloat = 2.4
+
+    private var calendar: Calendar {
+        AnalyticsTrendSeries.calendar
+    }
+
+    private var parsedPoints: [(date: Date, point: QuotaAnalyticsPoint)] {
+        AnalyticsTrendSeries.dailyPoints(from: points).compactMap { point in
+            guard let date = Self.date(from: point.date, calendar: calendar) else { return nil }
+            return (calendar.startOfDay(for: date), point)
+        }
+        .sorted { $0.date < $1.date }
+    }
+
+    private var heatmapData: HeatmapData {
+        switch mode {
+        case .daily:
+            dailyHeatmapData()
+        case .weekly, .cumulative:
+            weeklyHeatmapData()
+        }
+    }
+
+    private func dailyHeatmapData() -> HeatmapData {
+        let parsed = parsedPoints
+        guard let last = parsed.last?.date else {
+            return HeatmapData(weeks: [], monthLabels: [], width: 0)
+        }
+
+        let pointByDate = parsed.reduce(into: [Date: QuotaAnalyticsPoint]()) { result, item in
+            result[item.date] = item.point
+        }
+        let maxValue = max(parsed.map(\.point.value).max() ?? 0, 1)
+        let first = displayStartDate(endingAt: last)
+        let start = startOfWeek(containing: first)
+        let days = max(calendar.dateComponents([.day], from: start, to: last).day ?? 0, 0)
+        let weekCount = min((days / 7) + 1, 54)
+
+        let weeks = (0..<weekCount).map { weekIndex in
+            let cells = (0..<7).map { weekdayIndex -> HeatmapCell in
+                let dayOffset = weekIndex * 7 + weekdayIndex
+                let date = calendar.date(byAdding: .day, value: dayOffset, to: start) ?? start
+                let point = pointByDate[date]
+                let intensity = point.map { point in
+                    point.value <= 0 ? 0 : max(0.18, min(point.value / maxValue, 1))
+                } ?? 0
+                let isInRange = date >= first && date <= last
+                return HeatmapCell(
+                    id: "\(weekIndex)-\(weekdayIndex)",
+                    date: date,
+                    point: point,
+                    intensity: intensity,
+                    isInRange: isInRange
+                )
+            }
+            return HeatmapWeek(id: weekIndex, cells: cells)
+        }
+
+        let labels = monthLabels(from: start, first: first, last: last, weekCount: weekCount)
+        let width = CGFloat(weekCount) * cellSize + CGFloat(max(weekCount - 1, 0)) * spacing
+        return HeatmapData(weeks: weeks, monthLabels: labels, width: width)
+    }
+
+    private func weeklyHeatmapData() -> HeatmapData {
+        let buckets = AnalyticsTrendSeries.weeklyBuckets(from: points, mode: mode)
+        guard let last = buckets.last?.weekStart else {
+            return HeatmapData(weeks: [], monthLabels: [], width: 0)
+        }
+
+        let bucketByWeek = buckets.reduce(into: [Date: AnalyticsTrendBucket]()) { result, bucket in
+            result[bucket.weekStart] = bucket
+        }
+        let maxValue = max(buckets.map(\.value).max() ?? 0, 1)
+        let first = startOfWeek(containing: displayStartDate(endingAt: last))
+        let days = max(calendar.dateComponents([.day], from: first, to: last).day ?? 0, 0)
+        let weekCount = min((days / 7) + 1, 54)
+
+        let weeks = (0..<weekCount).map { weekIndex in
+            let weekStart = calendar.date(byAdding: .day, value: weekIndex * 7, to: first) ?? first
+            let bucket = bucketByWeek[weekStart]
+            let normalizedValue = bucket.map { $0.value <= 0 ? 0 : max(0.14, min($0.value / maxValue, 1)) } ?? 0
+            let filledRows = normalizedValue <= 0 ? 0 : max(1, min(Int((normalizedValue * 7).rounded(.up)), 7))
+
+            let cells = (0..<7).map { rowIndex -> HeatmapCell in
+                let isFilled = rowIndex >= 7 - filledRows
+                let point = bucket.map { bucket -> QuotaAnalyticsPoint in
+                    QuotaAnalyticsPoint(
+                        date: AnalyticsTrendSeries.dayLabel(for: weekStart),
+                        value: bucket.value,
+                        label: bucket.tooltipLabel,
+                        valueLabel: bucket.valueLabel
+                    )
+                }
+
+                return HeatmapCell(
+                    id: "\(weekIndex)-\(rowIndex)",
+                    date: weekStart,
+                    point: isFilled ? point : nil,
+                    intensity: isFilled ? normalizedValue : 0,
+                    isInRange: true
+                )
+            }
+            return HeatmapWeek(id: weekIndex, cells: cells)
+        }
+
+        let labels = monthLabels(from: first, first: first, last: last, weekCount: weekCount)
+        let width = CGFloat(weekCount) * cellSize + CGFloat(max(weekCount - 1, 0)) * spacing
+        return HeatmapData(weeks: weeks, monthLabels: labels, width: width)
+    }
+
+    var body: some View {
+        let data = heatmapData
+
+        ZStack(alignment: .topTrailing) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 0) {
+                    ForEach(data.monthLabels) { label in
+                        Text(label.title)
+                            .font(.system(size: 9, weight: .medium, design: .rounded))
+                            .foregroundStyle(.tertiary)
+                            .frame(width: monthLabelWidth(for: label, in: data), alignment: .leading)
+                    }
+                }
+                .frame(width: data.width, height: 12, alignment: .leading)
+
+                HStack(alignment: .top, spacing: spacing) {
+                    ForEach(data.weeks) { week in
+                        VStack(spacing: spacing) {
+                            ForEach(week.cells) { cell in
+                                heatmapCell(cell)
+                            }
+                        }
+                    }
+                }
+                .frame(width: data.width, alignment: .leading)
+            }
+
+            if let hoveredText {
+                Text(hoveredText)
+                    .font(.system(size: 10, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(.regularMaterial, in: Capsule())
+                    .overlay(
+                        Capsule()
+                            .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                    )
+                    .shadow(color: .black.opacity(0.16), radius: 8, y: 3)
+                    .offset(y: 18)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 2)
+    }
+
+    private func heatmapCell(_ cell: HeatmapCell) -> some View {
+        RoundedRectangle(cornerRadius: 2.4, style: .continuous)
+            .fill(fillColor(for: cell))
+            .frame(width: cellSize, height: cellSize)
+            .opacity(cell.isInRange ? 1 : 0)
+            .overlay {
+                if hoveredCellID == cell.id, cell.point != nil {
+                    RoundedRectangle(cornerRadius: 2.4, style: .continuous)
+                        .stroke(Color.primary.opacity(0.18), lineWidth: 1)
+                }
+            }
+            .onHover { hovering in
+                updateHover(hovering, cell: cell)
+            }
+    }
+
+    private func fillColor(for cell: HeatmapCell) -> Color {
+        guard cell.intensity > 0 else {
+            return Color.primary.opacity(0.06)
+        }
+        return Color.accentColor.opacity(0.16 + cell.intensity * 0.78)
+    }
+
+    private func updateHover(_ hovering: Bool, cell: HeatmapCell) {
+        guard let point = cell.point else {
+            if !hovering, hoveredCellID == cell.id {
+                hoveredCellID = nil
+                hoveredText = nil
+            }
+            return
+        }
+
+        if hovering {
+            hoveredCellID = cell.id
+            hoveredText = point.label.isEmpty
+                ? "\(point.valueLabel) on \(Self.shortDateLabel(for: cell.date))"
+                : "\(point.valueLabel) \(point.label)"
+        } else if hoveredCellID == cell.id {
+            hoveredCellID = nil
+            hoveredText = nil
+        }
+    }
+
+    private func monthLabelWidth(for label: MonthLabel, in data: HeatmapData) -> CGFloat {
+        guard let index = data.monthLabels.firstIndex(where: { $0.id == label.id }) else {
+            return 0
+        }
+        let nextColumn = data.monthLabels.dropFirst(index + 1).first?.column ?? data.weeks.count
+        let columns = max(nextColumn - label.column, 1)
+        return CGFloat(columns) * cellSize + CGFloat(max(columns - 1, 0)) * spacing
+    }
+
+    private func startOfWeek(containing date: Date) -> Date {
+        let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)
+        return calendar.date(from: components).map { calendar.startOfDay(for: $0) } ?? date
+    }
+
+    private func displayStartDate(endingAt date: Date) -> Date {
+        calendar.date(byAdding: .day, value: -370, to: date)
+            .map { calendar.startOfDay(for: $0) } ?? date
+    }
+
+    private func monthLabels(from start: Date, first: Date, last: Date, weekCount: Int) -> [MonthLabel] {
+        var labels: [MonthLabel] = []
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "MMM"
+
+        var components = calendar.dateComponents([.year, .month], from: first)
+        components.day = 1
+        var monthStart = calendar.date(from: components) ?? first
+        if monthStart < first {
+            monthStart = calendar.date(byAdding: .month, value: 1, to: monthStart) ?? first
+        }
+
+        while monthStart <= last {
+            let column = max(calendar.dateComponents([.day], from: start, to: monthStart).day ?? 0, 0) / 7
+            if column < weekCount {
+                labels.append(MonthLabel(
+                    id: AnalyticsTrendSeries.dayLabel(for: monthStart),
+                    title: formatter.string(from: monthStart),
+                    column: column
+                ))
+            }
+            guard let nextMonth = calendar.date(byAdding: .month, value: 1, to: monthStart) else { break }
+            monthStart = nextMonth
+        }
+        return labels
+    }
+
+    private static func date(from string: String, calendar: Calendar) -> Date? {
+        let day = String(string.prefix(10))
+        let parts = day.split(separator: "-").compactMap { Int($0) }
+        guard parts.count == 3 else { return nil }
+        return calendar.date(from: DateComponents(year: parts[0], month: parts[1], day: parts[2]))
+    }
+
+    private static func shortDateLabel(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "MMM d"
+        return formatter.string(from: date)
+    }
+
+    private struct HeatmapData {
+        let weeks: [HeatmapWeek]
+        let monthLabels: [MonthLabel]
+        let width: CGFloat
+    }
+
+    private struct HeatmapWeek: Identifiable {
+        let id: Int
+        let cells: [HeatmapCell]
+    }
+
+    private struct HeatmapCell: Identifiable {
+        let id: String
+        let date: Date
+        let point: QuotaAnalyticsPoint?
+        let intensity: Double
+        let isInRange: Bool
+    }
+
+    private struct MonthLabel: Identifiable {
+        let id: String
+        let title: String
+        let column: Int
+    }
+}
+
+private struct AnalyticsRowView: View {
+    let row: QuotaAnalyticsRow
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Text(row.title)
+                .font(.system(size: 10, weight: .semibold, design: .rounded))
+                .foregroundStyle(row.isAvailable ? .primary : .secondary)
+                .lineLimit(1)
+
+            Spacer(minLength: 8)
+
+            Text(row.value)
+                .font(.system(size: 10, weight: .medium, design: .rounded))
+                .foregroundStyle(row.isAvailable ? .primary : .secondary)
+                .multilineTextAlignment(.trailing)
+                .lineLimit(1)
+        }
     }
 }
 

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -759,7 +759,12 @@ private struct MenuAccountCardView: View {
             return (info.tierDisplayName, .secondary.opacity(0.1), .secondary)
         }
         
-        guard let planName = provider == .codex ? codexPlanDisplayName(data.planType) : data.planDisplayName else { return nil }
+        if provider == .codex, let planName = codexPlanDisplayName(data.planType) {
+            let config = planConfig(for: planName)
+            return (planName, config.bgColor, config.textColor)
+        }
+
+        guard let planName = data.planDisplayName else { return nil }
         return planConfig(for: planName)
     }
 


### PR DESCRIPTION
## Summary
- Add Codex quota analytics support to the v0 menu bar using the existing CLIProxyAPI-backed Codex account flow.
- Map the newer Codex usage response into session, weekly, Spark, credits, and reset quota rows.
- Add a Codex analytics submenu with metric tiles and usage trend views.
- Preserve Codex-specific plan badge labels so `pro` displays as `Pro 20x` and Pro Lite variants display as `Pro 5x`.

## Scope Notes
- Keeps master/v0 on the existing CLIProxyAPI and Codex CLI auth sources.
- Does not change auth, add provider, OAuth, or provider registration behavior.
- Leaves non-Codex plan display behavior unchanged.

## Implementation
- Adds `QuotaAnalytics` as a shared UI data model for usage metrics and trend rows.
- Adds `CodexUsageMapper` to centralize Codex usage parsing for both OpenAI and Codex CLI fetchers.
- Updates the menu builder to render Codex analytics details while preserving the existing Antigravity analytics path.

## Verification
- `git diff --check`
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug -derivedDataPath /tmp/quotio-derived build`