### PR TITLE
Add Codex reset credit inventory to quota analytics

### DIFF
--- a/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
@@ -179,10 +179,28 @@ actor CodexCLIQuotaFetcher {
 #if DEBUG
         Log.quota("plan_type=\(quotaData.planType ?? "<nil>")")
 #endif
+        if let resetCreditAnalytics = await fetchResetCreditAnalytics(accessToken: accessToken, accountId: accountId) {
+            quotaData.analytics = CodexResetCreditInventoryFetcher.merge(
+                resetCreditAnalytics,
+                into: quotaData.analytics
+            )
+        }
         if let profileAnalytics = await fetchProfileAnalytics(accessToken: accessToken, accountId: accountId) {
             quotaData.analytics = quotaData.analytics?.merging(profileAnalytics) ?? profileAnalytics
         }
         return quotaData
+    }
+
+    private func fetchResetCreditAnalytics(accessToken: String, accountId: String?) async -> QuotaAnalytics? {
+        do {
+            return try await CodexResetCreditInventoryFetcher(urlSession: session).fetchAnalytics(
+                accessToken: accessToken,
+                accountID: accountId
+            )
+        } catch {
+            Log.quota("Failed to fetch Codex reset credit inventory: \(error)")
+            return nil
+        }
     }
 
     private func fetchProfileAnalytics(accessToken: String, accountId: String?) async -> QuotaAnalytics? {

--- a/Quotio/Services/QuotaFetchers/CodexResetCreditInventoryFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CodexResetCreditInventoryFetcher.swift
@@ -1,0 +1,256 @@
+import CryptoKit
+import Foundation
+
+nonisolated struct CodexResetCreditInventoryFetcher: Sendable {
+    private static let inventoryURL = URL(string: "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits")!
+
+    let urlSession: URLSession
+    var now: @Sendable () -> Date = Date.init
+
+    init(urlSession: URLSession = .shared, now: @escaping @Sendable () -> Date = Date.init) {
+        self.urlSession = urlSession
+        self.now = now
+    }
+
+    func fetchAnalytics(accessToken: String, accountID: String?) async throws -> QuotaAnalytics? {
+        var request = URLRequest(url: Self.inventoryURL, timeoutInterval: 4)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("codex-1", forHTTPHeaderField: "OpenAI-Beta")
+        request.setValue("Codex Desktop", forHTTPHeaderField: "originator")
+        if let accountID, !accountID.isEmpty {
+            request.setValue(accountID, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+
+        let (data, response) = try await urlSession.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200..<300).contains(httpResponse.statusCode) else {
+            return nil
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom(Self.decodeISO8601Date)
+        let payload = try decoder.decode(CodexResetCreditInventoryResponse.self, from: data)
+        guard payload.availableCount >= 0 else { return nil }
+
+        let snapshot = CodexResetCreditInventorySnapshot(
+            credits: payload.credits.map(\.model),
+            availableCount: payload.availableCount,
+            updatedAt: now()
+        )
+        return Self.analytics(from: snapshot)
+    }
+
+    private static func analytics(from snapshot: CodexResetCreditInventorySnapshot) -> QuotaAnalytics? {
+        var rows = [
+            QuotaAnalyticsRow(
+                id: "codex-rate-limit-resets",
+                title: "Rate Limit Resets",
+                value: "\(snapshot.availableCount) available"
+            )
+        ]
+
+        rows.append(contentsOf: snapshot.availableCredits().map { credit in
+            QuotaAnalyticsRow(
+                id: "codex-rate-limit-reset-\(credit.id)",
+                title: credit.expiryDateLabel,
+                value: credit.expiryRelativeLabel(from: snapshot.updatedAt)
+            )
+        })
+
+        return QuotaAnalytics(rows: rows)
+    }
+
+    static func merge(_ resetCreditAnalytics: QuotaAnalytics, into analytics: QuotaAnalytics?) -> QuotaAnalytics {
+        var merged = analytics ?? QuotaAnalytics()
+        let resetCreditRowIDs = Set(resetCreditAnalytics.rows.map(\.id))
+        merged.rows.removeAll { resetCreditRowIDs.contains($0.id) }
+        return merged.merging(resetCreditAnalytics)
+    }
+
+    private static func decodeISO8601Date(from decoder: Decoder) throws -> Date {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        let standard = ISO8601DateFormatter()
+        standard.formatOptions = [.withInternetDateTime]
+
+        if let date = fractional.date(from: raw) ?? standard.date(from: raw) {
+            return date
+        }
+
+        throw DecodingError.dataCorruptedError(
+            in: container,
+            debugDescription: "Invalid ISO-8601 date"
+        )
+    }
+}
+
+private nonisolated struct CodexResetCreditInventoryResponse: Decodable {
+    let credits: [CodexResetCreditResponse]
+    let availableCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case credits
+        case availableCount = "available_count"
+    }
+}
+
+private nonisolated struct CodexResetCreditResponse: Decodable {
+    let id: String
+    let resetType: String
+    let status: CodexResetCreditStatus
+    let grantedAt: Date
+    let expiresAt: Date?
+    let redeemStartedAt: Date?
+    let redeemedAt: Date?
+    let title: String?
+    let description: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case resetType = "reset_type"
+        case status
+        case grantedAt = "granted_at"
+        case expiresAt = "expires_at"
+        case redeemStartedAt = "redeem_started_at"
+        case redeemedAt = "redeemed_at"
+        case title
+        case description
+    }
+
+    var model: CodexResetCredit {
+        CodexResetCredit(
+            providerID: id,
+            resetType: resetType,
+            status: status,
+            grantedAt: grantedAt,
+            expiresAt: expiresAt,
+            redeemStartedAt: redeemStartedAt,
+            redeemedAt: redeemedAt,
+            title: title,
+            description: description
+        )
+    }
+}
+
+private nonisolated struct CodexResetCreditInventorySnapshot: Sendable {
+    let credits: [CodexResetCredit]
+    let availableCount: Int
+    let updatedAt: Date
+
+    func availableCredits() -> [CodexResetCredit] {
+        credits
+            .filter { $0.status == .available && ($0.expiresAt.map { $0 > updatedAt } ?? true) }
+            .sorted { lhs, rhs in
+                switch (lhs.expiresAt, rhs.expiresAt) {
+                case let (lhsDate?, rhsDate?):
+                    if lhsDate != rhsDate { return lhsDate < rhsDate }
+                case (_?, nil):
+                    return true
+                case (nil, _?):
+                    return false
+                case (nil, nil):
+                    break
+                }
+                return lhs.id < rhs.id
+            }
+    }
+}
+
+private nonisolated struct CodexResetCredit: Sendable {
+    let id: String
+    let resetType: String
+    let status: CodexResetCreditStatus
+    let grantedAt: Date
+    let expiresAt: Date?
+    let redeemStartedAt: Date?
+    let redeemedAt: Date?
+    let title: String?
+    let description: String?
+
+    init(
+        providerID: String,
+        resetType: String,
+        status: CodexResetCreditStatus,
+        grantedAt: Date,
+        expiresAt: Date?,
+        redeemStartedAt: Date?,
+        redeemedAt: Date?,
+        title: String?,
+        description: String?
+    ) {
+        self.id = Self.stableID(for: providerID)
+        self.resetType = resetType
+        self.status = status
+        self.grantedAt = grantedAt
+        self.expiresAt = expiresAt
+        self.redeemStartedAt = redeemStartedAt
+        self.redeemedAt = redeemedAt
+        self.title = title
+        self.description = description
+    }
+
+    var expiryDateLabel: String {
+        guard let expiresAt else { return "No expiry" }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "d MMM · HH:mm"
+        return formatter.string(from: expiresAt)
+    }
+
+    func expiryRelativeLabel(from date: Date) -> String {
+        guard let expiresAt else { return "" }
+        let seconds = expiresAt.timeIntervalSince(date)
+        if seconds <= 0 { return "expired" }
+
+        let days = Int(ceil(seconds / 86_400))
+        if days >= 1 {
+            return "in \(days) \(days == 1 ? "day" : "days")"
+        }
+
+        let hours = Int(ceil(seconds / 3_600))
+        if hours >= 1 {
+            return "in \(hours) \(hours == 1 ? "hour" : "hours")"
+        }
+
+        let minutes = max(1, Int(ceil(seconds / 60)))
+        return "in \(minutes) \(minutes == 1 ? "minute" : "minutes")"
+    }
+
+    private static func stableID(for providerID: String) -> String {
+        let value = "com.quotio.codex.reset-credit-id.v1\0\(providerID)"
+        return SHA256.hash(data: Data(value.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+}
+
+private nonisolated enum CodexResetCreditStatus: Equatable, Decodable, Sendable {
+    case available
+    case redeeming
+    case redeemed
+    case expired
+    case unknown(String)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+        switch value {
+        case "available":
+            self = .available
+        case "redeeming":
+            self = .redeeming
+        case "redeemed":
+            self = .redeemed
+        case "expired":
+            self = .expired
+        default:
+            self = .unknown(value)
+        }
+    }
+}

--- a/Quotio/Services/QuotaFetchers/OpenAIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/OpenAIQuotaFetcher.swift
@@ -150,6 +150,12 @@ actor OpenAIQuotaFetcher {
 #if DEBUG
         Log.quota("plan_type=\(quotaData.planType ?? "<nil>")")
 #endif
+        if let resetCreditAnalytics = await fetchResetCreditAnalytics(accessToken: accessToken, accountId: accountId) {
+            quotaData.analytics = CodexResetCreditInventoryFetcher.merge(
+                resetCreditAnalytics,
+                into: quotaData.analytics
+            )
+        }
         if let profileAnalytics = await fetchProfileAnalytics(accessToken: accessToken, accountId: accountId) {
             quotaData.analytics = quotaData.analytics?.merging(profileAnalytics) ?? profileAnalytics
         }
@@ -184,6 +190,18 @@ actor OpenAIQuotaFetcher {
 
         let quota = try await fetchQuota(accessToken: accessToken, accountId: accountId, identity: identity)
         return (accountKey: accountKey, quota: quota)
+    }
+
+    private func fetchResetCreditAnalytics(accessToken: String, accountId: String?) async -> QuotaAnalytics? {
+        do {
+            return try await CodexResetCreditInventoryFetcher(urlSession: session).fetchAnalytics(
+                accessToken: accessToken,
+                accountID: accountId
+            )
+        } catch {
+            Log.quota("Failed to fetch Codex reset credit inventory: \(error)")
+            return nil
+        }
     }
 
     private func fetchProfileAnalytics(accessToken: String, accountId: String?) async -> QuotaAnalytics? {

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -1078,13 +1078,14 @@ private struct AnalyticsDetailSection: View {
 
     private static let usageMetricRowIDs = [
         "codex-extra-usage",
-        "codex-rate-limit-resets",
         "today",
         "yesterday",
         "last-30-days"
     ]
 
     private static let hiddenRowIDs = Set(primaryMetricRowIDs + usageMetricRowIDs)
+    private static let resetCreditsSummaryID = "codex-rate-limit-resets"
+    private static let resetCreditRowPrefix = "codex-rate-limit-reset-"
 
     private var metricRows: [QuotaAnalyticsRow] {
         metricRows(for: Self.primaryMetricRowIDs)
@@ -1095,7 +1096,7 @@ private struct AnalyticsDetailSection: View {
     }
 
     private var shouldShowNote: Bool {
-        metricRows.isEmpty && usageRows.isEmpty
+        metricRows.isEmpty && usageRows.isEmpty && resetCreditsSummary == nil
     }
 
     private func metricRows(for ids: [String]) -> [QuotaAnalyticsRow] {
@@ -1106,7 +1107,19 @@ private struct AnalyticsDetailSection: View {
     }
 
     private var detailRows: [QuotaAnalyticsRow] {
-        analytics.rows.filter { !Self.hiddenRowIDs.contains($0.id) }
+        analytics.rows.filter {
+            !Self.hiddenRowIDs.contains($0.id)
+                && $0.id != Self.resetCreditsSummaryID
+                && !$0.id.hasPrefix(Self.resetCreditRowPrefix)
+        }
+    }
+
+    private var resetCreditsSummary: QuotaAnalyticsRow? {
+        analytics.rows.first { $0.id == Self.resetCreditsSummaryID }
+    }
+
+    private var resetCreditRows: [QuotaAnalyticsRow] {
+        analytics.rows.filter { $0.id.hasPrefix(Self.resetCreditRowPrefix) }
     }
 
     var body: some View {
@@ -1117,6 +1130,10 @@ private struct AnalyticsDetailSection: View {
 
             if !usageRows.isEmpty {
                 AnalyticsMetricStripView(rows: usageRows)
+            }
+
+            if let resetCreditsSummary {
+                ResetCreditsInventoryView(summary: resetCreditsSummary, credits: resetCreditRows)
             }
 
             VStack(alignment: .leading, spacing: 8) {
@@ -1155,6 +1172,247 @@ private struct AnalyticsDetailSection: View {
             }
         }
         .padding(10)
+    }
+}
+
+private struct ResetCreditsInventoryView: View {
+    let summary: QuotaAnalyticsRow
+    let credits: [QuotaAnalyticsRow]
+
+    private var countLabel: String {
+        let count = summary.value.split(separator: " ").first.map(String.init) ?? "0"
+        return "\(count) resets available"
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "gift")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Color.blue)
+
+            Text(countLabel)
+                .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.85)
+
+            Spacer(minLength: 12)
+
+            HStack(spacing: 6) {
+                ForEach(Array(credits.enumerated()), id: \.element.id) { index, credit in
+                    ResetCreditChip(
+                        label: compactRelativeLabel(credit.value),
+                        tooltip: creditTooltip(credit),
+                        isNext: index == 0
+                    )
+                }
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.primary.opacity(0.025))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(.separator.opacity(0.45), lineWidth: 1)
+        )
+    }
+
+    private func compactRelativeLabel(_ value: String) -> String {
+        let lowercased = value.lowercased()
+        let parts = lowercased.split(separator: " ")
+        guard parts.count >= 3, parts.first == "in", let number = parts.dropFirst().first else {
+            return value.isEmpty ? "∞" : value
+        }
+
+        let unit = parts.dropFirst(2).first ?? ""
+        if unit.hasPrefix("day") { return "\(number)d" }
+        if unit.hasPrefix("hour") { return "\(number)h" }
+        if unit.hasPrefix("minute") { return "\(number)m" }
+        return String(number)
+    }
+
+    private func creditTooltip(_ credit: QuotaAnalyticsRow) -> String {
+        let suffix = credit.value.isEmpty ? "" : " - \(credit.value)"
+        return "Expires: \(credit.title)\(suffix)"
+    }
+}
+
+private struct ResetCreditChip: View {
+    let label: String
+    let tooltip: String
+    let isNext: Bool
+
+    var body: some View {
+        Text(label)
+            .font(.system(size: 12, weight: .medium, design: .monospaced))
+            .foregroundStyle(isNext ? Color.blue : .secondary)
+            .lineLimit(1)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(isNext ? Color.blue.opacity(0.18) : Color.primary.opacity(0.08))
+            )
+            .contentShape(Capsule(style: .continuous))
+            .menuNativeTooltip(tooltip)
+    }
+}
+
+private final class MenuTooltipWindow: NSWindow {
+    static let shared = MenuTooltipWindow()
+
+    private let label: NSTextField = {
+        let label = NSTextField(labelWithString: "")
+        label.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize, weight: .medium)
+        label.textColor = .labelColor
+        label.backgroundColor = .clear
+        label.isBezeled = false
+        label.isEditable = false
+        label.lineBreakMode = .byTruncatingTail
+        return label
+    }()
+
+    private init() {
+        super.init(
+            contentRect: .zero,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: true
+        )
+        isOpaque = false
+        backgroundColor = .clear
+        level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.popUpMenuWindow)) + 1)
+        collectionBehavior = [.canJoinAllSpaces, .transient]
+        ignoresMouseEvents = true
+
+        let effectView = NSVisualEffectView()
+        effectView.material = .toolTip
+        effectView.state = .active
+        effectView.wantsLayer = true
+        effectView.layer?.cornerRadius = 6
+
+        label.translatesAutoresizingMaskIntoConstraints = false
+        effectView.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: effectView.leadingAnchor, constant: 9),
+            label.trailingAnchor.constraint(equalTo: effectView.trailingAnchor, constant: -9),
+            label.topAnchor.constraint(equalTo: effectView.topAnchor, constant: 5),
+            label.bottomAnchor.constraint(equalTo: effectView.bottomAnchor, constant: -5)
+        ])
+
+        contentView = effectView
+    }
+
+    func show(text: String, near view: NSView) {
+        guard !text.isEmpty else {
+            hide()
+            return
+        }
+
+        label.stringValue = text
+        label.sizeToFit()
+
+        let labelSize = label.fittingSize
+        let windowSize = NSSize(width: min(labelSize.width + 18, 360), height: labelSize.height + 10)
+
+        guard let screen = view.window?.screen ?? NSScreen.main else { return }
+        let screenFrame = screen.visibleFrame
+        let viewFrame = view.window?.convertToScreen(view.convert(view.bounds, to: nil)) ?? .zero
+
+        var origin = NSPoint(
+            x: viewFrame.midX - windowSize.width / 2,
+            y: viewFrame.maxY + 5
+        )
+
+        if origin.x < screenFrame.minX {
+            origin.x = screenFrame.minX
+        }
+        if origin.x + windowSize.width > screenFrame.maxX {
+            origin.x = screenFrame.maxX - windowSize.width
+        }
+        if origin.y + windowSize.height > screenFrame.maxY {
+            origin.y = viewFrame.minY - windowSize.height - 5
+        }
+        if origin.y < screenFrame.minY {
+            origin.y = screenFrame.minY
+        }
+
+        setFrame(NSRect(origin: origin, size: windowSize), display: true)
+        orderFrontRegardless()
+    }
+
+    func hide() {
+        orderOut(nil)
+    }
+}
+
+private final class MenuTooltipTrackingView: NSView {
+    var text: String = ""
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        trackingAreas.forEach { removeTrackingArea($0) }
+        addTrackingArea(NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .mouseMoved, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        ))
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        MenuTooltipWindow.shared.show(text: text, near: self)
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        MenuTooltipWindow.shared.show(text: text, near: self)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        MenuTooltipWindow.shared.hide()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window == nil {
+            MenuTooltipWindow.shared.hide()
+        }
+    }
+
+    override func removeFromSuperview() {
+        MenuTooltipWindow.shared.hide()
+        super.removeFromSuperview()
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+}
+
+private struct MenuNativeTooltipView: NSViewRepresentable {
+    let text: String
+
+    func makeNSView(context: Context) -> MenuTooltipTrackingView {
+        let view = MenuTooltipTrackingView()
+        view.text = text
+        return view
+    }
+
+    func updateNSView(_ nsView: MenuTooltipTrackingView, context: Context) {
+        nsView.text = text
+    }
+
+    static func dismantleNSView(_ nsView: MenuTooltipTrackingView, coordinator: ()) {
+        MenuTooltipWindow.shared.hide()
+    }
+}
+
+private extension View {
+    func menuNativeTooltip(_ text: String) -> some View {
+        overlay(MenuNativeTooltipView(text: text))
     }
 }
 


### PR DESCRIPTION
## Summary
- Fetch Codex reset credit inventory alongside existing quota/profile analytics
- Merge reset-credit rows into quota analytics without duplicating existing entries
- Surface reset-credit availability and expiry details in the status bar analytics view with compact chips and tooltips

## Testing
- Not run (not requested)