### PR TITLE
Fix quota bucket display in main window

### DIFF
--- a/Quotio/Services/QuotaFetchers/CodexUsageMapper.swift
+++ b/Quotio/Services/QuotaFetchers/CodexUsageMapper.swift
@@ -13,13 +13,7 @@ nonisolated enum CodexUsageMapper {
         let response = try JSONDecoder().decode(CodexUsageResponseV2.self, from: data)
         let rawJSON = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
 
-        var models: [ModelQuota] = []
-        if let primary = modelQuota(name: "codex-session", from: response.rateLimit?.primaryWindow) {
-            models.append(primary)
-        }
-        if let secondary = modelQuota(name: "codex-weekly", from: response.rateLimit?.secondaryWindow) {
-            models.append(secondary)
-        }
+        var models = standardModels(from: response.rateLimit)
         models.append(contentsOf: extraModels(from: response.additionalRateLimits))
 
         let planType = response.planType ?? identity.planType
@@ -39,6 +33,31 @@ nonisolated enum CodexUsageMapper {
             percentage: Double(100 - snapshot.usedPercent),
             resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? ""
         )
+    }
+
+    private static func standardModels(from rateLimit: CodexUsageResponseV2.RateLimitDetails?) -> [ModelQuota] {
+        let windows: [(CodexUsageResponseV2.WindowSnapshot?, StandardWindowKind)] = [
+            (rateLimit?.primaryWindow, .session),
+            (rateLimit?.secondaryWindow, .weekly)
+        ]
+        var usedKinds = Set<StandardWindowKind>()
+
+        return windows.compactMap { snapshot, fallbackKind in
+            guard let snapshot else { return nil }
+            let kind = standardWindowKind(for: snapshot, fallback: fallbackKind)
+            guard usedKinds.insert(kind).inserted else { return nil }
+            return modelQuota(name: kind.id, from: snapshot)
+        }
+    }
+
+    private static func standardWindowKind(
+        for snapshot: CodexUsageResponseV2.WindowSnapshot,
+        fallback: StandardWindowKind
+    ) -> StandardWindowKind {
+        guard let seconds = snapshot.limitWindowSeconds, seconds > 0 else { return fallback }
+        if seconds >= 6 * 24 * 60 * 60 { return .weekly }
+        if seconds <= 24 * 60 * 60 { return .session }
+        return fallback
     }
 
     private static func extraModels(from limits: [CodexUsageResponseV2.AdditionalRateLimit]?) -> [ModelQuota] {
@@ -183,6 +202,18 @@ nonisolated enum CodexUsageMapper {
             switch self {
             case .fiveHour: "codex-spark"
             case .weekly: "codex-spark-weekly"
+            }
+        }
+    }
+
+    private enum StandardWindowKind {
+        case session
+        case weekly
+
+        var id: String {
+            switch self {
+            case .session: "codex-session"
+            case .weekly: "codex-weekly"
             }
         }
     }

--- a/Quotio/Views/Screens/QuotaScreen.swift
+++ b/Quotio/Views/Screens/QuotaScreen.swift
@@ -494,6 +494,17 @@ private struct AccountQuotaCardV2: View {
     /// Build 4-group display for Antigravity: Gemini 3 Pro, Gemini 3 Flash, Gemini 3 Image, Claude 4.5
     private var antigravityDisplayGroups: [AntigravityDisplayGroup] {
         guard let data = account.quotaData, provider == .antigravity else { return [] }
+
+        let summaryModels = data.models.filter { $0.name.hasPrefix("antigravity-") }
+        if !summaryModels.isEmpty {
+            return summaryModels.map {
+                AntigravityDisplayGroup(
+                    name: $0.displayName,
+                    percentage: $0.percentage,
+                    models: [$0]
+                )
+            }
+        }
         
         var groups: [AntigravityDisplayGroup] = []
         


### PR DESCRIPTION
## Summary

- show all Antigravity quota summary buckets in the main Quota window, matching the menu bar dropdown
- classify Codex session and weekly windows using `limit_window_seconds` instead of assuming fixed primary/secondary positions
- keep the existing positional mapping as a fallback when the upstream window duration is missing or ambiguous

## Root cause

The Antigravity summary API introduced new `antigravity-*` bucket identifiers, but the main window still grouped only the older raw model names. Codex also treated every primary window as Session even when the upstream API returned a seven-day weekly window there.

Fixes #433

Related issues:
- #432 reports the same Antigravity main-window regression
- #356 documents the Codex weekly-window misclassification fixed here

## Validation

- [x] `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build`
- [x] `git diff --check`
- [ ] manual light/dark verification with live Antigravity and Codex accounts
