### PR TITLE
Make Monitor mode independent from CLIProxyAPI

### DIFF
--- a/Quotio.xcodeproj/project.pbxproj
+++ b/Quotio.xcodeproj/project.pbxproj
@@ -13,10 +13,21 @@
 
 /* Begin PBXFileReference section */
 		78D386942EFBF30400C40FB6 /* Quotio.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Quotio.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A10000000000000000000001 /* QuotioTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QuotioTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		78D386B22EFBF30500C40FB6 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		78D386B32EFBF30500C40FB6 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		78D386B42EFBF30500C40FB6 /* Local.xcconfig.example */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig.example; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXContainerItemProxy section */
+		A1000000000000000000000B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 78D3868C2EFBF30400C40FB6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 78D386932EFBF30400C40FB6;
+			remoteInfo = Quotio;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
 		78D386962EFBF30400C40FB7 /* Exceptions for "Quotio" folder in "Quotio" target */ = {
@@ -29,6 +40,11 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		A10000000000000000000002 /* QuotioTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = QuotioTests;
+			sourceTree = "<group>";
+		};
 		78D386962EFBF30400C40FB6 /* Quotio */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -40,6 +56,13 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		A10000000000000000000006 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		78D386912EFBF30400C40FB6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -57,6 +80,7 @@
 			children = (
 				78D386B52EFBF30500C40FB6 /* Config */,
 				78D386962EFBF30400C40FB6 /* Quotio */,
+				A10000000000000000000002 /* QuotioTests */,
 				78D386952EFBF30400C40FB6 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -65,6 +89,7 @@
 			isa = PBXGroup;
 			children = (
 				78D386942EFBF30400C40FB6 /* Quotio.app */,
+				A10000000000000000000001 /* QuotioTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -82,6 +107,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		A10000000000000000000004 /* QuotioTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000000000000000000008 /* Build configuration list for PBXNativeTarget "QuotioTests" */;
+			buildPhases = (
+				A10000000000000000000005 /* Sources */,
+				A10000000000000000000006 /* Frameworks */,
+				A10000000000000000000007 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A1000000000000000000000C /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A10000000000000000000002 /* QuotioTests */,
+			);
+			name = QuotioTests;
+			packageProductDependencies = (
+			);
+			productName = QuotioTests;
+			productReference = A10000000000000000000001 /* QuotioTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		78D386932EFBF30400C40FB6 /* Quotio */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 78D3869F2EFBF30500C40FB6 /* Build configuration list for PBXNativeTarget "Quotio" */;
@@ -116,6 +164,10 @@
 				LastSwiftUpdateCheck = 2620;
 				LastUpgradeCheck = 2620;
 				TargetAttributes = {
+					A10000000000000000000004 = {
+						CreatedOnToolsVersion = 26.2;
+						TestTargetID = 78D386932EFBF30400C40FB6;
+					};
 					78D386932EFBF30400C40FB6 = {
 						CreatedOnToolsVersion = 26.2;
 					};
@@ -142,11 +194,19 @@
 			projectRoot = "";
 			targets = (
 				78D386932EFBF30400C40FB6 /* Quotio */,
+				A10000000000000000000004 /* QuotioTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		A10000000000000000000007 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		78D386922EFBF30400C40FB6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -157,6 +217,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		A10000000000000000000005 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		78D386902EFBF30400C40FB6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -167,6 +234,40 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		A10000000000000000000009 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.quotio.desktop.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated;
+				SWIFT_VERSION = 6.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Quotio.app/Contents/MacOS/Quotio";
+			};
+			name = Debug;
+		};
+		A1000000000000000000000A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.quotio.desktop.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated;
+				SWIFT_VERSION = 6.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Quotio.app/Contents/MacOS/Quotio";
+			};
+			name = Release;
+		};
 		78D3869D2EFBF30500C40FB6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -382,6 +483,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		A10000000000000000000008 /* Build configuration list for PBXNativeTarget "QuotioTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000000000000000000009 /* Debug */,
+				A1000000000000000000000A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		78D3868F2EFBF30400C40FB6 /* Build configuration list for PBXProject "Quotio" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -401,6 +511,14 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin PBXTargetDependency section */
+		A1000000000000000000000C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 78D386932EFBF30400C40FB6 /* Quotio */;
+			targetProxy = A1000000000000000000000B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCRemoteSwiftPackageReference section */
 		78D386B02EFBF30500C40FB6 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/Quotio.xcodeproj/xcshareddata/xcschemes/Quotio.xcscheme
+++ b/Quotio.xcodeproj/xcshareddata/xcschemes/Quotio.xcscheme
@@ -29,6 +29,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A10000000000000000000004"
+               BuildableName = "QuotioTests.xctest"
+               BlueprintName = "QuotioTests"
+               ReferencedContainer = "container:Quotio.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -11262,6 +11262,62 @@
         }
       }
     },
+    "monitor.refresh.failed" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The latest refresh failed. Showing the last successful quota." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "La dernière actualisation a échoué. Le dernier quota valide reste affiché." } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Lần làm mới gần nhất thất bại. Đang hiển thị quota thành công gần nhất." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "最新刷新失败，正在显示上次成功的配额。" } }
+      }
+    },
+    "monitor.refresh.partial" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Some accounts could not be refreshed. Their last successful quota is still shown." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Certains comptes n’ont pas pu être actualisés. Leur dernier quota valide reste affiché." } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Không thể làm mới một số tài khoản. Quota thành công gần nhất vẫn được giữ lại." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "部分账户无法刷新，仍显示其上次成功的配额。" } }
+      }
+    },
+    "monitor.status.outdated" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Showing quota last updated %@." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Affichage du quota mis à jour pour la dernière fois à %@." } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đang hiển thị quota được cập nhật lần cuối lúc %@." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "显示上次于 %@ 更新的配额。" } }
+      }
+    },
+    "monitor.status.updated" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Updated %@" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Mis à jour %@" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đã cập nhật %@" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "已于 %@ 更新" } }
+      }
+    },
+    "oauth.enterDeviceCode" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enter device code %@ in the browser." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Saisissez le code d’appareil %@ dans le navigateur." } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhập mã thiết bị %@ trong trình duyệt." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "请在浏览器中输入设备代码 %@。" } }
+      }
+    },
+    "oauth.authorizationCode" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Authorization code" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Code d’autorisation" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Mã xác thực" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "授权码" } }
+      }
+    },
+    "oauth.complete" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Complete" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Terminer" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hoàn tất" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "完成" } }
+      }
+    },
     "oauth.authenticate" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -11262,6 +11262,46 @@
         }
       }
     },
+    "monitor.source.apiKey" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "API key" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Clé API" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Khóa API" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "API 密钥" } }
+      }
+    },
+    "monitor.source.cliProxyFile" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "CLIProxyAPI file" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Fichier CLIProxyAPI" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Tệp CLIProxyAPI" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "CLIProxyAPI 文件" } }
+      }
+    },
+    "monitor.source.localIDE" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Local IDE" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "IDE local" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "IDE cục bộ" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "本地 IDE" } }
+      }
+    },
+    "monitor.source.localLogin" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Local login" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Connexion locale" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đăng nhập cục bộ" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "本地登录" } }
+      }
+    },
+    "monitor.source.quotio" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Quotio" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Quotio" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Quotio" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Quotio" } }
+      }
+    },
     "monitor.refresh.failed" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "The latest refresh failed. Showing the last successful quota." } },

--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -165,16 +165,20 @@ struct QuotioApp: App {
     // Use shared bootstrap instance for viewModel
     private var bootstrap: AppBootstrap { AppBootstrap.shared }
     @State private var logsViewModel = LogsViewModel()
-    @State private var menuBarSettings = MenuBarSettingsManager.shared
+    @State private var menuBarSettingsStorage: MenuBarSettingsManager? = isRunningUnitTests ? nil : .shared
     @State private var statusBarManager = StatusBarManager.shared
-    @State private var modeManager = OperatingModeManager.shared
-    @State private var appearanceManager = AppearanceManager.shared
-    @State private var languageManager = LanguageManager.shared
+    @State private var modeManagerStorage: OperatingModeManager? = isRunningUnitTests ? nil : .shared
+    @State private var appearanceManagerStorage: AppearanceManager? = isRunningUnitTests ? nil : .shared
+    @State private var languageManagerStorage: LanguageManager? = isRunningUnitTests ? nil : .shared
     @State private var showOnboarding = false
     @State private var showProxyBinarySourceSelection = false
     @Environment(\.openWindow) private var openWindow
 
     private var viewModel: QuotaViewModel { bootstrap.viewModel }
+    private var menuBarSettings: MenuBarSettingsManager { menuBarSettingsStorage! }
+    private var modeManager: OperatingModeManager { modeManagerStorage! }
+    private var appearanceManager: AppearanceManager { appearanceManagerStorage! }
+    private var languageManager: LanguageManager { languageManagerStorage! }
 
 
     var body: some Scene {

--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -10,6 +10,10 @@ import ServiceManagement
 import Sparkle
 #endif
 
+private var isRunningUnitTests: Bool {
+    ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+}
+
 // MARK: - App Bootstrap (Singleton for headless initialization)
 
 /// Manages app-wide initialization that must happen regardless of window visibility.
@@ -175,82 +179,86 @@ struct QuotioApp: App {
 
     var body: some Scene {
         Window("Quotio", id: "main") {
-            ContentView()
-                .id(languageManager.currentLanguage) // Force re-render on language change
-                .environment(viewModel)
-                .environment(logsViewModel)
-                .environment(\.locale, languageManager.locale)
-                .task {
-                    // Initialize via bootstrap (idempotent - safe to call multiple times)
-                    // This handles the case where window opens before AppDelegate finishes
-                    await bootstrap.initializeIfNeeded()
+            if isRunningUnitTests {
+                EmptyView()
+            } else {
+                ContentView()
+                    .id(languageManager.currentLanguage) // Force re-render on language change
+                    .environment(viewModel)
+                    .environment(logsViewModel)
+                    .environment(\.locale, languageManager.locale)
+                    .task {
+                        // Initialize via bootstrap (idempotent - safe to call multiple times)
+                        // This handles the case where window opens before AppDelegate finishes
+                        await bootstrap.initializeIfNeeded()
 
-                    // Show onboarding if needed
-                    if bootstrap.needsOnboarding {
-                        showOnboarding = true
-                    } else if viewModel.proxyManager.shouldPromptForBinarySourceSelection {
-                        showProxyBinarySourceSelection = true
+                        // Show onboarding if needed
+                        if bootstrap.needsOnboarding {
+                            showOnboarding = true
+                        } else if viewModel.proxyManager.shouldPromptForBinarySourceSelection {
+                            showProxyBinarySourceSelection = true
+                        }
                     }
-                }
-                .onChange(of: viewModel.proxyManager.proxyStatus.running) {
-                    bootstrap.updateStatusBar()
-                }
-                .onChange(of: viewModel.isLoadingQuotas) {
-                    bootstrap.updateStatusBar()
-                    // Rebuild menu when loading state changes so loader updates
-                    statusBarManager.rebuildMenuInPlace()
-                }
-                .onChange(of: languageManager.currentLanguage) { _, _ in
-                    // Rebuild menu bar when language changes
-                    statusBarManager.rebuildMenuInPlace()
-                }
-                .onChange(of: menuBarSettings.showQuotaInMenuBar) {
-                    bootstrap.updateStatusBar()
-                }
-                .onChange(of: menuBarSettings.showMenuBarIcon) {
-                    bootstrap.updateStatusBar()
-                }
-                .onChange(of: menuBarSettings.selectedItems) {
-                    bootstrap.updateStatusBar()
-                }
-                .onChange(of: menuBarSettings.colorMode) {
-                    bootstrap.updateStatusBar()
-                }
-                .onChange(of: menuBarSettings.totalUsageMode) {
-                    bootstrap.updateStatusBar()
-                    statusBarManager.rebuildMenuInPlace()
-                }
-                .onChange(of: menuBarSettings.modelAggregationMode) {
-                    bootstrap.updateStatusBar()
-                    statusBarManager.rebuildMenuInPlace()
-                }
-                .onChange(of: modeManager.currentMode) {
-                    bootstrap.updateStatusBar()
-                }
-                .onChange(of: viewModel.providerQuotas.count) {
-                    bootstrap.updateStatusBar()
-                    statusBarManager.rebuildMenuInPlace()
-                }
-                .onChange(of: viewModel.directAuthFiles.count) {
-                    bootstrap.updateStatusBar()
-                    statusBarManager.rebuildMenuInPlace()
-                }
-                .sheet(isPresented: $showOnboarding) {
-                    OnboardingFlow {
-                        Task {
-                            await bootstrap.completeOnboarding()
-                            if viewModel.proxyManager.shouldPromptForBinarySourceSelection {
-                                showProxyBinarySourceSelection = true
+                    .onChange(of: viewModel.proxyManager.proxyStatus.running) {
+                        bootstrap.updateStatusBar()
+                    }
+                    .onChange(of: viewModel.isLoadingQuotas) {
+                        bootstrap.updateStatusBar()
+                        // Rebuild menu when loading state changes so loader updates
+                        statusBarManager.rebuildMenuInPlace()
+                    }
+                    .onChange(of: languageManager.currentLanguage) { _, _ in
+                        // Rebuild menu bar when language changes
+                        statusBarManager.rebuildMenuInPlace()
+                    }
+                    .onChange(of: menuBarSettings.showQuotaInMenuBar) {
+                        bootstrap.updateStatusBar()
+                    }
+                    .onChange(of: menuBarSettings.showMenuBarIcon) {
+                        bootstrap.updateStatusBar()
+                    }
+                    .onChange(of: menuBarSettings.selectedItems) {
+                        bootstrap.updateStatusBar()
+                    }
+                    .onChange(of: menuBarSettings.colorMode) {
+                        bootstrap.updateStatusBar()
+                    }
+                    .onChange(of: menuBarSettings.totalUsageMode) {
+                        bootstrap.updateStatusBar()
+                        statusBarManager.rebuildMenuInPlace()
+                    }
+                    .onChange(of: menuBarSettings.modelAggregationMode) {
+                        bootstrap.updateStatusBar()
+                        statusBarManager.rebuildMenuInPlace()
+                    }
+                    .onChange(of: modeManager.currentMode) {
+                        bootstrap.updateStatusBar()
+                    }
+                    .onChange(of: viewModel.providerQuotas.count) {
+                        bootstrap.updateStatusBar()
+                        statusBarManager.rebuildMenuInPlace()
+                    }
+                    .onChange(of: viewModel.directAuthFiles.count) {
+                        bootstrap.updateStatusBar()
+                        statusBarManager.rebuildMenuInPlace()
+                    }
+                    .sheet(isPresented: $showOnboarding) {
+                        OnboardingFlow {
+                            Task {
+                                await bootstrap.completeOnboarding()
+                                if viewModel.proxyManager.shouldPromptForBinarySourceSelection {
+                                    showProxyBinarySourceSelection = true
+                                }
                             }
                         }
                     }
-                }
-                .sheet(isPresented: $showProxyBinarySourceSelection) {
-                    ProxyBinarySourceSelectionSheet {
-                        showProxyBinarySourceSelection = false
+                    .sheet(isPresented: $showProxyBinarySourceSelection) {
+                        ProxyBinarySourceSelectionSheet {
+                            showProxyBinarySourceSelection = false
+                        }
+                        .environment(viewModel)
                     }
-                    .environment(viewModel)
-                }
+            }
         }
         .defaultSize(width: 1000, height: 700)
         .commands {
@@ -280,6 +288,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hasTriggeredAntiDropForCurrentActivation = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        guard !isRunningUnitTests else { return }
+
         // Move orphan cleanup off main thread to avoid blocking app launch
         DispatchQueue.global(qos: .utility).async {
             TunnelManager.cleanupOrphans()

--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -507,11 +507,26 @@ actor AntigravityQuotaFetcher {
     private let clientId = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
     private let clientSecret = "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"
     private let userAgent = "antigravity/1.11.3 Darwin/arm64"
+    private let nativeCacheURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        .appendingPathComponent("Quotio/Monitor/antigravity-shadow-v1.json")
 
     private var session: URLSession
+    private let databaseService = AntigravityDatabaseService()
 
     // Cache subscription info to avoid duplicate API calls within same refresh cycle
     private var subscriptionCache: [String: SubscriptionInfo] = [:]
+
+    private struct NativeToken: Sendable {
+        var accessToken: String?
+        var refreshToken: String?
+        var expiresAt: Date?
+    }
+
+    private struct NativeTokenCache: Codable {
+        var accessToken: String
+        var expiresAt: Date
+        var refreshFingerprint: String
+    }
 
     init() {
         let config = ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15)
@@ -567,6 +582,7 @@ actor AntigravityQuotaFetcher {
     /// Persist refreshed access token back to auth file using read-modify-write
     /// to preserve all existing fields (including `disabled`, etc.)
     private func persistRefreshedToken(at url: URL, originalData: Data, newAccessToken: String, expiresIn: Int) {
+        guard (try? Data(contentsOf: url)) == originalData else { return }
         guard var json = try? JSONSerialization.jsonObject(with: originalData) as? [String: Any] else { return }
         json["access_token"] = newAccessToken
 
@@ -580,7 +596,7 @@ actor AntigravityQuotaFetcher {
         json["timestamp"] = Int64(now.timeIntervalSince1970 * 1000)
 
         if let updatedData = try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys]) {
-            try? updatedData.write(to: url)
+            try? SecureAtomicFileWriter.write(updatedData, to: url)
         }
     }
 
@@ -1029,12 +1045,70 @@ actor AntigravityQuotaFetcher {
         let expandedPath = NSString(string: authDir).expandingTildeInPath
         let fileManager = FileManager.default
 
-        guard let files = try? fileManager.contentsOfDirectory(atPath: expandedPath) else {
-            return ([:], [:])
-        }
-
         var quotaResults: [String: ProviderQuotaData] = [:]
         var subscriptionResults: [String: SubscriptionInfo] = [:]
+
+        for account in await MonitorCredentialVault.shared.accounts().filter({ $0.provider == .antigravity && !$0.isDisabled }) {
+            guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { continue }
+            if credential.expiresAt.map({ $0.timeIntervalSinceNow < 300 }) ?? false,
+               let refresh = credential.refreshToken,
+               let (access, expiresIn) = try? await refreshAccessTokenWithExpiry(refreshToken: refresh) {
+                credential.accessToken = access
+                credential.expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn))
+                try? await MonitorCredentialVault.shared.save(credential, metadata: account)
+            }
+            do {
+                var quota = try await fetchQuota(accessToken: credential.accessToken)
+                if quota.isForbidden,
+                   let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id),
+                   let refresh = latest.refreshToken,
+                   let (access, expiresIn) = try? await refreshAccessTokenWithExpiry(refreshToken: refresh) {
+                    credential = latest
+                    credential.accessToken = access
+                    credential.expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn))
+                    try? await MonitorCredentialVault.shared.save(credential, metadata: account)
+                    quota = try await fetchQuota(accessToken: access)
+                }
+                quotaResults[account.accountKey] = quota
+            } catch QuotaFetchError.httpError(let status) where status == 401 || status == 403 {
+                if let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id),
+                   let refresh = latest.refreshToken,
+                   let (access, expiresIn) = try? await refreshAccessTokenWithExpiry(refreshToken: refresh) {
+                    credential = latest
+                    credential.accessToken = access
+                    credential.expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn))
+                    try? await MonitorCredentialVault.shared.save(credential, metadata: account)
+                    quotaResults[account.accountKey] = try? await fetchQuota(accessToken: access)
+                }
+            } catch {
+                continue
+            }
+        }
+
+        if let ideToken = try? await databaseService.getCurrentTokenInfo(),
+           let accessToken = await usableNativeAccessToken(from: NativeToken(
+               accessToken: ideToken.accessToken,
+               refreshToken: ideToken.refreshToken,
+               expiresAt: ideToken.expiry.map {
+                   let raw = TimeInterval($0)
+                   return Date(timeIntervalSince1970: raw > 10_000_000_000 ? raw / 1000 : raw)
+               }
+           )),
+           let quota = try? await fetchQuota(accessToken: accessToken) {
+            quotaResults[await nativeAccountName(accessToken: accessToken)] = quota
+        }
+
+        if let native = loadNativeKeychainToken(),
+           let accessToken = await usableNativeAccessToken(from: native) {
+            if let quota = try? await fetchQuota(accessToken: accessToken) {
+                let key = await nativeAccountName(accessToken: accessToken)
+                if quotaResults[key] == nil { quotaResults[key] = quota }
+            }
+        }
+
+        guard let files = try? fileManager.contentsOfDirectory(atPath: expandedPath) else {
+            return (quotaResults, subscriptionResults)
+        }
 
         // Run all fetches concurrently using TaskGroup
         await withTaskGroup(of: (String, ProviderQuotaData?, SubscriptionInfo?).self) { group in
@@ -1054,16 +1128,84 @@ actor AntigravityQuotaFetcher {
             }
 
             for await (email, quota, subscription) in group {
-                if let quota = quota {
+                if let quota = quota, quotaResults[email] == nil {
                     quotaResults[email] = quota
                 }
-                if let subscription = subscription {
+                if let subscription = subscription, subscriptionResults[email] == nil {
                     subscriptionResults[email] = subscription
                 }
             }
         }
 
         return (quotaResults, subscriptionResults)
+    }
+
+    /// Antigravity/agy stores a go-keyring wrapped JSON credential. Quotio only reads that item;
+    /// refreshed access tokens are bound to the refresh-token fingerprint in our own cache.
+    private func loadNativeKeychainToken() -> NativeToken? {
+        guard let data = KeychainHelper.readExternalCredential(service: "gemini", account: "antigravity"),
+              var raw = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty else { return nil }
+        let prefix = "go-keyring-base64:"
+        if raw.hasPrefix(prefix) {
+            let encoded = String(raw.dropFirst(prefix.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let decoded = Data(base64Encoded: encoded),
+                  let text = String(data: decoded, encoding: .utf8) else { return nil }
+            raw = text
+        }
+        guard let data = raw.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return NativeToken(accessToken: raw, refreshToken: nil, expiresAt: nil)
+        }
+        let token = (root["token"] as? [String: Any]) ?? root
+        let access = token["access_token"] as? String ?? token["accessToken"] as? String
+        let refresh = token["refresh_token"] as? String ?? token["refreshToken"] as? String
+        let expiryText = token["expiry"] as? String ?? token["expires_at"] as? String ?? token["expiresAt"] as? String
+        return NativeToken(accessToken: access, refreshToken: refresh, expiresAt: expiryText.flatMap(parseDate))
+    }
+
+    private func usableNativeAccessToken(from token: NativeToken) async -> String? {
+        if let access = token.accessToken,
+           token.expiresAt.map({ $0.timeIntervalSinceNow > 300 }) ?? true {
+            return access
+        }
+        guard let refresh = token.refreshToken else { return token.accessToken }
+        let fingerprint = MonitorIdentity.fingerprint(refresh)
+        if let data = try? Data(contentsOf: nativeCacheURL),
+           let cached = try? JSONDecoder().decode(NativeTokenCache.self, from: data),
+           cached.refreshFingerprint == fingerprint,
+           cached.expiresAt.timeIntervalSinceNow > 300 {
+            return cached.accessToken
+        }
+        guard let (access, expiresIn) = try? await refreshAccessTokenWithExpiry(refreshToken: refresh) else { return nil }
+        let cache = NativeTokenCache(
+            accessToken: access,
+            expiresAt: Date().addingTimeInterval(TimeInterval(expiresIn)),
+            refreshFingerprint: fingerprint
+        )
+        if let data = try? JSONEncoder().encode(cache) {
+            try? SecureAtomicFileWriter.write(data, to: nativeCacheURL)
+        }
+        return access
+    }
+
+    private func nativeAccountName(accessToken: String) async -> String {
+        guard let url = URL(string: "https://www.googleapis.com/oauth2/v2/userinfo") else { return "Antigravity" }
+        var request = URLRequest(url: url)
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        guard let (data, response) = try? await session.data(for: request),
+              let http = response as? HTTPURLResponse,
+              200...299 ~= http.statusCode,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let email = json["email"] as? String,
+              !email.isEmpty else { return "Antigravity" }
+        return email
+    }
+
+    private func parseDate(_ value: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fractional.date(from: value) ?? ISO8601DateFormatter().date(from: value)
     }
 
     /// Legacy function - now just calls fetchAllAntigravityQuotas

--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -1038,7 +1038,10 @@ actor AntigravityQuotaFetcher {
 
     /// Fetch all Antigravity data (quotas + subscriptions) in one call
     /// This avoids duplicate API calls by reusing cached subscription info
-    func fetchAllAntigravityData(authDir: String = "~/.cli-proxy-api") async -> (quotas: [String: ProviderQuotaData], subscriptions: [String: SubscriptionInfo]) {
+    func fetchAllAntigravityData(
+        authDir: String = "~/.cli-proxy-api",
+        includeMonitorCredentials: Bool = false
+    ) async -> (quotas: [String: ProviderQuotaData], subscriptions: [String: SubscriptionInfo]) {
         // Clear cache at start of refresh cycle
         clearCache()
 
@@ -1048,40 +1051,42 @@ actor AntigravityQuotaFetcher {
         var quotaResults: [String: ProviderQuotaData] = [:]
         var subscriptionResults: [String: SubscriptionInfo] = [:]
 
-        for account in await MonitorCredentialVault.shared.accounts().filter({ $0.provider == .antigravity && !$0.isDisabled }) {
-            guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { continue }
-            if credential.expiresAt.map({ $0.timeIntervalSinceNow < 300 }) ?? false,
-               let refresh = credential.refreshToken,
-               let (access, expiresIn) = try? await refreshAccessTokenWithExpiry(refreshToken: refresh) {
-                credential.accessToken = access
-                credential.expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn))
-                try? await MonitorCredentialVault.shared.save(credential, metadata: account)
-            }
-            do {
-                var quota = try await fetchQuota(accessToken: credential.accessToken)
-                if quota.isForbidden,
-                   let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id),
-                   let refresh = latest.refreshToken,
+        if includeMonitorCredentials {
+            for account in await MonitorCredentialVault.shared.accounts().filter({ $0.provider == .antigravity && !$0.isDisabled }) {
+                guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { continue }
+                if credential.expiresAt.map({ $0.timeIntervalSinceNow < 300 }) ?? false,
+                   let refresh = credential.refreshToken,
                    let (access, expiresIn) = try? await refreshAccessTokenWithExpiry(refreshToken: refresh) {
-                    credential = latest
                     credential.accessToken = access
                     credential.expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn))
                     try? await MonitorCredentialVault.shared.save(credential, metadata: account)
-                    quota = try await fetchQuota(accessToken: access)
                 }
-                quotaResults[account.accountKey] = quota
-            } catch QuotaFetchError.httpError(let status) where status == 401 || status == 403 {
-                if let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id),
-                   let refresh = latest.refreshToken,
-                   let (access, expiresIn) = try? await refreshAccessTokenWithExpiry(refreshToken: refresh) {
-                    credential = latest
-                    credential.accessToken = access
-                    credential.expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn))
-                    try? await MonitorCredentialVault.shared.save(credential, metadata: account)
-                    quotaResults[account.accountKey] = try? await fetchQuota(accessToken: access)
+                do {
+                    var quota = try await fetchQuota(accessToken: credential.accessToken)
+                    if quota.isForbidden,
+                       let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id),
+                       let refresh = latest.refreshToken,
+                       let (access, expiresIn) = try? await refreshAccessTokenWithExpiry(refreshToken: refresh) {
+                        credential = latest
+                        credential.accessToken = access
+                        credential.expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn))
+                        try? await MonitorCredentialVault.shared.save(credential, metadata: account)
+                        quota = try await fetchQuota(accessToken: access)
+                    }
+                    quotaResults[account.accountKey] = quota
+                } catch QuotaFetchError.httpError(let status) where status == 401 || status == 403 {
+                    if let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id),
+                       let refresh = latest.refreshToken,
+                       let (access, expiresIn) = try? await refreshAccessTokenWithExpiry(refreshToken: refresh) {
+                        credential = latest
+                        credential.accessToken = access
+                        credential.expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn))
+                        try? await MonitorCredentialVault.shared.save(credential, metadata: account)
+                        quotaResults[account.accountKey] = try? await fetchQuota(accessToken: access)
+                    }
+                } catch {
+                    continue
                 }
-            } catch {
-                continue
             }
         }
 

--- a/Quotio/Services/DirectAuthFileService.swift
+++ b/Quotio/Services/DirectAuthFileService.swift
@@ -333,7 +333,7 @@ actor DirectAuthFileService {
                 var expiresAt: String?
                 if let expStr = json["expires_at"] as? String ?? json["expiresAt"] as? String ?? json["expiry"] as? String {
                     expiresAt = expStr
-                } else if let expNum = json["expires_at"] as? Double ?? json["expiry"] as? Double {
+                } else if let expNum = json["expires_at"] as? Double ?? json["expiresAt"] as? Double ?? json["expiry"] as? Double {
                     // Convert numeric timestamp to ISO string for consistency in AuthTokenData
                     expiresAt = ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: expNum))
                 }
@@ -467,7 +467,7 @@ actor DirectAuthFileService {
 // MARK: - Auth Token Data
 
 /// Token data extracted from auth file
-struct AuthTokenData: Sendable {
+nonisolated struct AuthTokenData: Sendable {
     let accessToken: String
     let refreshToken: String?
     let expiresAt: String?

--- a/Quotio/Services/DirectAuthFileService.swift
+++ b/Quotio/Services/DirectAuthFileService.swift
@@ -25,10 +25,12 @@ struct DirectAuthFile: Identifiable, Sendable, Hashable {
     /// Source location of the auth file
     enum AuthFileSource: String, Sendable {
         case cliProxyApi = "~/.cli-proxy-api"
+        case nativeCredential = "Native Credential"
         
         var displayName: String {
             switch self {
             case .cliProxyApi: return "CLI Proxy API"
+            case .nativeCredential: return "Native Credential"
             }
         }
     }
@@ -323,13 +325,13 @@ actor DirectAuthFileService {
             
         case .kiro:
             // Kiro (AWS CodeWhisperer) format
-            if let accessToken = json["access_token"] as? String {
+            if let accessToken = json["access_token"] as? String ?? json["accessToken"] as? String {
 
-                let refreshToken = json["refresh_token"] as? String
+                let refreshToken = json["refresh_token"] as? String ?? json["refreshToken"] as? String
 
                 // Robust parsing for expires_at (could be string or int/double)
                 var expiresAt: String?
-                if let expStr = json["expires_at"] as? String ?? json["expiry"] as? String {
+                if let expStr = json["expires_at"] as? String ?? json["expiresAt"] as? String ?? json["expiry"] as? String {
                     expiresAt = expStr
                 } else if let expNum = json["expires_at"] as? Double ?? json["expiry"] as? Double {
                     // Convert numeric timestamp to ISO string for consistency in AuthTokenData
@@ -340,8 +342,8 @@ actor DirectAuthFileService {
                 // Default to "IdC" if not specified for backwards compatibility
                 let authMethod = json["auth_method"] as? String ?? json["authMethod"] as? String ?? "IdC"
 
-                var clientId = json["client_id"] as? String
-                var clientSecret = json["client_secret"] as? String
+                var clientId = json["client_id"] as? String ?? json["clientId"] as? String
+                var clientSecret = json["client_secret"] as? String ?? json["clientSecret"] as? String
 
                 // For IdC auth, if clientId/clientSecret are missing, try to load from AWS SSO cache
                 // Social auth (Google) doesn't need these credentials
@@ -455,7 +457,7 @@ actor DirectAuthFileService {
         // Write back to file atomically
         do {
             let updatedData = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
-            try updatedData.write(to: URL(fileURLWithPath: filePath), options: .atomic)
+            try SecureAtomicFileWriter.write(updatedData, to: URL(fileURLWithPath: filePath))
         } catch {
             // Silent failure
         }

--- a/Quotio/Services/KeychainHelper.swift
+++ b/Quotio/Services/KeychainHelper.swift
@@ -18,6 +18,7 @@ enum KeychainHelper {
     private static let warpTokensAccount = "warp-tokens"
     private static let localManagementDefaultsKey = "managementKey"
     private static let warpTokensDefaultsKey = "warpTokens"
+    nonisolated private static let monitorAuthService = "dev.quotio.desktop.monitor-auth"
 
     // Legacy service names for keychain migration (newest first)
     private static let legacyRemoteServices = [
@@ -136,6 +137,103 @@ enum KeychainHelper {
         UserDefaults.standard.removeObject(forKey: warpTokensDefaultsKey)
     }
 
+    // MARK: - Monitor-only credentials
+
+    nonisolated static func saveMonitorCredential(_ data: Data, account: String) -> Bool {
+        saveData(data, service: monitorAuthService, account: account)
+    }
+
+    nonisolated static func getMonitorCredential(account: String) -> Data? {
+        readData(service: monitorAuthService, account: account)
+    }
+
+    nonisolated static func deleteMonitorCredential(account: String) {
+        deleteData(service: monitorAuthService, account: account)
+    }
+
+    nonisolated static func compareAndSwapMonitorCredential(
+        _ data: Data,
+        account: String,
+        expectedFingerprint: String
+    ) -> Bool {
+        guard let current = getMonitorCredential(account: account),
+              MonitorIdentity.fingerprint(current.base64EncodedString()) == expectedFingerprint else {
+            return false
+        }
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: monitorAuthService,
+            kSecAttrAccount as String: account,
+        ]
+        return SecItemUpdate(
+            query as CFDictionary,
+            [kSecValueData as String: data] as CFDictionary
+        ) == errSecSuccess
+    }
+
+    /// Read a credential owned by another local CLI/app without mutating it.
+    nonisolated static func readExternalCredential(service: String, account: String? = nil) -> Data? {
+        readExternalCredentialRecord(service: service, account: account)?.data
+    }
+
+    nonisolated static func readExternalCredentialRecord(
+        service: String,
+        account: String? = nil
+    ) -> (data: Data, account: String)? {
+        let query: [String: Any] = {
+            var value: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: service,
+                kSecReturnData as String: true,
+                kSecReturnAttributes as String: true,
+                kSecMatchLimit as String: kSecMatchLimitOne,
+            ]
+            if let account, !account.isEmpty {
+                value[kSecAttrAccount as String] = account
+            }
+            return value
+        }()
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecSuccess,
+           let item = result as? [String: Any],
+           let data = item[kSecValueData as String] as? Data,
+           let resolvedAccount = item[kSecAttrAccount as String] as? String {
+            return (data, resolvedAccount)
+        }
+        if status != errSecItemNotFound && status != errSecInteractionNotAllowed {
+            Log.keychain("External keychain read failed (service: \(service)): \(status)")
+        }
+        return nil
+    }
+
+    /// Update a known writable credential source after an OAuth refresh.
+    nonisolated static func writeExternalCredential(_ data: Data, service: String, account: String) -> Bool {
+        saveData(data, service: service, account: account)
+    }
+
+    nonisolated static func compareAndSwapExternalCredential(
+        service: String,
+        account: String,
+        expectedData: Data,
+        newData: Data
+    ) -> Bool {
+        guard readExternalCredentialRecord(service: service, account: account)?.data == expectedData else {
+            return false
+        }
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        let status = SecItemUpdate(
+            query as CFDictionary,
+            [kSecValueData as String: newData] as CFDictionary
+        )
+        return status == errSecSuccess
+    }
+
     private static func migrateData(from oldServices: [String], to newService: String, account: String) -> Data? {
         for oldService in oldServices {
             guard let data = readData(service: oldService, account: account) else { continue }
@@ -159,16 +257,30 @@ enum KeychainHelper {
     }
 
 
-    private static func saveData(_ data: Data, service: String, account: String) -> Bool {
-        deleteData(service: service, account: account)
-
-        let query: [String: Any] = [
+    nonisolated private static func saveData(_ data: Data, service: String, account: String) -> Bool {
+        let identity: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
-            kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         ]
+        let updateStatus = SecItemUpdate(
+            identity as CFDictionary,
+            [
+                kSecValueData as String: data,
+                kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            ] as CFDictionary
+        )
+        if updateStatus == errSecSuccess { return true }
+        guard updateStatus == errSecItemNotFound else {
+            Log.keychain("Keychain update failed (service: \(service), account: \(account)): \(updateStatus)")
+            return false
+        }
+
+        var query = identity
+        query.merge([
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+        ]) { _, new in new }
 
         let status = SecItemAdd(query as CFDictionary, nil)
         if status == errSecSuccess {
@@ -179,7 +291,7 @@ enum KeychainHelper {
         return false
     }
 
-    private static func readData(service: String, account: String) -> Data? {
+    nonisolated private static func readData(service: String, account: String) -> Data? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -210,7 +322,7 @@ enum KeychainHelper {
         return String(data: data, encoding: .utf8)
     }
 
-    private static func deleteData(service: String, account: String) {
+    nonisolated private static func deleteData(service: String, account: String) {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,

--- a/Quotio/Services/Monitor/ClaudeDesktopCredentialReader.swift
+++ b/Quotio/Services/Monitor/ClaudeDesktopCredentialReader.swift
@@ -1,0 +1,158 @@
+import CommonCrypto
+import CryptoKit
+import Foundation
+import SQLite3
+
+/// Read-only access to Claude Desktop's Electron token cache. Refresh tokens are intentionally ignored.
+nonisolated struct ClaudeDesktopCredential: Sendable {
+    let accessToken: String
+    let expiresAt: Date
+}
+
+nonisolated enum ClaudeDesktopCredentialReader {
+    private static let appSupport = MonitorIdentity.expand("~/Library/Application Support/Claude")
+    private static let configPath = (appSupport as NSString).appendingPathComponent("config.json")
+    private static let cookiePaths = [
+        (appSupport as NSString).appendingPathComponent("Cookies"),
+        (appSupport as NSString).appendingPathComponent("Network/Cookies"),
+    ]
+
+    static func hasCredentialMaterial() -> Bool {
+        guard let json = MonitorIdentity.json(at: configPath),
+              json["oauth:tokenCache"] is String || json["oauth:tokenCacheV2"] is String else { return false }
+        return cookiePaths.contains { FileManager.default.fileExists(atPath: $0) }
+    }
+
+    static func load() -> ClaudeDesktopCredential? {
+        guard hasCredentialMaterial(),
+              let passwordData = KeychainHelper.readExternalCredential(service: "Claude Safe Storage", account: "Claude Key"),
+              let password = String(data: passwordData, encoding: .utf8),
+              let key = try? deriveKey(password),
+              let organization = activeOrganization(key: key),
+              let root = MonitorIdentity.json(at: configPath) else { return nil }
+
+        let v2 = decodeCache(root["oauth:tokenCacheV2"], key: key)
+        let v1 = decodeCache(root["oauth:tokenCache"], key: key)
+        return bestCredential(in: v2, organization: organization)
+            ?? bestCredential(in: v1, organization: organization)
+    }
+
+    private static func activeOrganization(key: Data) -> String? {
+        for path in cookiePaths where FileManager.default.fileExists(atPath: path) {
+            var database: OpaquePointer?
+            guard sqlite3_open_v2(path, &database, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else { continue }
+            defer { sqlite3_close(database) }
+            let sql = "SELECT host_key, value, encrypted_value FROM cookies WHERE name='lastActiveOrg' AND host_key IN ('.claude.ai','claude.ai') ORDER BY last_update_utc DESC LIMIT 1"
+            var statement: OpaquePointer?
+            guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else { continue }
+            defer { sqlite3_finalize(statement) }
+            guard sqlite3_step(statement) == SQLITE_ROW else { continue }
+            let host = sqlite3_column_text(statement, 0).map { String(cString: $0) } ?? "claude.ai"
+            let plain = sqlite3_column_text(statement, 1).map { String(cString: $0) }
+            if let plain, UUID(uuidString: plain) != nil { return plain.lowercased() }
+            guard let blob = sqlite3_column_blob(statement, 2) else { continue }
+            let count = Int(sqlite3_column_bytes(statement, 2))
+            let encrypted = Data(bytes: blob, count: count)
+            guard let decrypted = try? decrypt(encrypted, key: key) else { continue }
+            let hostHash = Data(SHA256.hash(data: Data(host.utf8)))
+            guard decrypted.starts(with: hostHash),
+                  let value = String(data: decrypted.dropFirst(hostHash.count), encoding: .utf8),
+                  UUID(uuidString: value) != nil else { continue }
+            return value.lowercased()
+        }
+        return nil
+    }
+
+    private static func decodeCache(_ value: Any?, key: Data) -> [String: Any]? {
+        guard let encoded = value as? String,
+              let encrypted = Data(base64Encoded: encoded),
+              let decrypted = try? decrypt(encrypted, key: key) else { return nil }
+        return try? JSONSerialization.jsonObject(with: decrypted) as? [String: Any]
+    }
+
+    private static func bestCredential(in cache: [String: Any]?, organization: String) -> ClaudeDesktopCredential? {
+        guard let cache else { return nil }
+        let marker = ":https://api.anthropic.com:"
+        let minimumExpiry = Date().addingTimeInterval(120).timeIntervalSince1970 * 1000
+        var candidates: [(rank: Int, credential: ClaudeDesktopCredential)] = []
+        for (key, raw) in cache {
+            guard key.lowercased().contains(organization),
+                  let markerRange = key.range(of: marker),
+                  let entry = raw as? [String: Any],
+                  let token = entry["token"] as? String,
+                  !token.isEmpty,
+                  let expiry = (entry["expiresAt"] as? NSNumber)?.doubleValue,
+                  expiry > minimumExpiry else { continue }
+            let scopes = key[markerRange.upperBound...].split(whereSeparator: \.isWhitespace).map(String.init)
+            guard scopes.contains("user:profile") else { continue }
+            let clientID = String(key[..<markerRange.lowerBound].split(separator: ":").first ?? "")
+            let fullScope = scopes.contains("user:inference")
+            let production = clientID == "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+            let rank = (production && fullScope ? 100 : 0) + (fullScope ? 10 : 0) + scopes.count
+            candidates.append((rank, ClaudeDesktopCredential(
+                accessToken: token,
+                expiresAt: Date(timeIntervalSince1970: expiry / 1000)
+            )))
+        }
+        return candidates.max { $0.rank < $1.rank }?.credential
+    }
+
+    private static func deriveKey(_ password: String) throws -> Data {
+        let passwordData = Data(password.utf8)
+        let salt = Data("saltysalt".utf8)
+        var key = Data(count: kCCKeySizeAES128)
+        let keyCount = key.count
+        let status = key.withUnsafeMutableBytes { keyBytes in
+            passwordData.withUnsafeBytes { passwordBytes in
+                salt.withUnsafeBytes { saltBytes in
+                    CCKeyDerivationPBKDF(
+                        CCPBKDFAlgorithm(kCCPBKDF2),
+                        passwordBytes.bindMemory(to: Int8.self).baseAddress,
+                        passwordData.count,
+                        saltBytes.bindMemory(to: UInt8.self).baseAddress,
+                        salt.count,
+                        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA1),
+                        1003,
+                        keyBytes.bindMemory(to: UInt8.self).baseAddress,
+                        keyCount
+                    )
+                }
+            }
+        }
+        guard status == kCCSuccess else { throw MonitorOAuthError.invalidResponse }
+        return key
+    }
+
+    private static func decrypt(_ encrypted: Data, key: Data) throws -> Data {
+        guard encrypted.starts(with: Data("v10".utf8)) else { throw MonitorOAuthError.invalidResponse }
+        let payload = encrypted.dropFirst(3)
+        let iv = Data(repeating: 0x20, count: kCCBlockSizeAES128)
+        var output = Data(count: payload.count + kCCBlockSizeAES128)
+        var outputLength = 0
+        let capacity = output.count
+        let status = output.withUnsafeMutableBytes { outputBytes in
+            payload.withUnsafeBytes { payloadBytes in
+                key.withUnsafeBytes { keyBytes in
+                    iv.withUnsafeBytes { ivBytes in
+                        CCCrypt(
+                            CCOperation(kCCDecrypt),
+                            CCAlgorithm(kCCAlgorithmAES),
+                            CCOptions(kCCOptionPKCS7Padding),
+                            keyBytes.baseAddress,
+                            key.count,
+                            ivBytes.baseAddress,
+                            payloadBytes.baseAddress,
+                            payload.count,
+                            outputBytes.baseAddress,
+                            capacity,
+                            &outputLength
+                        )
+                    }
+                }
+            }
+        }
+        guard status == kCCSuccess else { throw MonitorOAuthError.invalidResponse }
+        output.count = outputLength
+        return output
+    }
+}

--- a/Quotio/Services/Monitor/MonitorOAuthCallbackServer.swift
+++ b/Quotio/Services/Monitor/MonitorOAuthCallbackServer.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Network
+
+nonisolated final class MonitorOAuthCallbackServer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var listener: NWListener?
+    private var callbackContinuation: CheckedContinuation<URL, Error>?
+    private var pendingCallback: URL?
+    private var timeoutWorkItem: DispatchWorkItem?
+
+    func start(preferredPort: UInt16? = nil) async throws -> UInt16 {
+        let parameters = NWParameters.tcp
+        parameters.allowLocalEndpointReuse = true
+        let listener: NWListener
+        if let preferredPort, let port = NWEndpoint.Port(rawValue: preferredPort) {
+            listener = try NWListener(using: parameters, on: port)
+        } else {
+            listener = try NWListener(using: parameters, on: .any)
+        }
+        self.listener = listener
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.handle(connection)
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            listener.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    listener.stateUpdateHandler = nil
+                    guard let port = listener.port?.rawValue else {
+                        continuation.resume(throwing: MonitorOAuthError.invalidResponse)
+                        return
+                    }
+                    continuation.resume(returning: port)
+                case .failed(let error):
+                    listener.stateUpdateHandler = nil
+                    continuation.resume(throwing: error)
+                default:
+                    break
+                }
+            }
+            listener.start(queue: DispatchQueue(label: "dev.quotio.monitor-oauth"))
+        }
+    }
+
+    func waitForCallback(timeout: Duration = .seconds(180)) async throws -> URL {
+        let components = timeout.components
+        let seconds = max(0, Double(components.seconds) + Double(components.attoseconds) / 1_000_000_000_000_000_000)
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                lock.lock()
+                if Task.isCancelled {
+                    lock.unlock()
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                if let pendingCallback {
+                    self.pendingCallback = nil
+                    lock.unlock()
+                    listener?.cancel()
+                    listener = nil
+                    continuation.resume(returning: pendingCallback)
+                    return
+                }
+                callbackContinuation = continuation
+                let workItem = DispatchWorkItem { [weak self] in
+                    self?.completeCallback(error: MonitorOAuthError.expired)
+                }
+                timeoutWorkItem = workItem
+                lock.unlock()
+                DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + seconds, execute: workItem)
+            }
+        } onCancel: {
+            completeCallback(error: CancellationError())
+        }
+    }
+
+    func stop() {
+        completeCallback(error: CancellationError())
+    }
+
+    private func completeCallback(url: URL? = nil, error: Error? = nil) {
+        lock.lock()
+        let continuation = callbackContinuation
+        callbackContinuation = nil
+        let timeoutWorkItem = timeoutWorkItem
+        self.timeoutWorkItem = nil
+        if continuation == nil, let url {
+            pendingCallback = url
+        }
+        let listener = listener
+        self.listener = nil
+        lock.unlock()
+        timeoutWorkItem?.cancel()
+        listener?.cancel()
+        if let url, let continuation {
+            continuation.resume(returning: url)
+        } else if let error, let continuation {
+            continuation.resume(throwing: error)
+        }
+    }
+
+    private func handle(_ connection: NWConnection) {
+        connection.start(queue: DispatchQueue(label: "dev.quotio.monitor-oauth.connection"))
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { [weak self] data, _, _, _ in
+            guard let self,
+                  let data,
+                  let request = String(data: data, encoding: .utf8),
+                  let requestLine = request.split(separator: "\r\n").first else {
+                connection.cancel()
+                return
+            }
+            let parts = requestLine.split(separator: " ")
+            guard parts.count >= 2,
+                  let url = URL(string: "http://localhost\(parts[1])") else {
+                connection.cancel()
+                return
+            }
+            let body = "<html><body><h2>Authentication complete</h2><p>You can return to Quotio.</p></body></html>"
+            let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: \(body.utf8.count)\r\nConnection: close\r\n\r\n\(body)"
+            connection.send(content: Data(response.utf8), completion: .contentProcessed { _ in connection.cancel() })
+
+            completeCallback(url: url)
+        }
+    }
+}

--- a/Quotio/Services/Monitor/MonitorOAuthCoordinator.swift
+++ b/Quotio/Services/Monitor/MonitorOAuthCoordinator.swift
@@ -1,0 +1,520 @@
+import AppKit
+import CryptoKit
+import Foundation
+
+actor MonitorOAuthCoordinator {
+    static let shared = MonitorOAuthCoordinator()
+
+    private let githubClientID = "Iv1.b507a08c87ecfe98"
+    private var activeTask: Task<MonitorAccount, Error>?
+    private var callbackServer: MonitorOAuthCallbackServer?
+    private var claudePending: (state: String, verifier: String)?
+
+    func login(provider: AIProvider) async throws -> MonitorAccount {
+        let task: Task<MonitorAccount, Error>
+        switch provider {
+        case .copilot:
+            task = Task { try await githubDeviceFlow() }
+        case .kiro:
+            task = Task { try await kiroDeviceFlow() }
+        case .codex, .gemini, .antigravity:
+            task = Task { try await browserPKCEFlow(provider: provider) }
+        default:
+            throw MonitorOAuthError.flowNotImplemented(provider.displayName)
+        }
+        activeTask = task
+        defer { activeTask = nil }
+        return try await task.value
+    }
+
+    func cancel() {
+        activeTask?.cancel()
+        activeTask = nil
+        callbackServer?.stop()
+        callbackServer = nil
+        claudePending = nil
+    }
+
+    func beginClaudeLogin() async throws -> (url: URL, state: String) {
+        let state = UUID().uuidString
+        let verifier = Self.randomURLSafeString(byteCount: 48)
+        let challenge = Self.base64URL(Data(SHA256.hash(data: Data(verifier.utf8))))
+        var components = URLComponents(string: "https://claude.ai/oauth/authorize")!
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: "9d1c250a-e61b-44d9-88ed-5944d1962f5e"),
+            URLQueryItem(name: "redirect_uri", value: "https://platform.claude.com/oauth/code/callback"),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "scope", value: "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "code", value: "true"),
+            URLQueryItem(name: "code_challenge", value: challenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+        ]
+        guard let url = components.url,
+              await MainActor.run(body: { NSWorkspace.shared.open(url) }) else {
+            throw MonitorOAuthError.browserOpenFailed
+        }
+        claudePending = (state, verifier)
+        return (url, state)
+    }
+
+    func completeClaudeLogin(code rawCode: String) async throws -> MonitorAccount {
+        guard let pending = claudePending else { throw MonitorOAuthError.expired }
+        defer { claudePending = nil }
+        let pieces = rawCode.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: "#", maxSplits: 1).map(String.init)
+        guard let code = pieces.first, !code.isEmpty else { throw MonitorOAuthError.invalidResponse }
+        if pieces.count == 2, pieces[1] != pending.state { throw MonitorOAuthError.stateMismatch }
+        let tokens = try await postJSON(
+            url: "https://platform.claude.com/v1/oauth/token",
+            body: [
+                "grant_type": "authorization_code",
+                "code": code,
+                "client_id": "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+                "redirect_uri": "https://platform.claude.com/oauth/code/callback",
+                "code_verifier": pending.verifier,
+                "state": pending.state,
+            ]
+        )
+        guard let accessToken = tokens["access_token"] as? String else { throw MonitorOAuthError.invalidResponse }
+        let accountJSON = tokens["account"] as? [String: Any]
+        let email = accountJSON?["email_address"] as? String ?? "Claude"
+        let accountID = accountJSON?["uuid"] as? String
+        let account = MonitorAccount.make(
+            provider: .claude,
+            accountKey: email,
+            source: .quotioKeychain,
+            credentialReference: "keychain",
+            canDelete: true
+        )
+        let credential = MonitorOAuthCredential(
+            accessToken: accessToken,
+            refreshToken: tokens["refresh_token"] as? String,
+            idToken: nil,
+            accountID: accountID,
+            expiresAt: (tokens["expires_in"] as? NSNumber).map { Date().addingTimeInterval($0.doubleValue) },
+            extra: [:]
+        )
+        try await MonitorCredentialVault.shared.save(credential, metadata: account)
+        return account
+    }
+
+    private struct BrowserConfiguration: Sendable {
+        let authorizationURL: String
+        let tokenURL: String
+        let clientID: String
+        let clientSecret: String?
+        let scopes: String
+        let preferredPort: UInt16?
+        let callbackPath: String
+        let extraAuthorizationValues: [String: String]
+    }
+
+    private func browserPKCEFlow(provider: AIProvider) async throws -> MonitorAccount {
+        let config = try browserConfiguration(provider)
+        let server = MonitorOAuthCallbackServer()
+        callbackServer = server
+        defer {
+            server.stop()
+            callbackServer = nil
+        }
+        let port = try await server.start(preferredPort: config.preferredPort)
+        let callbackHost = provider == .codex ? "localhost" : "127.0.0.1"
+        let redirectURI = "http://\(callbackHost):\(port)\(config.callbackPath)"
+        let state = UUID().uuidString
+        let verifier = Self.randomURLSafeString(byteCount: 48)
+        let challenge = Self.base64URL(Data(SHA256.hash(data: Data(verifier.utf8))))
+
+        guard var components = URLComponents(string: config.authorizationURL) else {
+            throw MonitorOAuthError.invalidResponse
+        }
+        var values = config.extraAuthorizationValues
+        values.merge([
+            "client_id": config.clientID,
+            "redirect_uri": redirectURI,
+            "response_type": "code",
+            "scope": config.scopes,
+            "state": state,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        ]) { _, new in new }
+        components.queryItems = values.sorted { $0.key < $1.key }.map {
+            URLQueryItem(name: $0.key, value: $0.value)
+        }
+        guard let authorizationURL = components.url else { throw MonitorOAuthError.invalidResponse }
+        guard await MainActor.run(body: { NSWorkspace.shared.open(authorizationURL) }) else {
+            throw MonitorOAuthError.browserOpenFailed
+        }
+
+        let callback = try await server.waitForCallback()
+        let code = try Self.authorizationCode(from: callback, expectedState: state)
+        var exchange = [
+            "client_id": config.clientID,
+            "code": code,
+            "code_verifier": verifier,
+            "grant_type": "authorization_code",
+            "redirect_uri": redirectURI,
+        ]
+        if let secret = config.clientSecret { exchange["client_secret"] = secret }
+        let tokens = try await postForm(url: config.tokenURL, values: exchange)
+        return try await saveBrowserCredential(provider: provider, tokens: tokens)
+    }
+
+    private func browserConfiguration(_ provider: AIProvider) throws -> BrowserConfiguration {
+        switch provider {
+        case .codex:
+            return BrowserConfiguration(
+                authorizationURL: "https://auth.openai.com/oauth/authorize",
+                tokenURL: "https://auth.openai.com/oauth/token",
+                clientID: "app_EMoamEEZ73f0CkXaXp7hrann",
+                clientSecret: nil,
+                scopes: "openid profile email offline_access",
+                preferredPort: 1455,
+                callbackPath: "/auth/callback",
+                extraAuthorizationValues: [
+                    "codex_cli_simplified_flow": "true",
+                    "id_token_add_organizations": "true",
+                    "originator": "codex_cli_rs",
+                ]
+            )
+        case .gemini:
+            return googleConfiguration(
+                clientID: "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com",
+                clientSecret: "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"
+            )
+        case .antigravity:
+            return googleConfiguration(
+                clientID: "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com",
+                clientSecret: "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"
+            )
+        default:
+            throw MonitorOAuthError.flowNotImplemented(provider.displayName)
+        }
+    }
+
+    private func googleConfiguration(clientID: String, clientSecret: String) -> BrowserConfiguration {
+        BrowserConfiguration(
+            authorizationURL: "https://accounts.google.com/o/oauth2/v2/auth",
+            tokenURL: "https://oauth2.googleapis.com/token",
+            clientID: clientID,
+            clientSecret: clientSecret,
+            scopes: "openid email profile https://www.googleapis.com/auth/cloud-platform",
+            preferredPort: nil,
+            callbackPath: "/oauth2callback",
+            extraAuthorizationValues: ["access_type": "offline", "prompt": "consent"]
+        )
+    }
+
+    private func saveBrowserCredential(provider: AIProvider, tokens: [String: Any]) async throws -> MonitorAccount {
+        guard let accessToken = tokens["access_token"] as? String else { throw MonitorOAuthError.invalidResponse }
+        let idToken = tokens["id_token"] as? String
+        let refreshToken = tokens["refresh_token"] as? String
+        let expiresIn = (tokens["expires_in"] as? NSNumber)?.doubleValue
+        var email = MonitorIdentity.jwtString(idToken, claim: "email")
+        var accountID: String?
+        if provider == .codex {
+            accountID = MonitorIdentity.jwtNestedString(
+                idToken,
+                namespace: "https://api.openai.com/auth",
+                claim: "chatgpt_account_id"
+            )
+        } else {
+            let user = try? await googleUserInfo(accessToken: accessToken)
+            email = email ?? user?.email
+            accountID = user?.id
+        }
+        let key = email ?? accountID ?? "\(provider.displayName) \(UUID().uuidString.prefix(8))"
+        let account = MonitorAccount.make(
+            provider: provider,
+            accountKey: key,
+            displayName: email ?? key,
+            source: .quotioKeychain,
+            credentialReference: "keychain",
+            canDelete: true
+        )
+        let credential = MonitorOAuthCredential(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            idToken: idToken,
+            accountID: accountID,
+            expiresAt: expiresIn.map { Date().addingTimeInterval($0) },
+            extra: [:]
+        )
+        try await MonitorCredentialVault.shared.save(credential, metadata: account)
+        return account
+    }
+
+    private func googleUserInfo(accessToken: String) async throws -> (email: String?, id: String?) {
+        var request = URLRequest(url: URL(string: "https://www.googleapis.com/oauth2/v2/userinfo")!)
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, 200...299 ~= http.statusCode,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw MonitorOAuthError.invalidResponse
+        }
+        return (json["email"] as? String, json["id"] as? String)
+    }
+
+    private func githubDeviceFlow() async throws -> MonitorAccount {
+        let device = try await postForm(
+            url: "https://github.com/login/device/code",
+            values: ["client_id": githubClientID, "scope": "read:user"]
+        )
+        guard let deviceCode = device["device_code"] as? String,
+              let userCode = device["user_code"] as? String,
+              let verification = device["verification_uri"] as? String,
+              let verificationURL = URL(string: verification) else {
+            throw MonitorOAuthError.invalidResponse
+        }
+
+        _ = await MainActor.run { NSWorkspace.shared.open(verificationURL) }
+        let interval = max(5, device["interval"] as? Int ?? 5)
+        let expiresIn = device["expires_in"] as? Int ?? 900
+        let deadline = Date().addingTimeInterval(TimeInterval(expiresIn))
+        await MainActor.run {
+            NotificationCenter.default.post(
+                name: .monitorOAuthDeviceCode,
+                object: nil,
+                userInfo: ["code": userCode, "url": verification]
+            )
+        }
+
+        var pollInterval = interval
+        while Date() < deadline {
+            try Task.checkCancellation()
+            try await Task.sleep(for: .seconds(pollInterval))
+            let response = try await postForm(
+                url: "https://github.com/login/oauth/access_token",
+                values: [
+                    "client_id": githubClientID,
+                    "device_code": deviceCode,
+                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                ]
+            )
+            if let token = response["access_token"] as? String {
+                return try await saveGitHubCredential(token)
+            }
+            switch response["error"] as? String {
+            case "authorization_pending": continue
+            case "slow_down": pollInterval += 5
+            case "expired_token": throw MonitorOAuthError.expired
+            case "access_denied": throw CancellationError()
+            default: throw MonitorOAuthError.invalidResponse
+            }
+        }
+        throw MonitorOAuthError.expired
+    }
+
+    private func saveGitHubCredential(_ token: String) async throws -> MonitorAccount {
+        var request = URLRequest(url: URL(string: "https://api.github.com/user")!)
+        request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.addValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse,
+              200...299 ~= http.statusCode,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let login = json["login"] as? String else {
+            throw MonitorOAuthError.invalidResponse
+        }
+        let account = MonitorAccount.make(
+            provider: .copilot,
+            accountKey: login,
+            displayName: login,
+            source: .quotioKeychain,
+            credentialReference: "keychain",
+            canDelete: true
+        )
+        let credential = MonitorOAuthCredential(
+            accessToken: token,
+            refreshToken: nil,
+            idToken: nil,
+            accountID: String(describing: json["id"] ?? login),
+            expiresAt: nil,
+            extra: [:]
+        )
+        try await MonitorCredentialVault.shared.save(credential, metadata: account)
+        return account
+    }
+
+    private func kiroDeviceFlow() async throws -> MonitorAccount {
+        let region = "us-east-1"
+        let base = "https://oidc.\(region).amazonaws.com"
+        let registration = try await postJSON(
+            url: "\(base)/client/register",
+            body: [
+                "clientName": "Quotio Monitor",
+                "clientType": "public",
+                "scopes": ["codewhisperer:completions", "codewhisperer:analysis", "codewhisperer:conversations"],
+            ]
+        )
+        guard let clientID = registration["clientId"] as? String,
+              let clientSecret = registration["clientSecret"] as? String else {
+            throw MonitorOAuthError.invalidResponse
+        }
+        let device = try await postJSON(
+            url: "\(base)/device_authorization",
+            body: [
+                "clientId": clientID,
+                "clientSecret": clientSecret,
+                "startUrl": "https://view.awsapps.com/start",
+            ]
+        )
+        guard let deviceCode = device["deviceCode"] as? String,
+              let userCode = device["userCode"] as? String,
+              let verification = (device["verificationUriComplete"] as? String) ?? (device["verificationUri"] as? String),
+              let verificationURL = URL(string: verification) else {
+            throw MonitorOAuthError.invalidResponse
+        }
+        _ = await MainActor.run { NSWorkspace.shared.open(verificationURL) }
+        await MainActor.run {
+            NotificationCenter.default.post(
+                name: .monitorOAuthDeviceCode,
+                object: nil,
+                userInfo: ["code": userCode, "url": verification]
+            )
+        }
+        var interval = max(5, device["interval"] as? Int ?? 5)
+        let deadline = Date().addingTimeInterval(TimeInterval(device["expiresIn"] as? Int ?? 600))
+        while Date() < deadline {
+            try Task.checkCancellation()
+            try await Task.sleep(for: .seconds(interval))
+            let result: [String: Any]
+            do {
+                result = try await postJSON(
+                    url: "\(base)/token",
+                    body: [
+                        "clientId": clientID,
+                        "clientSecret": clientSecret,
+                        "deviceCode": deviceCode,
+                        "grantType": "urn:ietf:params:oauth:grant-type:device_code",
+                    ]
+                )
+            } catch MonitorOAuthError.provider(let code) where code == "authorization_pending" {
+                continue
+            } catch MonitorOAuthError.provider(let code) where code == "slow_down" {
+                interval += 5
+                continue
+            }
+            guard let accessToken = result["accessToken"] as? String,
+                  let refreshToken = result["refreshToken"] as? String else {
+                throw MonitorOAuthError.invalidResponse
+            }
+            let accountKey = "AWS Builder ID"
+            let account = MonitorAccount.make(
+                provider: .kiro,
+                accountKey: accountKey,
+                source: .quotioKeychain,
+                credentialReference: "keychain",
+                canDelete: true
+            )
+            let credential = MonitorOAuthCredential(
+                accessToken: accessToken,
+                refreshToken: refreshToken,
+                idToken: nil,
+                accountID: nil,
+                expiresAt: Date().addingTimeInterval(TimeInterval(result["expiresIn"] as? Int ?? 3600)),
+                extra: [
+                    "authMethod": "IdC",
+                    "clientId": clientID,
+                    "clientSecret": clientSecret,
+                    "region": region,
+                ]
+            )
+            try await MonitorCredentialVault.shared.save(credential, metadata: account)
+            return account
+        }
+        throw MonitorOAuthError.expired
+    }
+
+    private func postJSON(url: String, body: [String: Any]) async throws -> [String: Any] {
+        guard let endpoint = URL(string: url) else { throw MonitorOAuthError.invalidResponse }
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw MonitorOAuthError.invalidResponse
+        }
+        guard 200...299 ~= http.statusCode else {
+            throw MonitorOAuthError.provider(
+                (json["error"] as? String) ?? (json["errorCode"] as? String) ?? "http_\(http.statusCode)"
+            )
+        }
+        return json
+    }
+
+    private func postForm(url: String, values: [String: String]) async throws -> [String: Any] {
+        guard let endpoint = URL(string: url) else { throw MonitorOAuthError.invalidResponse }
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = values
+            .map { "\($0.key.monitorFormEncoded)=\($0.value.monitorFormEncoded)" }
+            .sorted()
+            .joined(separator: "&")
+            .data(using: .utf8)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse,
+              200...299 ~= http.statusCode,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw MonitorOAuthError.invalidResponse
+        }
+        return json
+    }
+
+    nonisolated private static func randomURLSafeString(byteCount: Int) -> String {
+        base64URL(Data((0..<byteCount).map { _ in UInt8.random(in: .min ... .max) }))
+    }
+
+    nonisolated static func authorizationCode(from callback: URL, expectedState: String) throws -> String {
+        guard let values = URLComponents(url: callback, resolvingAgainstBaseURL: false)?.queryItems,
+              values.first(where: { $0.name == "state" })?.value == expectedState else {
+            throw MonitorOAuthError.stateMismatch
+        }
+        guard let code = values.first(where: { $0.name == "code" })?.value, !code.isEmpty else {
+            throw MonitorOAuthError.invalidResponse
+        }
+        return code
+    }
+
+    nonisolated private static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+extension Notification.Name {
+    static let monitorOAuthDeviceCode = Notification.Name("MonitorOAuth.deviceCode")
+}
+
+nonisolated enum MonitorOAuthError: LocalizedError {
+    case flowNotImplemented(String)
+    case invalidResponse
+    case expired
+    case stateMismatch
+    case browserOpenFailed
+    case provider(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .flowNotImplemented(let provider): "Quotio-managed login for \(provider) is not available yet. Sign in with the provider's native CLI and refresh Monitor Only."
+        case .invalidResponse: "The OAuth provider returned an invalid response."
+        case .expired: "The device authorization expired. Please try again."
+        case .stateMismatch: "The OAuth callback state did not match the login request."
+        case .browserOpenFailed: "Quotio could not open the OAuth page in your browser."
+        case .provider(let code): "The OAuth provider returned \(code)."
+        }
+    }
+}
+
+private extension String {
+    nonisolated var monitorFormEncoded: String {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return addingPercentEncoding(withAllowedCharacters: allowed) ?? self
+    }
+}

--- a/Quotio/Services/Monitor/MonitorOAuthCoordinator.swift
+++ b/Quotio/Services/Monitor/MonitorOAuthCoordinator.swift
@@ -398,10 +398,19 @@ actor MonitorOAuthCoordinator {
                   let refreshToken = result["refreshToken"] as? String else {
                 throw MonitorOAuthError.invalidResponse
             }
-            let accountKey = "AWS Builder ID"
+            let expiresAt = Date().addingTimeInterval(TimeInterval(result["expiresIn"] as? Int ?? 3600))
+            let identity = await KiroQuotaFetcher().authenticatedAccountIdentity(
+                accessToken: accessToken,
+                expiresAt: expiresAt,
+                clientID: clientID,
+                clientSecret: clientSecret,
+                region: region
+            )
+            let accountKey = Self.kiroAccountKey(identity: identity, clientID: clientID)
             let account = MonitorAccount.make(
                 provider: .kiro,
                 accountKey: accountKey,
+                displayName: identity ?? "AWS Builder ID",
                 source: .quotioKeychain,
                 credentialReference: "keychain",
                 canDelete: true
@@ -410,8 +419,8 @@ actor MonitorOAuthCoordinator {
                 accessToken: accessToken,
                 refreshToken: refreshToken,
                 idToken: nil,
-                accountID: nil,
-                expiresAt: Date().addingTimeInterval(TimeInterval(result["expiresIn"] as? Int ?? 3600)),
+                accountID: identity,
+                expiresAt: expiresAt,
                 extra: [
                     "authMethod": "IdC",
                     "clientId": clientID,
@@ -423,6 +432,13 @@ actor MonitorOAuthCoordinator {
             return account
         }
         throw MonitorOAuthError.expired
+    }
+
+    nonisolated static func kiroAccountKey(identity: String?, clientID: String) -> String {
+        if let identity = identity?.trimmingCharacters(in: .whitespacesAndNewlines), !identity.isEmpty {
+            return identity
+        }
+        return "AWS Builder ID • " + String(MonitorIdentity.fingerprint(clientID).prefix(8))
     }
 
     private func postJSON(url: String, body: [String: Any]) async throws -> [String: Any] {

--- a/Quotio/Services/Monitor/MonitorRuntime.swift
+++ b/Quotio/Services/Monitor/MonitorRuntime.swift
@@ -1,0 +1,631 @@
+import CryptoKit
+import Foundation
+
+nonisolated enum MonitorAccountSource: String, Codable, Sendable, CaseIterable {
+    case quotioKeychain
+    case nativeCredential
+    case legacyCLIProxy
+    case localIDE
+    case apiKey
+
+    var priority: Int {
+        switch self {
+        case .quotioKeychain: 300
+        case .nativeCredential, .localIDE, .apiKey: 200
+        case .legacyCLIProxy: 100
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .quotioKeychain: "Quotio"
+        case .nativeCredential: "Local login"
+        case .legacyCLIProxy: "CLIProxyAPI file"
+        case .localIDE: "Local IDE"
+        case .apiKey: "API key"
+        }
+    }
+}
+
+nonisolated struct MonitorAccount: Identifiable, Codable, Hashable, Sendable {
+    let id: String
+    let provider: AIProvider
+    let accountKey: String
+    let displayName: String
+    let source: MonitorAccountSource
+    let credentialReference: String?
+    let canDelete: Bool
+    var isDisabled: Bool
+
+    var deduplicationKey: String {
+        let identity = accountKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return "\(provider.rawValue):\(identity)"
+    }
+
+    static func make(
+        provider: AIProvider,
+        accountKey: String,
+        displayName: String? = nil,
+        source: MonitorAccountSource,
+        credentialReference: String? = nil,
+        canDelete: Bool = false,
+        isDisabled: Bool = false
+    ) -> MonitorAccount {
+        let normalized = accountKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let idSeed = "\(provider.rawValue)|\(normalized.lowercased())"
+        return MonitorAccount(
+            id: "monitor-" + MonitorIdentity.fingerprint(idSeed),
+            provider: provider,
+            accountKey: normalized,
+            displayName: displayName?.nilIfBlank ?? normalized,
+            source: source,
+            credentialReference: credentialReference,
+            canDelete: canDelete,
+            isDisabled: isDisabled
+        )
+    }
+}
+
+nonisolated struct MonitorRefreshIssue: Codable, Hashable, Sendable {
+    let message: String
+    let occurredAt: Date
+}
+
+nonisolated struct MonitorRefreshBatch: Sendable {
+    var accounts: [MonitorAccount]
+    var quotas: [AIProvider: [String: ProviderQuotaData]]
+    var issues: [AIProvider: MonitorRefreshIssue]
+}
+
+nonisolated protocol MonitorProviderRuntime: Sendable {
+    var provider: AIProvider { get }
+    func discoverAccounts() async -> [MonitorAccount]
+    func refresh(force: Bool) async -> [String: ProviderQuotaData]
+}
+
+nonisolated protocol MonitorCredentialStore: Sendable {
+    func accounts() async -> [MonitorAccount]
+    func credential(for accountID: String) async -> MonitorOAuthCredential?
+    func reloadLatest(accountID: String) async -> MonitorOAuthCredential?
+    func save(_ credential: MonitorOAuthCredential, metadata: MonitorAccount) async throws
+    func delete(accountID: String) async
+}
+
+nonisolated struct MonitorOAuthCredential: Codable, Sendable {
+    var accessToken: String
+    var refreshToken: String?
+    var idToken: String?
+    var accountID: String?
+    var expiresAt: Date?
+    var extra: [String: String]
+}
+
+actor MonitorCredentialVault: MonitorCredentialStore {
+    static let shared = MonitorCredentialVault()
+
+    private let metadata: MonitorMetadataStore
+    private var loadedGenerations: [String: String] = [:]
+
+    init(metadata: MonitorMetadataStore = .shared) {
+        self.metadata = metadata
+    }
+
+    func accounts() async -> [MonitorAccount] {
+        await metadata.accounts()
+    }
+
+    func credential(for accountID: String) -> MonitorOAuthCredential? {
+        guard let data = KeychainHelper.getMonitorCredential(account: accountID) else { return nil }
+        loadedGenerations[accountID] = MonitorIdentity.fingerprint(data.base64EncodedString())
+        return try? JSONDecoder().decode(MonitorOAuthCredential.self, from: data)
+    }
+
+    func reloadLatest(accountID: String) -> MonitorOAuthCredential? {
+        credential(for: accountID)
+    }
+
+    func save(_ credential: MonitorOAuthCredential, metadata account: MonitorAccount) async throws {
+        let data = try JSONEncoder().encode(credential)
+        let saved: Bool
+        if let expected = loadedGenerations[account.id] {
+            saved = KeychainHelper.compareAndSwapMonitorCredential(
+                data,
+                account: account.id,
+                expectedFingerprint: expected
+            )
+        } else {
+            saved = KeychainHelper.saveMonitorCredential(data, account: account.id)
+        }
+        guard saved else {
+            throw MonitorRuntimeError.credentialWriteFailed
+        }
+        loadedGenerations[account.id] = MonitorIdentity.fingerprint(data.base64EncodedString())
+        try await self.metadata.saveAccount(account)
+    }
+
+    func delete(accountID: String) async {
+        KeychainHelper.deleteMonitorCredential(account: accountID)
+        loadedGenerations.removeValue(forKey: accountID)
+        try? await metadata.deleteAccount(accountID)
+    }
+}
+
+actor MonitorMetadataStore {
+    static let shared = MonitorMetadataStore()
+
+    private struct Payload: Codable {
+        var accounts: [MonitorAccount] = []
+        var disabledAccountIDs: Set<String> = []
+    }
+
+    private let url: URL
+
+    init(url: URL? = nil) {
+        self.url = url ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Quotio/Monitor/accounts-v1.json")
+    }
+
+    func accounts() -> [MonitorAccount] { load().accounts }
+    func disabledAccountIDs() -> Set<String> { load().disabledAccountIDs }
+
+    func saveAccount(_ account: MonitorAccount) throws {
+        var payload = load()
+        payload.accounts.removeAll { $0.id == account.id }
+        payload.accounts.append(account)
+        try save(payload)
+    }
+
+    func deleteAccount(_ accountID: String) throws {
+        var payload = load()
+        payload.accounts.removeAll { $0.id == accountID }
+        payload.disabledAccountIDs.remove(accountID)
+        try save(payload)
+    }
+
+    func setDisabled(_ disabled: Bool, accountID: String) throws {
+        var payload = load()
+        if disabled { payload.disabledAccountIDs.insert(accountID) }
+        else { payload.disabledAccountIDs.remove(accountID) }
+        try save(payload)
+    }
+
+    private func load() -> Payload {
+        guard let data = try? Data(contentsOf: url),
+              let payload = try? JSONDecoder().decode(Payload.self, from: data) else { return Payload() }
+        return payload
+    }
+
+    private func save(_ payload: Payload) throws {
+        try SecureAtomicFileWriter.write(try JSONEncoder().encode(payload), to: url)
+    }
+}
+
+actor MonitorSnapshotStore {
+    private struct Payload: Codable {
+        var quotas: [String: [String: ProviderQuotaData]]
+    }
+
+    private let url: URL
+
+    init(url: URL? = nil) {
+        if let url {
+            self.url = url
+        } else {
+            let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            self.url = base
+                .appendingPathComponent("Quotio", isDirectory: true)
+                .appendingPathComponent("Monitor", isDirectory: true)
+                .appendingPathComponent("snapshots-v1.json")
+        }
+    }
+
+    func load() -> [AIProvider: [String: ProviderQuotaData]] {
+        guard let data = try? Data(contentsOf: url),
+              let payload = try? JSONDecoder().decode(Payload.self, from: data) else {
+            return [:]
+        }
+        return payload.quotas.reduce(into: [:]) { result, item in
+            if let provider = AIProvider(rawValue: item.key) {
+                result[provider] = item.value
+            }
+        }
+    }
+
+    func store(_ quotas: [AIProvider: [String: ProviderQuotaData]]) {
+        let encoded = quotas.reduce(into: [String: [String: ProviderQuotaData]]()) {
+            $0[$1.key.rawValue] = $1.value
+        }
+        guard let data = try? JSONEncoder().encode(Payload(quotas: encoded)) else { return }
+        do {
+            try SecureAtomicFileWriter.write(data, to: url)
+        } catch {
+            Log.quota("Failed to persist Monitor snapshot: \(error.localizedDescription)")
+        }
+    }
+}
+
+actor MonitorAccountDiscovery {
+    private let vault: MonitorCredentialStore
+    private let directAuthService: DirectAuthFileService
+    private let metadata: MonitorMetadataStore
+
+    init(
+        vault: MonitorCredentialStore = MonitorCredentialVault.shared,
+        directAuthService: DirectAuthFileService = DirectAuthFileService(),
+        metadata: MonitorMetadataStore = .shared
+    ) {
+        self.vault = vault
+        self.directAuthService = directAuthService
+        self.metadata = metadata
+    }
+
+    func discover() async -> [MonitorAccount] {
+        var candidates = await vault.accounts()
+        candidates.append(contentsOf: discoverNativeFiles())
+        candidates.append(contentsOf: discoverNativeKeychains())
+        let legacy = await directAuthService.scanAllAuthFiles().map { file in
+            let accountKey: String
+            if file.provider == .codex {
+                accountKey = file.email?.nilIfBlank
+                    ?? file.filename.replacingOccurrences(of: ".json", with: "")
+            } else if let email = file.email, !email.isEmpty {
+                accountKey = email
+            } else {
+                accountKey = file.filename.replacingOccurrences(of: ".json", with: "")
+            }
+            let displayName = file.email?.nilIfBlank ?? file.login?.nilIfBlank ?? file.filename
+            return MonitorAccount.make(
+                provider: file.provider,
+                accountKey: accountKey,
+                displayName: displayName,
+                source: .legacyCLIProxy,
+                credentialReference: file.filePath
+            )
+        }
+        candidates.append(contentsOf: legacy)
+
+        let disabled = await metadata.disabledAccountIDs()
+        return Self.selectPreferred(candidates, disabledIDs: disabled)
+    }
+
+    nonisolated static func selectPreferred(
+        _ candidates: [MonitorAccount],
+        disabledIDs: Set<String> = []
+    ) -> [MonitorAccount] {
+        var selected: [String: MonitorAccount] = [:]
+        for var account in candidates {
+            account.isDisabled = disabledIDs.contains(account.id)
+            let key = account.deduplicationKey
+            if let existing = selected[key], existing.source.priority >= account.source.priority {
+                continue
+            }
+            selected[key] = account
+        }
+        return selected.values.sorted {
+            if $0.provider.displayName == $1.provider.displayName {
+                return $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+            }
+            return $0.provider.displayName < $1.provider.displayName
+        }
+    }
+
+    func setDisabled(_ disabled: Bool, accountID: String) async {
+        try? await metadata.setDisabled(disabled, accountID: accountID)
+    }
+
+    private func discoverNativeFiles() -> [MonitorAccount] {
+        var accounts: [MonitorAccount] = []
+        accounts.append(contentsOf: discoverCodexFiles())
+        accounts.append(contentsOf: discoverClaudeFile())
+        if ClaudeDesktopCredentialReader.hasCredentialMaterial() {
+            accounts.append(.make(
+                provider: .claude,
+                accountKey: "Claude Desktop",
+                source: .localIDE,
+                credentialReference: "claude-desktop"
+            ))
+        }
+        accounts.append(contentsOf: discoverGeminiFile())
+        accounts.append(contentsOf: discoverCopilotFiles())
+        accounts.append(contentsOf: discoverKiroFile())
+        let antigravityDatabase = MonitorIdentity.expand("~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb")
+        if FileManager.default.fileExists(atPath: antigravityDatabase) {
+            accounts.append(.make(
+                provider: .antigravity,
+                accountKey: "Antigravity",
+                source: .localIDE,
+                credentialReference: antigravityDatabase
+            ))
+        }
+        return accounts
+    }
+
+    private func discoverCodexFiles() -> [MonitorAccount] {
+        var paths: [String] = []
+        if let home = ProcessInfo.processInfo.environment["CODEX_HOME"], !home.isEmpty {
+            paths.append((home as NSString).appendingPathComponent("auth.json"))
+        }
+        paths.append(contentsOf: ["~/.config/codex/auth.json", "~/.codex/auth.json"].map(MonitorIdentity.expand))
+        return paths.compactMap { path in
+            guard let json = MonitorIdentity.json(at: path),
+                  let tokens = json["tokens"] as? [String: Any],
+                  (tokens["access_token"] as? String)?.isEmpty == false else { return nil }
+            let email = MonitorIdentity.jwtString(tokens["id_token"] as? String, claim: "email")
+            let accountID = (tokens["account_id"] as? String)
+                ?? MonitorIdentity.jwtNestedString(tokens["id_token"] as? String, namespace: "https://api.openai.com/auth", claim: "chatgpt_account_id")
+            let key = email ?? accountID ?? "Codex"
+            return MonitorAccount.make(provider: .codex, accountKey: key, source: .nativeCredential, credentialReference: path)
+        }
+    }
+
+    private func discoverClaudeFile() -> [MonitorAccount] {
+        let base = ProcessInfo.processInfo.environment["CLAUDE_CONFIG_DIR"]?.nilIfBlank ?? MonitorIdentity.expand("~/.claude")
+        let path = (base as NSString).appendingPathComponent(".credentials.json")
+        guard let json = MonitorIdentity.json(at: path),
+              let oauth = json["claudeAiOauth"] as? [String: Any],
+              (oauth["accessToken"] as? String)?.isEmpty == false else { return [] }
+        let email = (oauth["email"] as? String) ?? "Claude Code"
+        return [.make(provider: .claude, accountKey: email, source: .nativeCredential, credentialReference: path)]
+    }
+
+    private func discoverGeminiFile() -> [MonitorAccount] {
+        let authPath = MonitorIdentity.expand("~/.gemini/oauth_creds.json")
+        guard let auth = MonitorIdentity.json(at: authPath),
+              (auth["access_token"] as? String)?.isEmpty == false else { return [] }
+        let accountsPath = MonitorIdentity.expand("~/.gemini/google_accounts.json")
+        let email = (MonitorIdentity.json(at: accountsPath)?["active"] as? String)
+            ?? MonitorIdentity.jwtString(auth["id_token"] as? String, claim: "email")
+            ?? "Gemini CLI"
+        return [.make(provider: .gemini, accountKey: email, source: .nativeCredential, credentialReference: authPath)]
+    }
+
+    private func discoverCopilotFiles() -> [MonitorAccount] {
+        let paths = [
+            "~/.config/github-copilot/apps.json",
+            "~/.config/github-copilot/hosts.json",
+            "~/.config/gh/hosts.yml",
+        ].map(MonitorIdentity.expand)
+        return paths.compactMap { path in
+            guard FileManager.default.fileExists(atPath: path) else { return nil }
+            return MonitorAccount.make(provider: .copilot, accountKey: "GitHub Copilot", source: .nativeCredential, credentialReference: path)
+        }
+    }
+
+    private func discoverKiroFile() -> [MonitorAccount] {
+        let path = MonitorIdentity.expand("~/.aws/sso/cache/kiro-auth-token.json")
+        guard let json = MonitorIdentity.json(at: path),
+              (json["accessToken"] as? String ?? json["access_token"] as? String)?.isEmpty == false else { return [] }
+        let key = (json["email"] as? String) ?? (json["profileArn"] as? String) ?? "Kiro"
+        return [.make(provider: .kiro, accountKey: key, source: .nativeCredential, credentialReference: path)]
+    }
+
+    private func discoverNativeKeychains() -> [MonitorAccount] {
+        var accounts: [MonitorAccount] = []
+        if let data = KeychainHelper.readExternalCredential(service: "Codex Auth"),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let tokens = json["tokens"] as? [String: Any],
+           (tokens["access_token"] as? String)?.isEmpty == false {
+            let email = MonitorIdentity.jwtString(tokens["id_token"] as? String, claim: "email") ?? "Codex"
+            accounts.append(.make(provider: .codex, accountKey: email, source: .nativeCredential, credentialReference: "keychain:Codex Auth"))
+        }
+        if let data = KeychainHelper.readExternalCredential(service: "Claude Code-credentials"),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let oauth = json["claudeAiOauth"] as? [String: Any],
+           (oauth["accessToken"] as? String)?.isEmpty == false {
+            accounts.append(.make(provider: .claude, accountKey: (oauth["email"] as? String) ?? "Claude Code", source: .nativeCredential, credentialReference: "keychain:Claude Code-credentials"))
+        }
+        if KeychainHelper.readExternalCredential(service: "gemini", account: "antigravity") != nil {
+            accounts.append(.make(provider: .antigravity, accountKey: "Antigravity", source: .nativeCredential, credentialReference: "keychain:gemini:antigravity"))
+        }
+        if KeychainHelper.readExternalCredential(service: "gh:github.com") != nil {
+            accounts.append(.make(provider: .copilot, accountKey: "GitHub Copilot", source: .nativeCredential, credentialReference: "keychain:gh:github.com"))
+        }
+        return accounts
+    }
+}
+
+actor MonitorRefreshCoordinator {
+    private let discovery: MonitorAccountDiscovery
+    private let snapshots: MonitorSnapshotStore
+    private var inFlight: [AIProvider: Task<[String: ProviderQuotaData], Never>] = [:]
+    private var retryAfter: [AIProvider: Date] = [:]
+    private(set) var issues: [AIProvider: MonitorRefreshIssue] = [:]
+
+    init(
+        discovery: MonitorAccountDiscovery = MonitorAccountDiscovery(),
+        snapshots: MonitorSnapshotStore = MonitorSnapshotStore()
+    ) {
+        self.discovery = discovery
+        self.snapshots = snapshots
+    }
+
+    func bootstrap() async -> MonitorRefreshBatch {
+        MonitorRefreshBatch(
+            accounts: await discovery.discover(),
+            quotas: await snapshots.load(),
+            issues: issues
+        )
+    }
+
+    func discoverAccounts(merging quotas: [AIProvider: [String: ProviderQuotaData]] = [:]) async -> [MonitorAccount] {
+        var accounts = await discovery.discover()
+        let existingKeys = Set(accounts.map(\.deduplicationKey))
+        var appendedKeys = existingKeys
+
+        for (provider, accountQuotas) in quotas {
+            let source: MonitorAccountSource
+            switch provider {
+            case .cursor, .trae: source = .localIDE
+            case .glm, .warp, .clinePass: source = .apiKey
+            default: source = .nativeCredential
+            }
+            for accountKey in accountQuotas.keys {
+                let account = MonitorAccount.make(
+                    provider: provider,
+                    accountKey: accountKey,
+                    source: source
+                )
+                guard appendedKeys.insert(account.deduplicationKey).inserted else { continue }
+                accounts.append(account)
+            }
+        }
+        let placeholders: [AIProvider: Set<String>] = [
+            .copilot: ["github copilot"],
+            .antigravity: ["antigravity"],
+            .gemini: ["gemini cli"],
+            .claude: ["claude code"],
+            .codex: ["codex", "codex user"],
+            .kiro: ["kiro"],
+        ]
+        accounts = accounts.filter { account in
+            guard placeholders[account.provider]?.contains(account.accountKey.lowercased()) == true else { return true }
+            return !accounts.contains {
+                $0.provider == account.provider
+                    && $0.id != account.id
+                    && placeholders[account.provider]?.contains($0.accountKey.lowercased()) != true
+                    && $0.source.priority >= account.source.priority
+            }
+        }
+        return accounts.sorted {
+            if $0.provider.displayName == $1.provider.displayName {
+                return $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+            }
+            return $0.provider.displayName < $1.provider.displayName
+        }
+    }
+
+    func refresh(
+        provider: AIProvider,
+        force: Bool,
+        previous: [String: ProviderQuotaData],
+        operation: @escaping @Sendable () async -> [String: ProviderQuotaData]
+    ) async -> [String: ProviderQuotaData] {
+        if !force, let retry = retryAfter[provider], retry > Date() {
+            return previous
+        }
+        if let task = inFlight[provider] {
+            return await task.value
+        }
+
+        let task = Task { await operation() }
+        inFlight[provider] = task
+        let fresh = await task.value
+        inFlight[provider] = nil
+
+        if fresh.isEmpty, !previous.isEmpty {
+            issues[provider] = MonitorRefreshIssue(
+                message: "monitor.refresh.failed".localizedStatic(),
+                occurredAt: Date()
+            )
+            retryAfter[provider] = Date().addingTimeInterval(60)
+            return previous
+        }
+
+        if !fresh.isEmpty {
+            var merged = previous
+            merged.merge(fresh) { _, new in new }
+            if fresh.count < previous.count {
+                issues[provider] = MonitorRefreshIssue(
+                    message: "monitor.refresh.partial".localizedStatic(),
+                    occurredAt: Date()
+                )
+                retryAfter[provider] = Date().addingTimeInterval(60)
+            } else {
+                issues.removeValue(forKey: provider)
+                retryAfter.removeValue(forKey: provider)
+            }
+            return merged
+        }
+
+        issues.removeValue(forKey: provider)
+        retryAfter.removeValue(forKey: provider)
+        return fresh
+    }
+
+    func finish(quotas: [AIProvider: [String: ProviderQuotaData]]) async {
+        await snapshots.store(quotas)
+    }
+
+    func currentIssues() -> [AIProvider: MonitorRefreshIssue] {
+        issues
+    }
+
+    func setDisabled(_ disabled: Bool, accountID: String) async {
+        await discovery.setDisabled(disabled, accountID: accountID)
+    }
+
+    func deleteOwnedAccount(accountID: String) async {
+        await MonitorCredentialVault.shared.delete(accountID: accountID)
+    }
+}
+
+nonisolated enum SecureAtomicFileWriter {
+    static func write(_ data: Data, to url: URL) throws {
+        let manager = FileManager.default
+        let directory = url.deletingLastPathComponent()
+        try manager.createDirectory(at: directory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        if let values = try? url.resourceValues(forKeys: [.isSymbolicLinkKey]), values.isSymbolicLink == true {
+            throw MonitorRuntimeError.symbolicLinkRefused
+        }
+        let temporary = directory.appendingPathComponent(".\(url.lastPathComponent).\(UUID().uuidString).tmp")
+        try data.write(to: temporary, options: .withoutOverwriting)
+        try manager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: temporary.path)
+        if manager.fileExists(atPath: url.path) {
+            _ = try manager.replaceItemAt(url, withItemAt: temporary)
+        } else {
+            try manager.moveItem(at: temporary, to: url)
+        }
+    }
+}
+
+nonisolated enum MonitorIdentity {
+    static func fingerprint(_ value: String) -> String {
+        SHA256.hash(data: Data(value.utf8)).map { String(format: "%02x", $0) }.joined().prefix(20).description
+    }
+
+    static func expand(_ path: String) -> String {
+        NSString(string: path).expandingTildeInPath
+    }
+
+    static func json(at path: String) -> [String: Any]? {
+        guard let data = FileManager.default.contents(atPath: path) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    static func jwtString(_ token: String?, claim: String) -> String? {
+        jwtPayload(token)?[claim] as? String
+    }
+
+    static func jwtNestedString(_ token: String?, namespace: String, claim: String) -> String? {
+        (jwtPayload(token)?[namespace] as? [String: Any])?[claim] as? String
+    }
+
+    private static func jwtPayload(_ token: String?) -> [String: Any]? {
+        guard let token else { return nil }
+        let parts = token.split(separator: ".")
+        guard parts.count > 1 else { return nil }
+        var value = String(parts[1]).replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        value += String(repeating: "=", count: (4 - value.count % 4) % 4)
+        guard let data = Data(base64Encoded: value) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+}
+
+nonisolated enum MonitorRuntimeError: LocalizedError {
+    case credentialWriteFailed
+    case symbolicLinkRefused
+
+    var errorDescription: String? {
+        switch self {
+        case .credentialWriteFailed: "Could not save the Monitor credential in Keychain."
+        case .symbolicLinkRefused: "Refusing to write credentials through a symbolic link."
+        }
+    }
+}
+
+private extension String {
+    nonisolated var nilIfBlank: String? {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Quotio/Services/Monitor/MonitorRuntime.swift
+++ b/Quotio/Services/Monitor/MonitorRuntime.swift
@@ -17,12 +17,16 @@ nonisolated enum MonitorAccountSource: String, Codable, Sendable, CaseIterable {
     }
 
     var displayName: String {
+        localizationKey.localizedStatic()
+    }
+
+    var localizationKey: String {
         switch self {
-        case .quotioKeychain: "Quotio"
-        case .nativeCredential: "Local login"
-        case .legacyCLIProxy: "CLIProxyAPI file"
-        case .localIDE: "Local IDE"
-        case .apiKey: "API key"
+        case .quotioKeychain: "monitor.source.quotio"
+        case .nativeCredential: "monitor.source.localLogin"
+        case .legacyCLIProxy: "monitor.source.cliProxyFile"
+        case .localIDE: "monitor.source.localIDE"
+        case .apiKey: "monitor.source.apiKey"
         }
     }
 }
@@ -282,7 +286,7 @@ actor MonitorAccountDiscovery {
         let legacyFiles = await directAuthService.scanAllAuthFiles()
         let codexAliases = Self.codexAliases(from: legacyFiles)
         var candidates = await canonicalizeCodexAccounts(await vault.accounts(), aliases: codexAliases)
-        candidates.append(contentsOf: discoverNativeFiles(codexAliases: codexAliases))
+        candidates.append(contentsOf: await discoverNativeFiles(codexAliases: codexAliases))
         candidates.append(contentsOf: discoverNativeKeychains(codexAliases: codexAliases))
         let legacy = legacyFiles.map(MonitorAccount.makeLegacy)
         candidates.append(contentsOf: legacy)
@@ -378,7 +382,11 @@ actor MonitorAccountDiscovery {
         try? await metadata.setDisabled(disabled, accountID: accountID)
     }
 
-    private func discoverNativeFiles(codexAliases: [String: String]) -> [MonitorAccount] {
+    func disabledAccountIDs() async -> Set<String> {
+        await metadata.disabledAccountIDs()
+    }
+
+    private func discoverNativeFiles(codexAliases: [String: String]) async -> [MonitorAccount] {
         var accounts: [MonitorAccount] = []
         accounts.append(contentsOf: discoverCodexFiles(aliases: codexAliases))
         accounts.append(contentsOf: discoverClaudeFile())
@@ -394,7 +402,8 @@ actor MonitorAccountDiscovery {
         accounts.append(contentsOf: discoverCopilotFiles())
         accounts.append(contentsOf: discoverKiroFile())
         let antigravityDatabase = MonitorIdentity.expand("~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb")
-        if FileManager.default.fileExists(atPath: antigravityDatabase) {
+        if let token = try? await AntigravityDatabaseService().getCurrentTokenInfo(),
+           token.accessToken?.nilIfBlank != nil || token.refreshToken?.nilIfBlank != nil {
             accounts.append(.make(
                 provider: .antigravity,
                 accountKey: "Antigravity",
@@ -519,6 +528,7 @@ actor MonitorRefreshCoordinator {
 
     func discoverAccounts(merging quotas: [AIProvider: [String: ProviderQuotaData]] = [:]) async -> [MonitorAccount] {
         var accounts = await discovery.discover()
+        let disabledIDs = await discovery.disabledAccountIDs()
         let existingKeys = Set(accounts.map(\.deduplicationKey))
         var appendedKeys = existingKeys
 
@@ -530,10 +540,11 @@ actor MonitorRefreshCoordinator {
             default: source = .nativeCredential
             }
             for accountKey in accountQuotas.keys {
-                let account = MonitorAccount.make(
+                let account = Self.makeQuotaDerivedAccount(
                     provider: provider,
                     accountKey: accountKey,
-                    source: source
+                    source: source,
+                    disabledIDs: disabledIDs
                 )
                 guard appendedKeys.insert(account.deduplicationKey).inserted else { continue }
                 accounts.append(account)
@@ -564,10 +575,22 @@ actor MonitorRefreshCoordinator {
         }
     }
 
+    nonisolated static func makeQuotaDerivedAccount(
+        provider: AIProvider,
+        accountKey: String,
+        source: MonitorAccountSource,
+        disabledIDs: Set<String>
+    ) -> MonitorAccount {
+        var account = MonitorAccount.make(provider: provider, accountKey: accountKey, source: source)
+        account.isDisabled = disabledIDs.contains(account.id)
+        return account
+    }
+
     func refresh(
         provider: AIProvider,
         force: Bool,
         previous: [String: ProviderQuotaData],
+        credentialAvailability: MonitorCredentialAvailability = .unknown,
         operation: @escaping @Sendable () async -> [String: ProviderQuotaData]
     ) async -> [String: ProviderQuotaData] {
         if !force, let retry = retryAfter[provider], retry > Date() {
@@ -581,6 +604,12 @@ actor MonitorRefreshCoordinator {
         inFlight[provider] = task
         let fresh = await task.value
         inFlight[provider] = nil
+
+        if fresh.isEmpty, credentialAvailability == .missing {
+            issues.removeValue(forKey: provider)
+            retryAfter.removeValue(forKey: provider)
+            return [:]
+        }
 
         if fresh.isEmpty, !previous.isEmpty {
             issues[provider] = MonitorRefreshIssue(
@@ -627,6 +656,12 @@ actor MonitorRefreshCoordinator {
     func deleteOwnedAccount(accountID: String) async {
         await MonitorCredentialVault.shared.delete(accountID: accountID)
     }
+}
+
+nonisolated enum MonitorCredentialAvailability: Equatable, Sendable {
+    case unknown
+    case present
+    case missing
 }
 
 nonisolated enum SecureAtomicFileWriter {

--- a/Quotio/Services/Monitor/MonitorRuntime.swift
+++ b/Quotio/Services/Monitor/MonitorRuntime.swift
@@ -64,6 +64,25 @@ nonisolated struct MonitorAccount: Identifiable, Codable, Hashable, Sendable {
             isDisabled: isDisabled
         )
     }
+
+    static func makeLegacy(_ file: DirectAuthFile) -> MonitorAccount {
+        let accountKey: String
+        if file.provider == .codex {
+            accountKey = file.filename.codexFilenameKey
+        } else if let email = file.email, !email.isEmpty {
+            accountKey = email
+        } else {
+            accountKey = file.filename.replacingOccurrences(of: ".json", with: "")
+        }
+        let displayName = file.email?.nilIfBlank ?? file.login?.nilIfBlank ?? file.filename
+        return make(
+            provider: file.provider,
+            accountKey: accountKey,
+            displayName: displayName,
+            source: .legacyCLIProxy,
+            credentialReference: file.filePath
+        )
+    }
 }
 
 nonisolated struct MonitorRefreshIssue: Codable, Hashable, Sendable {
@@ -263,25 +282,7 @@ actor MonitorAccountDiscovery {
         var candidates = await vault.accounts()
         candidates.append(contentsOf: discoverNativeFiles())
         candidates.append(contentsOf: discoverNativeKeychains())
-        let legacy = await directAuthService.scanAllAuthFiles().map { file in
-            let accountKey: String
-            if file.provider == .codex {
-                accountKey = file.email?.nilIfBlank
-                    ?? file.filename.replacingOccurrences(of: ".json", with: "")
-            } else if let email = file.email, !email.isEmpty {
-                accountKey = email
-            } else {
-                accountKey = file.filename.replacingOccurrences(of: ".json", with: "")
-            }
-            let displayName = file.email?.nilIfBlank ?? file.login?.nilIfBlank ?? file.filename
-            return MonitorAccount.make(
-                provider: file.provider,
-                accountKey: accountKey,
-                displayName: displayName,
-                source: .legacyCLIProxy,
-                credentialReference: file.filePath
-            )
-        }
+        let legacy = await directAuthService.scanAllAuthFiles().map(MonitorAccount.makeLegacy)
         candidates.append(contentsOf: legacy)
 
         let disabled = await metadata.disabledAccountIDs()

--- a/Quotio/Services/Monitor/MonitorRuntime.swift
+++ b/Quotio/Services/Monitor/MonitorRuntime.swift
@@ -279,10 +279,12 @@ actor MonitorAccountDiscovery {
     }
 
     func discover() async -> [MonitorAccount] {
-        var candidates = await vault.accounts()
-        candidates.append(contentsOf: discoverNativeFiles())
-        candidates.append(contentsOf: discoverNativeKeychains())
-        let legacy = await directAuthService.scanAllAuthFiles().map(MonitorAccount.makeLegacy)
+        let legacyFiles = await directAuthService.scanAllAuthFiles()
+        let codexAliases = Self.codexAliases(from: legacyFiles)
+        var candidates = await canonicalizeCodexAccounts(await vault.accounts(), aliases: codexAliases)
+        candidates.append(contentsOf: discoverNativeFiles(codexAliases: codexAliases))
+        candidates.append(contentsOf: discoverNativeKeychains(codexAliases: codexAliases))
+        let legacy = legacyFiles.map(MonitorAccount.makeLegacy)
         candidates.append(contentsOf: legacy)
 
         let disabled = await metadata.disabledAccountIDs()
@@ -310,13 +312,75 @@ actor MonitorAccountDiscovery {
         }
     }
 
+    nonisolated static func canonicalizeCodexAccount(
+        _ account: MonitorAccount,
+        accountID: String?,
+        aliases: [String: String]
+    ) -> MonitorAccount {
+        guard account.provider == .codex,
+              let accountID = accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let canonicalKey = aliases[accountID] else { return account }
+        return MonitorAccount(
+            id: account.id,
+            provider: account.provider,
+            accountKey: canonicalKey,
+            displayName: account.displayName,
+            source: account.source,
+            credentialReference: account.credentialReference,
+            canDelete: account.canDelete,
+            isDisabled: account.isDisabled
+        )
+    }
+
+    private nonisolated static func codexAliases(from files: [DirectAuthFile]) -> [String: String] {
+        var keysByAccountID: [String: Set<String>] = [:]
+        for file in files where file.provider == .codex {
+            guard let json = MonitorIdentity.json(at: file.filePath) else { continue }
+            let accountID = (json["account_id"] as? String)
+                ?? MonitorIdentity.jwtNestedString(
+                    json["id_token"] as? String,
+                    namespace: "https://api.openai.com/auth",
+                    claim: "chatgpt_account_id"
+                )
+            guard let accountID = accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !accountID.isEmpty else { continue }
+            keysByAccountID[accountID, default: []].insert(file.filename.codexFilenameKey)
+        }
+        return keysByAccountID.reduce(into: [:]) { aliases, entry in
+            guard entry.value.count == 1, let key = entry.value.first else { return }
+            aliases[entry.key] = key
+        }
+    }
+
+    private func canonicalizeCodexAccounts(
+        _ accounts: [MonitorAccount],
+        aliases: [String: String]
+    ) async -> [MonitorAccount] {
+        var result: [MonitorAccount] = []
+        for account in accounts {
+            guard account.provider == .codex,
+                  let credential = await vault.credential(for: account.id) else {
+                result.append(account)
+                continue
+            }
+            let accountID = credential.accountID
+                ?? MonitorIdentity.jwtNestedString(
+                    credential.idToken,
+                    namespace: "https://api.openai.com/auth",
+                    claim: "chatgpt_account_id"
+                )
+            result.append(Self.canonicalizeCodexAccount(account, accountID: accountID, aliases: aliases))
+        }
+        return result
+    }
+
     func setDisabled(_ disabled: Bool, accountID: String) async {
         try? await metadata.setDisabled(disabled, accountID: accountID)
     }
 
-    private func discoverNativeFiles() -> [MonitorAccount] {
+    private func discoverNativeFiles(codexAliases: [String: String]) -> [MonitorAccount] {
         var accounts: [MonitorAccount] = []
-        accounts.append(contentsOf: discoverCodexFiles())
+        accounts.append(contentsOf: discoverCodexFiles(aliases: codexAliases))
         accounts.append(contentsOf: discoverClaudeFile())
         if ClaudeDesktopCredentialReader.hasCredentialMaterial() {
             accounts.append(.make(
@@ -341,7 +405,7 @@ actor MonitorAccountDiscovery {
         return accounts
     }
 
-    private func discoverCodexFiles() -> [MonitorAccount] {
+    private func discoverCodexFiles(aliases: [String: String]) -> [MonitorAccount] {
         var paths: [String] = []
         if let home = ProcessInfo.processInfo.environment["CODEX_HOME"], !home.isEmpty {
             paths.append((home as NSString).appendingPathComponent("auth.json"))
@@ -355,7 +419,8 @@ actor MonitorAccountDiscovery {
             let accountID = (tokens["account_id"] as? String)
                 ?? MonitorIdentity.jwtNestedString(tokens["id_token"] as? String, namespace: "https://api.openai.com/auth", claim: "chatgpt_account_id")
             let key = email ?? accountID ?? "Codex"
-            return MonitorAccount.make(provider: .codex, accountKey: key, source: .nativeCredential, credentialReference: path)
+            let account = MonitorAccount.make(provider: .codex, accountKey: key, source: .nativeCredential, credentialReference: path)
+            return Self.canonicalizeCodexAccount(account, accountID: accountID, aliases: aliases)
         }
     }
 
@@ -400,14 +465,18 @@ actor MonitorAccountDiscovery {
         return [.make(provider: .kiro, accountKey: key, source: .nativeCredential, credentialReference: path)]
     }
 
-    private func discoverNativeKeychains() -> [MonitorAccount] {
+    private func discoverNativeKeychains(codexAliases: [String: String]) -> [MonitorAccount] {
         var accounts: [MonitorAccount] = []
         if let data = KeychainHelper.readExternalCredential(service: "Codex Auth"),
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let tokens = json["tokens"] as? [String: Any],
            (tokens["access_token"] as? String)?.isEmpty == false {
-            let email = MonitorIdentity.jwtString(tokens["id_token"] as? String, claim: "email") ?? "Codex"
-            accounts.append(.make(provider: .codex, accountKey: email, source: .nativeCredential, credentialReference: "keychain:Codex Auth"))
+            let idToken = tokens["id_token"] as? String
+            let email = MonitorIdentity.jwtString(idToken, claim: "email") ?? "Codex"
+            let accountID = (tokens["account_id"] as? String)
+                ?? MonitorIdentity.jwtNestedString(idToken, namespace: "https://api.openai.com/auth", claim: "chatgpt_account_id")
+            let account = MonitorAccount.make(provider: .codex, accountKey: email, source: .nativeCredential, credentialReference: "keychain:Codex Auth")
+            accounts.append(Self.canonicalizeCodexAccount(account, accountID: accountID, aliases: codexAliases))
         }
         if let data = KeychainHelper.readExternalCredential(service: "Claude Code-credentials"),
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
@@ -315,7 +315,10 @@ actor ClaudeCodeQuotaFetcher {
 
     /// Fetch quota for all Claude accounts from auth files in ~/.cli-proxy-api/
     /// - Parameter forceRefresh: If true, bypass cache and fetch fresh data
-    func fetchAsProviderQuota(forceRefresh: Bool = false) async -> [String: ProviderQuotaData] {
+    func fetchAsProviderQuota(
+        forceRefresh: Bool = false,
+        includeMonitorCredentials: Bool = false
+    ) async -> [String: ProviderQuotaData] {
         let expandedPath = NSString(string: authDir).expandingTildeInPath
         let fileManager = FileManager.default
         let legacyFiles = (try? fileManager.contentsOfDirectory(atPath: expandedPath))?
@@ -325,7 +328,9 @@ actor ClaudeCodeQuotaFetcher {
         let nativeBase = (claudeHome?.isEmpty == false ? claudeHome! : NSString(string: "~/.claude").expandingTildeInPath)
         let nativePath = (nativeBase as NSString).appendingPathComponent(".credentials.json")
         let nativePaths = fileManager.fileExists(atPath: nativePath) ? [nativePath] : []
-        var results = await fetchOwnedQuotas(forceRefresh: forceRefresh)
+        var results = includeMonitorCredentials
+            ? await fetchOwnedQuotas(forceRefresh: forceRefresh)
+            : [:]
         for (key, quota) in await fetchNativeKeychainQuotas(forceRefresh: forceRefresh) where results[key] == nil {
             results[key] = quota
         }

--- a/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
@@ -61,7 +61,7 @@ actor ClaudeCodeQuotaFetcher {
     private let usageURL = "https://api.anthropic.com/api/oauth/usage"
 
     /// Anthropic OAuth token refresh endpoint
-    private let tokenURL = "https://console.anthropic.com/v1/oauth/token"
+    private let tokenURL = "https://platform.claude.com/v1/oauth/token"
     private let clientId = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 
     /// URLSession for network requests
@@ -159,15 +159,15 @@ actor ClaudeCodeQuotaFetcher {
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        let params = [
+        let params: [String: Any] = [
             "grant_type": "refresh_token",
             "refresh_token": refreshToken,
-            "client_id": clientId
+            "client_id": clientId,
+            "scope": "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload",
         ]
-        let body = params.map { "\($0.key)=\($0.value)" }.joined(separator: "&")
-        request.httpBody = body.data(using: .utf8)
+        request.httpBody = try JSONSerialization.data(withJSONObject: params)
 
         let (data, response) = try await session.data(for: request)
 
@@ -190,25 +190,55 @@ actor ClaudeCodeQuotaFetcher {
     }
 
     /// Update the auth file on disk with refreshed token data
-    private func updateAuthFile(at path: String, json: [String: Any], accessToken: String, refreshToken: String?, expiresIn: Int?) {
-        var updatedJSON = json
-        updatedJSON["access_token"] = accessToken
-        if let refreshToken = refreshToken {
-            updatedJSON["refresh_token"] = refreshToken
+    private func updateAuthFile(
+        at path: String,
+        expectedRefreshToken: String?,
+        accessToken: String,
+        refreshToken: String?,
+        expiresIn: Int?
+    ) {
+        guard let latestData = FileManager.default.contents(atPath: path),
+              let latestJSON = try? JSONSerialization.jsonObject(with: latestData) as? [String: Any] else { return }
+        let latestOAuth = latestJSON["claudeAiOauth"] as? [String: Any]
+        let latestRefresh = latestJSON["refresh_token"] as? String ?? latestOAuth?["refreshToken"] as? String
+        guard latestRefresh == expectedRefreshToken else { return }
+        let updatedJSON = updatedAuthJSON(
+            latestJSON,
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            expiresIn: expiresIn
+        )
+        if let data = try? JSONSerialization.data(withJSONObject: updatedJSON, options: [.prettyPrinted, .sortedKeys]) {
+            try? SecureAtomicFileWriter.write(data, to: URL(fileURLWithPath: path))
         }
+    }
 
+    private func updatedAuthJSON(
+        _ json: [String: Any],
+        accessToken: String,
+        refreshToken: String?,
+        expiresIn: Int?
+    ) -> [String: Any] {
+        var updatedJSON = json
         let now = Date()
         let formatter = ISO8601DateFormatter()
-        updatedJSON["last_refresh"] = formatter.string(from: now)
-
-        if let expiresIn = expiresIn {
-            let expiryDate = now.addingTimeInterval(TimeInterval(expiresIn))
-            updatedJSON["expired"] = formatter.string(from: expiryDate)
+        if var oauth = updatedJSON["claudeAiOauth"] as? [String: Any] {
+            oauth["accessToken"] = accessToken
+            if let refreshToken { oauth["refreshToken"] = refreshToken }
+            if let expiresIn {
+                oauth["expiresAt"] = Int(now.addingTimeInterval(TimeInterval(expiresIn)).timeIntervalSince1970 * 1000)
+            }
+            updatedJSON["claudeAiOauth"] = oauth
+        } else {
+            updatedJSON["access_token"] = accessToken
+            if let refreshToken { updatedJSON["refresh_token"] = refreshToken }
+            updatedJSON["last_refresh"] = formatter.string(from: now)
+            if let expiresIn {
+                updatedJSON["expired"] = formatter.string(from: now.addingTimeInterval(TimeInterval(expiresIn)))
+            }
         }
 
-        if let data = try? JSONSerialization.data(withJSONObject: updatedJSON, options: [.prettyPrinted, .sortedKeys]) {
-            try? data.write(to: URL(fileURLWithPath: path))
-        }
+        return updatedJSON
     }
 
     /// Fetch usage data from Anthropic OAuth API
@@ -223,6 +253,8 @@ actor ClaudeCodeQuotaFetcher {
         request.addValue("application/json", forHTTPHeaderField: "Accept")
         request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.addValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        request.addValue("claude-code/2.1.69", forHTTPHeaderField: "User-Agent")
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
         do {
             let (data, response) = try await session.data(for: request)
@@ -230,7 +262,7 @@ actor ClaudeCodeQuotaFetcher {
             // Check HTTP status code
             if let httpResponse = response as? HTTPURLResponse {
                 // 401 Unauthorized indicates authentication error
-                if httpResponse.statusCode == 401 {
+                if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
                     return .authenticationError
                 }
                 // Other non-2xx status codes
@@ -286,39 +318,188 @@ actor ClaudeCodeQuotaFetcher {
     func fetchAsProviderQuota(forceRefresh: Bool = false) async -> [String: ProviderQuotaData] {
         let expandedPath = NSString(string: authDir).expandingTildeInPath
         let fileManager = FileManager.default
-        
-        guard let files = try? fileManager.contentsOfDirectory(atPath: expandedPath) else {
-            return [:]
+        let legacyFiles = (try? fileManager.contentsOfDirectory(atPath: expandedPath))?
+            .filter { $0.hasPrefix("claude-") && $0.hasSuffix(".json") }
+            .map { (expandedPath as NSString).appendingPathComponent($0) } ?? []
+        let claudeHome = ProcessInfo.processInfo.environment["CLAUDE_CONFIG_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let nativeBase = (claudeHome?.isEmpty == false ? claudeHome! : NSString(string: "~/.claude").expandingTildeInPath)
+        let nativePath = (nativeBase as NSString).appendingPathComponent(".credentials.json")
+        let nativePaths = fileManager.fileExists(atPath: nativePath) ? [nativePath] : []
+        var results = await fetchOwnedQuotas(forceRefresh: forceRefresh)
+        for (key, quota) in await fetchNativeKeychainQuotas(forceRefresh: forceRefresh) where results[key] == nil {
+            results[key] = quota
         }
-        
-        // Filter for claude auth files
-        let claudeFiles = files.filter { $0.hasPrefix("claude-") && $0.hasSuffix(".json") }
-        
-        guard !claudeFiles.isEmpty else { return [:] }
-        
-        var results: [String: ProviderQuotaData] = [:]
-        
-        // Process Claude auth files concurrently
-        await withTaskGroup(of: (String, ProviderQuotaData?).self) { group in
-            for file in claudeFiles {
-                let filePath = (expandedPath as NSString).appendingPathComponent(file)
-                
-                group.addTask {
-                    guard let quota = await self.fetchQuotaFromAuthFile(at: filePath, forceRefresh: forceRefresh) else {
-                        return ("", nil)
-                    }
-                    return (quota.email, quota.data)
-                }
-            }
-            
-            for await (email, data) in group {
-                if !email.isEmpty, let data = data {
-                    results[email] = data
-                }
-            }
+        for filePath in nativePaths {
+            guard let quota = await fetchQuotaFromAuthFile(at: filePath, forceRefresh: forceRefresh),
+                  results[quota.email] == nil else { continue }
+            results[quota.email] = quota.data
+        }
+
+        if let desktop = await fetchClaudeDesktopQuota(forceRefresh: forceRefresh),
+           results[desktop.key] == nil {
+            results[desktop.key] = desktop.value
+        }
+
+        for filePath in legacyFiles {
+            guard let quota = await fetchQuotaFromAuthFile(at: filePath, forceRefresh: forceRefresh),
+                  results[quota.email] == nil else { continue }
+            results[quota.email] = quota.data
         }
         
         return results
+    }
+
+    private func fetchClaudeDesktopQuota(forceRefresh: Bool) async -> (key: String, value: ProviderQuotaData)? {
+        let key = "Claude Desktop"
+        if !forceRefresh, let cached = quotaCache[key], cached.isValid(ttl: cacheTTL) {
+            return (key, cached.data)
+        }
+        guard let credential = ClaudeDesktopCredentialReader.load() else { return nil }
+        let response = await fetchUsageFromAPI(accessToken: credential.accessToken, email: key)
+        guard case .success(let info) = response, let quota = quotaData(from: info) else { return nil }
+        quotaCache[key] = CachedQuota(data: quota, timestamp: Date())
+        return (key, quota)
+    }
+
+    private func fetchNativeKeychainQuotas(forceRefresh: Bool) async -> [String: ProviderQuotaData] {
+        guard let record = KeychainHelper.readExternalCredentialRecord(service: "Claude Code-credentials"),
+              let json = try? JSONSerialization.jsonObject(with: record.data) as? [String: Any],
+              let oauth = json["claudeAiOauth"] as? [String: Any],
+              var accessToken = oauth["accessToken"] as? String else { return [:] }
+        let email = oauth["email"] as? String ?? "Claude Code"
+        if !forceRefresh, let cached = quotaCache[email], cached.isValid(ttl: cacheTTL) {
+            return [email: cached.data]
+        }
+        let refreshToken = oauth["refreshToken"] as? String
+        do {
+            if isTokenExpired(json: normalizedExpiryJSON(json)), let refreshToken {
+                let refreshed = try await refreshAccessToken(refreshToken: refreshToken)
+                accessToken = refreshed.accessToken
+                persistClaudeKeychainRefresh(
+                    record: record,
+                    json: json,
+                    accessToken: refreshed.accessToken,
+                    expectedRefreshToken: refreshToken,
+                    newRefreshToken: refreshed.refreshToken ?? refreshToken,
+                    expiresIn: refreshed.expiresIn
+                )
+            }
+            var response = await fetchUsageFromAPI(accessToken: accessToken, email: email)
+            if case .authenticationError = response,
+               let latest = KeychainHelper.readExternalCredentialRecord(service: "Claude Code-credentials", account: record.account),
+               let latestJSON = try? JSONSerialization.jsonObject(with: latest.data) as? [String: Any],
+               let latestOAuth = latestJSON["claudeAiOauth"] as? [String: Any],
+               let latestRefreshToken = latestOAuth["refreshToken"] as? String {
+                let refreshed = try await refreshAccessToken(refreshToken: latestRefreshToken)
+                accessToken = refreshed.accessToken
+                persistClaudeKeychainRefresh(
+                    record: latest,
+                    json: latestJSON,
+                    accessToken: refreshed.accessToken,
+                    expectedRefreshToken: latestRefreshToken,
+                    newRefreshToken: refreshed.refreshToken ?? latestRefreshToken,
+                    expiresIn: refreshed.expiresIn
+                )
+                response = await fetchUsageFromAPI(accessToken: accessToken, email: email)
+            }
+            guard case .success(let info) = response, let quota = quotaData(from: info) else { return [:] }
+            quotaCache[email] = CachedQuota(data: quota, timestamp: Date())
+            return [email: quota]
+        } catch {
+            return quotaCache[email].map { [email: $0.data] } ?? [:]
+        }
+    }
+
+    private func persistClaudeKeychainRefresh(
+        record: (data: Data, account: String),
+        json: [String: Any],
+        accessToken: String,
+        expectedRefreshToken: String,
+        newRefreshToken: String,
+        expiresIn: Int?
+    ) {
+        guard let oauth = json["claudeAiOauth"] as? [String: Any],
+              oauth["refreshToken"] as? String == expectedRefreshToken else { return }
+        let updated = updatedAuthJSON(
+            json,
+            accessToken: accessToken,
+            refreshToken: newRefreshToken,
+            expiresIn: expiresIn
+        )
+        guard let data = try? JSONSerialization.data(withJSONObject: updated, options: [.prettyPrinted, .sortedKeys]) else { return }
+        _ = KeychainHelper.compareAndSwapExternalCredential(
+            service: "Claude Code-credentials",
+            account: record.account,
+            expectedData: record.data,
+            newData: data
+        )
+    }
+
+    private func fetchOwnedQuotas(forceRefresh: Bool) async -> [String: ProviderQuotaData] {
+        var results: [String: ProviderQuotaData] = [:]
+        for account in await MonitorCredentialVault.shared.accounts().filter({ $0.provider == .claude && !$0.isDisabled }) {
+            guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { continue }
+            if !forceRefresh, let cached = quotaCache[account.accountKey], cached.isValid(ttl: cacheTTL) {
+                results[account.accountKey] = cached.data
+                continue
+            }
+            do {
+                if credential.expiresAt.map({ $0.timeIntervalSinceNow < 300 }) ?? false,
+                   let refreshToken = credential.refreshToken {
+                    let refreshed = try await refreshAccessToken(refreshToken: refreshToken)
+                    credential.accessToken = refreshed.accessToken
+                    credential.refreshToken = refreshed.refreshToken ?? refreshToken
+                    credential.expiresAt = refreshed.expiresIn.map { Date().addingTimeInterval(TimeInterval($0)) }
+                    try await MonitorCredentialVault.shared.save(credential, metadata: account)
+                }
+                var response = await fetchUsageFromAPI(accessToken: credential.accessToken, email: account.accountKey)
+                if case .authenticationError = response {
+                    if let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id) {
+                        credential = latest
+                    }
+                    guard let refreshToken = credential.refreshToken else { continue }
+                    let refreshed = try await refreshAccessToken(refreshToken: refreshToken)
+                    credential.accessToken = refreshed.accessToken
+                    credential.refreshToken = refreshed.refreshToken ?? refreshToken
+                    credential.expiresAt = refreshed.expiresIn.map { Date().addingTimeInterval(TimeInterval($0)) }
+                    try await MonitorCredentialVault.shared.save(credential, metadata: account)
+                    response = await fetchUsageFromAPI(accessToken: credential.accessToken, email: account.accountKey)
+                }
+                if case .success(let info) = response, let data = quotaData(from: info) {
+                    quotaCache[account.accountKey] = CachedQuota(data: data, timestamp: Date())
+                    results[account.accountKey] = data
+                }
+            } catch {
+                if let cached = quotaCache[account.accountKey] { results[account.accountKey] = cached.data }
+            }
+        }
+        return results
+    }
+
+    private func quotaData(from info: ClaudeCodeQuotaInfo) -> ProviderQuotaData? {
+        var models: [ModelQuota] = []
+        if let value = info.fiveHour {
+            models.append(ModelQuota(name: "five-hour-session", percentage: value.remaining, resetTime: value.resetsAt))
+        }
+        if let value = info.sevenDay {
+            models.append(ModelQuota(name: "seven-day-weekly", percentage: value.remaining, resetTime: value.resetsAt))
+        }
+        if let value = info.sevenDaySonnet {
+            models.append(ModelQuota(name: "seven-day-sonnet", percentage: value.remaining, resetTime: value.resetsAt))
+        }
+        if let value = info.sevenDayOpus {
+            models.append(ModelQuota(name: "seven-day-opus", percentage: value.remaining, resetTime: value.resetsAt))
+        }
+        if let extra = info.extraUsage, let remaining = extra.remaining {
+            var model = ModelQuota(name: "extra-usage", percentage: remaining, resetTime: "")
+            if let used = extra.usedCredits, let limit = extra.monthlyLimit {
+                model.used = Int(used)
+                model.limit = Int(limit)
+            }
+            models.append(model)
+        }
+        guard !models.isEmpty else { return nil }
+        return ProviderQuotaData(models: models, lastUpdated: Date(), isForbidden: false, planType: nil)
     }
     
     /// Fetch quota from a single auth file
@@ -333,10 +514,11 @@ actor ClaudeCodeQuotaFetcher {
             return nil
         }
 
-        guard var accessToken = json["access_token"] as? String,
-              let email = json["email"] as? String else {
+        let nestedOAuth = json["claudeAiOauth"] as? [String: Any]
+        guard var accessToken = (json["access_token"] as? String) ?? (nestedOAuth?["accessToken"] as? String) else {
             return nil
         }
+        let email = (json["email"] as? String) ?? (nestedOAuth?["email"] as? String) ?? "Claude Code"
 
         // Check cache first (unless force refresh)
         if !forceRefresh, let cached = quotaCache[email], cached.isValid(ttl: cacheTTL) {
@@ -344,11 +526,12 @@ actor ClaudeCodeQuotaFetcher {
         }
 
         // Refresh expired token before fetching usage
-        if isTokenExpired(json: json), let refreshToken = json["refresh_token"] as? String {
+        let refreshToken = (json["refresh_token"] as? String) ?? (nestedOAuth?["refreshToken"] as? String)
+        if isTokenExpired(json: normalizedExpiryJSON(json)), let refreshToken {
             do {
                 let refreshed = try await refreshAccessToken(refreshToken: refreshToken)
                 accessToken = refreshed.accessToken
-                updateAuthFile(at: path, json: json, accessToken: refreshed.accessToken, refreshToken: refreshed.refreshToken, expiresIn: refreshed.expiresIn)
+                updateAuthFile(at: path, expectedRefreshToken: refreshToken, accessToken: refreshed.accessToken, refreshToken: refreshed.refreshToken ?? refreshToken, expiresIn: refreshed.expiresIn)
                 NSLog("[ClaudeQuota] Token refreshed for \(email)")
             } catch {
                 NSLog("[ClaudeQuota] Token refresh failed for \(email): \(error.localizedDescription)")
@@ -357,67 +540,29 @@ actor ClaudeCodeQuotaFetcher {
         }
 
         // Fetch usage from API using the token
-        let result = await fetchUsageFromAPI(accessToken: accessToken, email: email)
+        var result = await fetchUsageFromAPI(accessToken: accessToken, email: email)
+        if case .authenticationError = result {
+            do {
+                guard let latestData = fileManager.contents(atPath: path),
+                      let latestJSON = try? JSONSerialization.jsonObject(with: latestData) as? [String: Any] else {
+                    return (email, ProviderQuotaData(models: [], lastUpdated: Date(), isForbidden: true))
+                }
+                let latestOAuth = latestJSON["claudeAiOauth"] as? [String: Any]
+                guard let latestRefreshToken = (latestJSON["refresh_token"] as? String) ?? (latestOAuth?["refreshToken"] as? String) else {
+                    return (email, ProviderQuotaData(models: [], lastUpdated: Date(), isForbidden: true))
+                }
+                let refreshed = try await refreshAccessToken(refreshToken: latestRefreshToken)
+                accessToken = refreshed.accessToken
+                updateAuthFile(at: path, expectedRefreshToken: latestRefreshToken, accessToken: refreshed.accessToken, refreshToken: refreshed.refreshToken ?? latestRefreshToken, expiresIn: refreshed.expiresIn)
+                result = await fetchUsageFromAPI(accessToken: accessToken, email: email)
+            } catch {
+                // The authentication result below is kept so the UI can ask for a new login.
+            }
+        }
 
         switch result {
         case .success(let info):
-            // Convert to ProviderQuotaData
-            var models: [ModelQuota] = []
-
-            if let fiveHour = info.fiveHour {
-                models.append(ModelQuota(
-                    name: "five-hour-session",
-                    percentage: fiveHour.remaining,
-                    resetTime: fiveHour.resetsAt
-                ))
-            }
-
-            if let sevenDay = info.sevenDay {
-                models.append(ModelQuota(
-                    name: "seven-day-weekly",
-                    percentage: sevenDay.remaining,
-                    resetTime: sevenDay.resetsAt
-                ))
-            }
-
-            if let sonnet = info.sevenDaySonnet {
-                models.append(ModelQuota(
-                    name: "seven-day-sonnet",
-                    percentage: sonnet.remaining,
-                    resetTime: sonnet.resetsAt
-                ))
-            }
-
-            if let opus = info.sevenDayOpus {
-                models.append(ModelQuota(
-                    name: "seven-day-opus",
-                    percentage: opus.remaining,
-                    resetTime: opus.resetsAt
-                ))
-            }
-
-            if let extra = info.extraUsage, let remaining = extra.remaining {
-                var extraModel = ModelQuota(
-                    name: "extra-usage",
-                    percentage: remaining,
-                    resetTime: ""
-                )
-                // Add usage details if available
-                if let used = extra.usedCredits, let limit = extra.monthlyLimit {
-                    extraModel.used = Int(used)
-                    extraModel.limit = Int(limit)
-                }
-                models.append(extraModel)
-            }
-
-            guard !models.isEmpty else { return nil }
-
-            let quotaData = ProviderQuotaData(
-                models: models,
-                lastUpdated: Date(),
-                isForbidden: false,
-                planType: nil
-            )
+            guard let quotaData = quotaData(from: info) else { return nil }
 
             // Update cache
             quotaCache[email] = CachedQuota(data: quotaData, timestamp: Date())
@@ -452,5 +597,16 @@ actor ClaudeCodeQuotaFetcher {
     /// Clear cache for a specific email
     func clearCache(for email: String) {
         quotaCache.removeValue(forKey: email)
+    }
+
+    private func normalizedExpiryJSON(_ json: [String: Any]) -> [String: Any] {
+        guard let oauth = json["claudeAiOauth"] as? [String: Any] else { return json }
+        var normalized = json
+        if let expiresAt = oauth["expiresAt"] as? Double {
+            normalized["expired"] = Date(timeIntervalSince1970: expiresAt / 1000).ISO8601Format()
+        } else if let expiresAt = oauth["expiresAt"] as? NSNumber {
+            normalized["expired"] = Date(timeIntervalSince1970: expiresAt.doubleValue / 1000).ISO8601Format()
+        }
+        return normalized
     }
 }

--- a/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
@@ -372,10 +372,7 @@ actor CodexCLIQuotaFetcher {
             guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
                   let auth = try? JSONDecoder().decode(CodexAuthFile.self, from: data) else { continue }
             let claims = auth.idToken.flatMap(decodeJWT)
-            let key = nonEmpty(auth.email)
-                ?? nonEmpty(claims?.email)
-                ?? nonEmpty(auth.accountId)
-                ?? filename.codexFilenameKey
+            let key = filename.codexFilenameKey
             let accountID = auth.accountId ?? claims?.accountId
             let identity = CodexQuotaIdentity(planType: claims?.planType)
             var accessToken = auth.accessToken
@@ -410,12 +407,6 @@ actor CodexCLIQuotaFetcher {
             }
         }
         return results
-    }
-
-    private func nonEmpty(_ value: String?) -> String? {
-        guard let value else { return nil }
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
     }
 
     private func fetchNativeKeychainQuotas() async -> [String: ProviderQuotaData] {

--- a/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
@@ -46,6 +46,12 @@ nonisolated struct CodexJWTClaims: Sendable {
     let subscriptionActiveUntil: Date?
 }
 
+nonisolated struct CodexQuotaAccountIdentity: Sendable {
+    let key: String
+    let email: String?
+    let accountID: String?
+}
+
 /// Fetches quota from Codex CLI auth file
 actor CodexCLIQuotaFetcher {
     private let usageURL = "https://chatgpt.com/backend-api/wham/usage"
@@ -360,6 +366,101 @@ actor CodexCLIQuotaFetcher {
             results[key] = quota
         }
         return results
+    }
+
+    func reconcileLegacyAliases(
+        in quotas: [String: ProviderQuotaData]
+    ) async -> [String: ProviderQuotaData] {
+        var current = readAuthSources().map { source in
+            let claims = source.auth.tokens?.idToken.flatMap(decodeJWT)
+            return CodexQuotaAccountIdentity(
+                key: claims?.email ?? source.auth.tokens?.accountId ?? "Codex User",
+                email: claims?.email,
+                accountID: source.auth.tokens?.accountId ?? claims?.accountId
+            )
+        }
+
+        if let record = KeychainHelper.readExternalCredentialRecord(service: "Codex Auth"),
+           let auth = try? JSONDecoder().decode(CodexCLIAuthFile.self, from: record.data),
+           let tokens = auth.tokens {
+            let claims = tokens.idToken.flatMap(decodeJWT)
+            current.append(CodexQuotaAccountIdentity(
+                key: claims?.email ?? tokens.accountId ?? "Codex",
+                email: claims?.email,
+                accountID: tokens.accountId ?? claims?.accountId
+            ))
+        }
+
+        for account in await MonitorCredentialVault.shared.accounts().filter({ $0.provider == .codex }) {
+            guard let credential = await MonitorCredentialVault.shared.credential(for: account.id) else { continue }
+            let claims = credential.idToken.flatMap(decodeJWT)
+            current.append(CodexQuotaAccountIdentity(
+                key: account.accountKey,
+                email: claims?.email,
+                accountID: credential.accountID ?? claims?.accountId
+            ))
+        }
+
+        return Self.reconcileLegacyAliases(
+            in: quotas,
+            legacy: readLegacyIdentities(),
+            current: current
+        )
+    }
+
+    nonisolated static func reconcileLegacyAliases(
+        in quotas: [String: ProviderQuotaData],
+        legacy: [CodexQuotaAccountIdentity],
+        current: [CodexQuotaAccountIdentity]
+    ) -> [String: ProviderQuotaData] {
+        var reconciled = quotas
+        let legacyByEmail = Dictionary(grouping: legacy.compactMap { identity -> (String, CodexQuotaAccountIdentity)? in
+            guard let email = identity.email?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+                  !email.isEmpty else { return nil }
+            return (email, identity)
+        }, by: \.0)
+
+        for (email, entries) in legacyByEmail {
+            let legacyAccounts = entries.map(\.1)
+            guard legacyAccounts.contains(where: { reconciled[$0.key] != nil }) else { continue }
+
+            let legacyAccountIDs = Set(legacyAccounts.compactMap { identity -> String? in
+                guard let accountID = identity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !accountID.isEmpty else { return nil }
+                return accountID
+            })
+            let matchingCurrent = current.filter {
+                $0.email?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == email
+            }
+            let hasDistinctCurrentAccount = matchingCurrent.contains { identity in
+                guard let accountID = identity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !accountID.isEmpty, !legacyAccountIDs.isEmpty else { return true }
+                return !legacyAccountIDs.contains(accountID)
+            }
+            guard !hasDistinctCurrentAccount else { continue }
+
+            for key in reconciled.keys where key.lowercased() == email {
+                reconciled.removeValue(forKey: key)
+            }
+        }
+        return reconciled
+    }
+
+    private func readLegacyIdentities() -> [CodexQuotaAccountIdentity] {
+        let directory = NSString(string: "~/.cli-proxy-api").expandingTildeInPath
+        guard let files = try? FileManager.default.contentsOfDirectory(atPath: directory) else { return [] }
+        return files.compactMap { filename in
+            guard filename.hasPrefix("codex-"), filename.hasSuffix(".json") else { return nil }
+            let path = (directory as NSString).appendingPathComponent(filename)
+            guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+                  let auth = try? JSONDecoder().decode(CodexAuthFile.self, from: data) else { return nil }
+            let claims = auth.idToken.flatMap(decodeJWT)
+            return CodexQuotaAccountIdentity(
+                key: filename.codexFilenameKey,
+                email: claims?.email,
+                accountID: auth.accountId ?? claims?.accountId
+            )
+        }
     }
 
     private func fetchLegacyQuotas() async -> [String: ProviderQuotaData] {

--- a/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
@@ -10,9 +10,9 @@ import Foundation
 
 /// Auth file structure for Codex CLI (~/.codex/auth.json)
 nonisolated struct CodexCLIAuthFile: Codable, Sendable {
-    let OPENAI_API_KEY: String?
-    let tokens: CodexCLITokens?
-    let lastRefresh: String?
+    var OPENAI_API_KEY: String?
+    var tokens: CodexCLITokens?
+    var lastRefresh: String?
     
     enum CodingKeys: String, CodingKey {
         case OPENAI_API_KEY
@@ -22,10 +22,10 @@ nonisolated struct CodexCLIAuthFile: Codable, Sendable {
 }
 
 nonisolated struct CodexCLITokens: Codable, Sendable {
-    let idToken: String?
-    let accessToken: String?
-    let refreshToken: String?
-    let accountId: String?
+    var idToken: String?
+    var accessToken: String?
+    var refreshToken: String?
+    var accountId: String?
     
     enum CodingKeys: String, CodingKey {
         case idToken = "id_token"
@@ -48,9 +48,9 @@ nonisolated struct CodexJWTClaims: Sendable {
 
 /// Fetches quota from Codex CLI auth file
 actor CodexCLIQuotaFetcher {
-    private let authFilePath = "~/.codex/auth.json"
     private let usageURL = "https://chatgpt.com/backend-api/wham/usage"
     private let refreshURL = "https://auth.openai.com/oauth/token"
+    private let clientID = "app_EMoamEEZ73f0CkXaXp7hrann"
     
     private var session: URLSession
     
@@ -75,21 +75,40 @@ actor CodexCLIQuotaFetcher {
         self.session = URLSession(configuration: config)
     }
     
-    /// Check if Codex auth file exists
+    private var authFilePaths: [String] {
+        var paths: [String] = []
+        if let home = ProcessInfo.processInfo.environment["CODEX_HOME"], !home.isEmpty {
+            paths.append((home as NSString).appendingPathComponent("auth.json"))
+        }
+        paths.append(NSString(string: "~/.config/codex/auth.json").expandingTildeInPath)
+        paths.append(NSString(string: "~/.codex/auth.json").expandingTildeInPath)
+        var seen = Set<String>()
+        return paths.filter { seen.insert($0).inserted }
+    }
+
+    /// Check if any supported Codex auth source exists.
     func isAuthFilePresent() -> Bool {
-        let expandedPath = NSString(string: authFilePath).expandingTildeInPath
-        return FileManager.default.fileExists(atPath: expandedPath)
+        authFilePaths.contains { FileManager.default.fileExists(atPath: $0) }
     }
     
     /// Read auth file from ~/.codex/auth.json
     func readAuthFile() -> CodexCLIAuthFile? {
-        let expandedPath = NSString(string: authFilePath).expandingTildeInPath
-        
-        guard let data = try? Data(contentsOf: URL(fileURLWithPath: expandedPath)) else {
-            return nil
+        for path in authFilePaths {
+            guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+                  let auth = try? JSONDecoder().decode(CodexCLIAuthFile.self, from: data),
+                  auth.tokens?.accessToken?.isEmpty == false else { continue }
+            return auth
         }
-        
-        return try? JSONDecoder().decode(CodexCLIAuthFile.self, from: data)
+        return nil
+    }
+
+    private func readAuthSources() -> [(path: String, auth: CodexCLIAuthFile)] {
+        authFilePaths.compactMap { path in
+            guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+                  let auth = try? JSONDecoder().decode(CodexCLIAuthFile.self, from: data),
+                  auth.tokens?.accessToken?.isEmpty == false else { return nil }
+            return (path, auth)
+        }
     }
     
     /// Decode JWT to extract email and plan info
@@ -216,18 +235,23 @@ actor CodexCLIQuotaFetcher {
     }
     
     /// Refresh access token using refresh token
-    func refreshAccessToken(refreshToken: String) async throws -> String {
+    nonisolated struct TokenRefresh: Sendable {
+        let accessToken: String
+        let refreshToken: String?
+        let idToken: String?
+        let expiresIn: Int?
+    }
+
+    func refreshAccessToken(refreshToken: String) async throws -> TokenRefresh {
         var request = URLRequest(url: URL(string: refreshURL)!)
         request.httpMethod = "POST"
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        
-        let body: [String: Any] = [
-            "grant_type": "refresh_token",
-            "refresh_token": refreshToken,
-            "client_id": "app_EMoamEEZ73f0CkXaXp7hrann"  // Codex CLI client ID
-        ]
-        
-        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        let body = [
+            "grant_type=refresh_token",
+            "client_id=\(clientID.urlFormEncoded)",
+            "refresh_token=\(refreshToken.urlFormEncoded)",
+        ].joined(separator: "&")
+        request.httpBody = Data(body.utf8)
         
         let (data, response) = try await session.data(for: request)
         
@@ -236,12 +260,20 @@ actor CodexCLIQuotaFetcher {
             throw CodexCLIQuotaError.tokenRefreshFailed
         }
         
-        struct RefreshResponse: Codable {
+        struct RefreshResponse: Decodable {
             let access_token: String
+            let refresh_token: String?
+            let id_token: String?
+            let expires_in: Int?
         }
         
         let tokenResponse = try JSONDecoder().decode(RefreshResponse.self, from: data)
-        return tokenResponse.access_token
+        return TokenRefresh(
+            accessToken: tokenResponse.access_token,
+            refreshToken: tokenResponse.refresh_token,
+            idToken: tokenResponse.id_token,
+            expiresIn: tokenResponse.expires_in
+        )
     }
     
     /// Check if access token is expired by decoding JWT
@@ -261,59 +293,296 @@ actor CodexCLIQuotaFetcher {
             return true
         }
         
-        // Token is expired if exp is in the past (with 60s buffer)
-        return Date(timeIntervalSince1970: exp) < Date().addingTimeInterval(60)
+        // Refresh five minutes early so scheduled quota checks do not race token expiry.
+        return Date(timeIntervalSince1970: exp) < Date().addingTimeInterval(300)
     }
     
     /// Fetch quota and convert to ProviderQuotaData for unified display
     func fetchAsProviderQuota() async -> [String: ProviderQuotaData] {
-        guard let authFile = readAuthFile(),
-              let tokens = authFile.tokens,
-              let accessToken = tokens.accessToken else {
-            return [:]
+        var results = await fetchOwnedQuotas()
+        for (key, quota) in await fetchNativeKeychainQuotas() where results[key] == nil {
+            results[key] = quota
         }
-        
-        // Get email and plan from id_token
-        var email = "Codex User"
-        var planType: String? = nil
-        var accountId: String? = tokens.accountId
-        
-        if let idToken = tokens.idToken, let claims = decodeJWT(token: idToken) {
-            email = claims.email ?? email
-            planType = claims.planType
-            if accountId == nil {
-                accountId = claims.accountId
+        for source in readAuthSources() {
+            guard let tokens = source.auth.tokens, let originalAccessToken = tokens.accessToken else { continue }
+            var email = "Codex User"
+            var planType: String?
+            var accountId = tokens.accountId
+            if let idToken = tokens.idToken, let claims = decodeJWT(token: idToken) {
+                email = claims.email ?? email
+                planType = claims.planType
+                accountId = accountId ?? claims.accountId
             }
-        }
-        
-        // Check if token is expired and try to refresh
-        var currentAccessToken = accessToken
-        if isTokenExpired(accessToken: accessToken), let refreshToken = tokens.refreshToken {
+
+            var accessToken = originalAccessToken
+            var refreshToken = tokens.refreshToken
+            if isTokenExpired(accessToken: accessToken), let currentRefresh = refreshToken {
+                do {
+                    let refreshed = try await refreshAccessToken(refreshToken: currentRefresh)
+                    accessToken = refreshed.accessToken
+                    refreshToken = refreshed.refreshToken ?? currentRefresh
+                    try persistRefresh(refreshed, originalRefreshToken: currentRefresh, path: source.path)
+                } catch {
+                    Log.quota("Failed to refresh Codex token")
+                }
+            }
+
             do {
-                currentAccessToken = try await refreshAccessToken(refreshToken: refreshToken)
+                let quota: ProviderQuotaData
+                do {
+                    quota = try await fetchQuota(
+                        accessToken: accessToken,
+                        accountId: accountId,
+                        identity: CodexQuotaIdentity(planType: planType)
+                    )
+                } catch CodexCLIQuotaError.httpError(let status) where status == 401 || status == 403 {
+                    let latestTokens = readAuthFile(at: source.path)?.tokens
+                    let currentRefresh = latestTokens?.refreshToken ?? refreshToken
+                    guard let currentRefresh else { throw CodexCLIQuotaError.tokenRefreshFailed }
+                    let latestClaims = latestTokens?.idToken.flatMap(decodeJWT)
+                    let refreshed = try await refreshAccessToken(refreshToken: currentRefresh)
+                    try persistRefresh(refreshed, originalRefreshToken: currentRefresh, path: source.path)
+                    quota = try await fetchQuota(
+                        accessToken: refreshed.accessToken,
+                        accountId: latestTokens?.accountId ?? latestClaims?.accountId ?? accountId,
+                        identity: CodexQuotaIdentity(planType: latestClaims?.planType ?? planType)
+                    )
+                }
+#if DEBUG
+                Log.quota("finalPlan=\(quota.planType ?? "<nil>") jwt=\(planType ?? "<nil>")")
+#endif
+                if results[email] == nil { results[email] = quota }
             } catch {
-                Log.quota("Failed to refresh Codex token: \(error)")
-                // Continue with potentially expired token, API will fail if truly expired
+                Log.quota("Failed to fetch Codex quota for local credential: \(error.localizedDescription)")
             }
         }
-        
-        // Fetch quota from API
+        for (key, quota) in await fetchLegacyQuotas() where results[key] == nil {
+            results[key] = quota
+        }
+        return results
+    }
+
+    private func fetchLegacyQuotas() async -> [String: ProviderQuotaData] {
+        let directory = NSString(string: "~/.cli-proxy-api").expandingTildeInPath
+        guard let files = try? FileManager.default.contentsOfDirectory(atPath: directory) else { return [:] }
+        var results: [String: ProviderQuotaData] = [:]
+
+        for filename in files where filename.hasPrefix("codex-") && filename.hasSuffix(".json") {
+            let path = (directory as NSString).appendingPathComponent(filename)
+            guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+                  let auth = try? JSONDecoder().decode(CodexAuthFile.self, from: data) else { continue }
+            let claims = auth.idToken.flatMap(decodeJWT)
+            let key = nonEmpty(auth.email)
+                ?? nonEmpty(claims?.email)
+                ?? nonEmpty(auth.accountId)
+                ?? filename.codexFilenameKey
+            let accountID = auth.accountId ?? claims?.accountId
+            let identity = CodexQuotaIdentity(planType: claims?.planType)
+            var accessToken = auth.accessToken
+            var refreshToken = auth.refreshToken
+
+            if isTokenExpired(accessToken: accessToken), let currentRefreshToken = refreshToken {
+                if let refreshed = try? await refreshAccessToken(refreshToken: currentRefreshToken) {
+                    accessToken = refreshed.accessToken
+                    self.persistLegacyRefresh(refreshed, originalRefreshToken: currentRefreshToken, path: path)
+                    refreshToken = refreshed.refreshToken ?? currentRefreshToken
+                }
+            }
+
+            do {
+                do {
+                    results[key] = try await fetchQuota(accessToken: accessToken, accountId: accountID, identity: identity)
+                } catch CodexCLIQuotaError.httpError(let status) where status == 401 || status == 403 {
+                    guard let latestData = try? Data(contentsOf: URL(fileURLWithPath: path)),
+                          let latest = try? JSONDecoder().decode(CodexAuthFile.self, from: latestData),
+                          let latestRefreshToken = latest.refreshToken ?? refreshToken else { continue }
+                    let latestClaims = latest.idToken.flatMap(decodeJWT)
+                    let refreshed = try await refreshAccessToken(refreshToken: latestRefreshToken)
+                    persistLegacyRefresh(refreshed, originalRefreshToken: latestRefreshToken, path: path)
+                    results[key] = try await fetchQuota(
+                        accessToken: refreshed.accessToken,
+                        accountId: latest.accountId ?? latestClaims?.accountId ?? accountID,
+                        identity: CodexQuotaIdentity(planType: latestClaims?.planType ?? claims?.planType)
+                    )
+                }
+            } catch {
+                Log.quota("Failed to fetch Codex quota for legacy credential: \(error.localizedDescription)")
+            }
+        }
+        return results
+    }
+
+    private func nonEmpty(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func fetchNativeKeychainQuotas() async -> [String: ProviderQuotaData] {
+        guard let record = KeychainHelper.readExternalCredentialRecord(service: "Codex Auth"),
+              var auth = try? JSONDecoder().decode(CodexCLIAuthFile.self, from: record.data),
+              var tokens = auth.tokens,
+              var accessToken = tokens.accessToken else { return [:] }
+        let claims = tokens.idToken.flatMap(decodeJWT)
+        let key = claims?.email ?? tokens.accountId ?? "Codex"
         do {
-            let providerQuota = try await fetchQuota(
-                accessToken: currentAccessToken,
-                accountId: accountId,
-                identity: CodexQuotaIdentity(planType: planType)
-            )
-#if DEBUG
-            Log.quota("finalPlan=\(providerQuota.planType ?? "<nil>") jwt=\(planType ?? "<nil>")")
-#endif
-            
-            return [email: providerQuota]
+            if isTokenExpired(accessToken: accessToken), let refresh = tokens.refreshToken {
+                let refreshed = try await refreshAccessToken(refreshToken: refresh)
+                accessToken = refreshed.accessToken
+                tokens.accessToken = refreshed.accessToken
+                tokens.refreshToken = refreshed.refreshToken ?? refresh
+                tokens.idToken = refreshed.idToken ?? tokens.idToken
+                auth.tokens = tokens
+                if let data = try? JSONEncoder().encode(auth) {
+                    _ = KeychainHelper.compareAndSwapExternalCredential(
+                        service: "Codex Auth",
+                        account: record.account,
+                        expectedData: record.data,
+                        newData: data
+                    )
+                }
+            }
+            do {
+                return [key: try await fetchQuota(
+                    accessToken: accessToken,
+                    accountId: tokens.accountId ?? claims?.accountId,
+                    identity: CodexQuotaIdentity(planType: claims?.planType)
+                )]
+            } catch CodexCLIQuotaError.httpError(let status) where status == 401 || status == 403 {
+                guard let latest = KeychainHelper.readExternalCredentialRecord(service: "Codex Auth", account: record.account),
+                      let latestAuth = try? JSONDecoder().decode(CodexCLIAuthFile.self, from: latest.data),
+                      let latestTokens = latestAuth.tokens,
+                      let refresh = latestTokens.refreshToken else { return [:] }
+                let latestClaims = latestTokens.idToken.flatMap(decodeJWT)
+                let refreshed = try await refreshAccessToken(refreshToken: refresh)
+                persistNativeKeychainRefresh(refreshed, originalRefreshToken: refresh, account: record.account)
+                return [key: try await fetchQuota(
+                    accessToken: refreshed.accessToken,
+                    accountId: latestTokens.accountId ?? latestClaims?.accountId,
+                    identity: CodexQuotaIdentity(planType: latestClaims?.planType)
+                )]
+            }
         } catch {
-            Log.quota("Failed to fetch Codex quota: \(error)")
             return [:]
         }
     }
+
+    private func persistNativeKeychainRefresh(
+        _ refreshed: TokenRefresh,
+        originalRefreshToken: String,
+        account: String
+    ) {
+        guard let latest = KeychainHelper.readExternalCredentialRecord(service: "Codex Auth", account: account),
+              var auth = try? JSONDecoder().decode(CodexCLIAuthFile.self, from: latest.data),
+              var tokens = auth.tokens,
+              tokens.refreshToken == originalRefreshToken else { return }
+        tokens.accessToken = refreshed.accessToken
+        tokens.refreshToken = refreshed.refreshToken ?? originalRefreshToken
+        tokens.idToken = refreshed.idToken ?? tokens.idToken
+        auth.tokens = tokens
+        guard let data = try? JSONEncoder().encode(auth) else { return }
+        _ = KeychainHelper.compareAndSwapExternalCredential(
+            service: "Codex Auth",
+            account: account,
+            expectedData: latest.data,
+            newData: data
+        )
+    }
+
+    private func fetchOwnedQuotas() async -> [String: ProviderQuotaData] {
+        var results: [String: ProviderQuotaData] = [:]
+        for account in await MonitorCredentialVault.shared.accounts().filter({ $0.provider == .codex && !$0.isDisabled }) {
+            guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { continue }
+            do {
+                if credential.expiresAt.map({ $0.timeIntervalSinceNow < 300 }) ?? isTokenExpired(accessToken: credential.accessToken),
+                   let refresh = credential.refreshToken {
+                    let refreshed = try await refreshAccessToken(refreshToken: refresh)
+                    credential.accessToken = refreshed.accessToken
+                    credential.refreshToken = refreshed.refreshToken ?? refresh
+                    credential.idToken = refreshed.idToken ?? credential.idToken
+                    credential.expiresAt = refreshed.expiresIn.map { Date().addingTimeInterval(TimeInterval($0)) }
+                    try await MonitorCredentialVault.shared.save(credential, metadata: account)
+                }
+                let claims = credential.idToken.flatMap(decodeJWT)
+                do {
+                    results[account.accountKey] = try await fetchQuota(
+                        accessToken: credential.accessToken,
+                        accountId: credential.accountID ?? claims?.accountId,
+                        identity: CodexQuotaIdentity(planType: claims?.planType)
+                    )
+                } catch CodexCLIQuotaError.httpError(let status) where status == 401 || status == 403 {
+                    if let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id) {
+                        credential = latest
+                    }
+                    guard let refresh = credential.refreshToken else { throw CodexCLIQuotaError.tokenRefreshFailed }
+                    let refreshed = try await refreshAccessToken(refreshToken: refresh)
+                    credential.accessToken = refreshed.accessToken
+                    credential.refreshToken = refreshed.refreshToken ?? refresh
+                    credential.idToken = refreshed.idToken ?? credential.idToken
+                    credential.expiresAt = refreshed.expiresIn.map { Date().addingTimeInterval(TimeInterval($0)) }
+                    try await MonitorCredentialVault.shared.save(credential, metadata: account)
+                    results[account.accountKey] = try await fetchQuota(
+                        accessToken: credential.accessToken,
+                        accountId: credential.accountID ?? claims?.accountId,
+                        identity: CodexQuotaIdentity(planType: claims?.planType)
+                    )
+                }
+            } catch {
+                Log.quota("Failed to fetch Codex quota for Quotio credential")
+            }
+        }
+        return results
+    }
+
+    private func persistRefresh(_ refreshed: TokenRefresh, originalRefreshToken: String, path: String) throws {
+        let url = URL(fileURLWithPath: path)
+        guard let currentData = try? Data(contentsOf: url),
+              var json = try? JSONSerialization.jsonObject(with: currentData) as? [String: Any],
+              var tokenJSON = json["tokens"] as? [String: Any],
+              tokenJSON["refresh_token"] as? String == originalRefreshToken else {
+            return
+        }
+        tokenJSON["access_token"] = refreshed.accessToken
+        tokenJSON["refresh_token"] = refreshed.refreshToken ?? originalRefreshToken
+        if let idToken = refreshed.idToken { tokenJSON["id_token"] = idToken }
+        json["tokens"] = tokenJSON
+        json["last_refresh"] = ISO8601DateFormatter().string(from: Date())
+        let data = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
+        try SecureAtomicFileWriter.write(data, to: url)
+    }
+
+    private func persistLegacyRefresh(_ refreshed: TokenRefresh, originalRefreshToken: String, path: String) {
+        let url = URL(fileURLWithPath: path)
+        guard let currentData = try? Data(contentsOf: url),
+              var json = try? JSONSerialization.jsonObject(with: currentData) as? [String: Any],
+              json["refresh_token"] as? String == originalRefreshToken else { return }
+        json["access_token"] = refreshed.accessToken
+        json["refresh_token"] = refreshed.refreshToken ?? originalRefreshToken
+        if let idToken = refreshed.idToken { json["id_token"] = idToken }
+        let lifetime = TimeInterval(refreshed.expiresIn ?? 3600)
+        json["expired"] = ISO8601DateFormatter().string(from: Date().addingTimeInterval(lifetime))
+        guard let data = try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys]) else { return }
+        try? SecureAtomicFileWriter.write(data, to: url)
+    }
+
+    private func readAuthFile(at path: String) -> CodexCLIAuthFile? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else { return nil }
+        return try? JSONDecoder().decode(CodexCLIAuthFile.self, from: data)
+    }
+}
+
+private extension String {
+    nonisolated var urlFormEncoded: String {
+        addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed) ?? self
+    }
+}
+
+private extension CharacterSet {
+    nonisolated static let urlQueryValueAllowed: CharacterSet = {
+        var set = CharacterSet.alphanumerics
+        set.insert(charactersIn: "-._~")
+        return set
+    }()
 }
 
 // MARK: - Errors

--- a/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
@@ -236,16 +236,38 @@ actor CopilotQuotaFetcher {
     }
     
     func fetchAllCopilotQuotas(authDir: String = "~/.cli-proxy-api") async -> [String: ProviderQuotaData] {
+        var results: [String: ProviderQuotaData] = [:]
+        for account in await MonitorCredentialVault.shared.accounts().filter({ $0.provider == .copilot && !$0.isDisabled }) {
+            guard let credential = await MonitorCredentialVault.shared.credential(for: account.id) else { continue }
+            do {
+                let entitlement = try await fetchEntitlement(accessToken: credential.accessToken)
+                results[account.accountKey] = convertToQuotaData(entitlement: entitlement)
+            } catch {
+                continue
+            }
+        }
+
+        let nativeTokens = loadNativeTokens()
+        for token in nativeTokens {
+            do {
+                let entitlement = try await fetchEntitlement(accessToken: token)
+                let key = await fetchGitHubLogin(accessToken: token) ?? "GitHub Copilot"
+                if results[key] == nil {
+                    results[key] = convertToQuotaData(entitlement: entitlement)
+                }
+            } catch {
+                continue
+            }
+        }
+
         let expandedPath = NSString(string: authDir).expandingTildeInPath
         let fileManager = FileManager.default
         
         guard let files = try? fileManager.contentsOfDirectory(atPath: expandedPath) else {
-            return [:]
+            return results
         }
         
         let copilotFiles = files.filter { $0.hasPrefix("github-copilot-") && $0.hasSuffix(".json") }
-        
-        var results: [String: ProviderQuotaData] = [:]
         
         for file in copilotFiles {
             let filePath = (expandedPath as NSString).appendingPathComponent(file)
@@ -257,6 +279,66 @@ actor CopilotQuotaFetcher {
         }
         
         return results
+    }
+
+    private func loadNativeTokens() -> [String] {
+        var tokens: [String] = []
+        let jsonPaths = [
+            "~/.config/github-copilot/apps.json",
+            "~/.config/github-copilot/hosts.json",
+        ].map { NSString(string: $0).expandingTildeInPath }
+
+        for path in jsonPaths {
+            guard let data = FileManager.default.contents(atPath: path),
+                  let object = try? JSONSerialization.jsonObject(with: data) else { continue }
+            collectTokens(from: object, into: &tokens)
+        }
+
+        let ghHosts = NSString(string: "~/.config/gh/hosts.yml").expandingTildeInPath
+        if let yaml = try? String(contentsOfFile: ghHosts, encoding: .utf8) {
+            for line in yaml.split(separator: "\n") {
+                let parts = line.split(separator: ":", maxSplits: 1).map(String.init)
+                guard parts.count == 2,
+                      parts[0].trimmingCharacters(in: .whitespaces) == "oauth_token" else { continue }
+                let token = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+                if !token.isEmpty { tokens.append(token) }
+            }
+        }
+
+        if let data = KeychainHelper.readExternalCredential(service: "gh:github.com"),
+           let token = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !token.isEmpty {
+            tokens.append(token)
+        }
+        return Array(Set(tokens))
+    }
+
+    private func fetchGitHubLogin(accessToken: String) async -> String? {
+        guard let url = URL(string: "https://api.github.com/user") else { return nil }
+        var request = URLRequest(url: url)
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.addValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        guard let (data, response) = try? await session.data(for: request),
+              let http = response as? HTTPURLResponse,
+              200...299 ~= http.statusCode,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return json["login"] as? String
+    }
+
+    private func collectTokens(from value: Any, into tokens: inout [String]) {
+        if let dictionary = value as? [String: Any] {
+            for (key, child) in dictionary {
+                if ["oauth_token", "oauthToken", "access_token"].contains(key),
+                   let token = child as? String,
+                   !token.isEmpty {
+                    tokens.append(token)
+                } else {
+                    collectTokens(from: child, into: &tokens)
+                }
+            }
+        } else if let array = value as? [Any] {
+            for child in array { collectTokens(from: child, into: &tokens) }
+        }
     }
     
     private func loadAuthFile(from path: String) -> CopilotAuthFile? {

--- a/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
@@ -235,15 +235,20 @@ actor CopilotQuotaFetcher {
         }
     }
     
-    func fetchAllCopilotQuotas(authDir: String = "~/.cli-proxy-api") async -> [String: ProviderQuotaData] {
+    func fetchAllCopilotQuotas(
+        authDir: String = "~/.cli-proxy-api",
+        includeMonitorCredentials: Bool = false
+    ) async -> [String: ProviderQuotaData] {
         var results: [String: ProviderQuotaData] = [:]
-        for account in await MonitorCredentialVault.shared.accounts().filter({ $0.provider == .copilot && !$0.isDisabled }) {
-            guard let credential = await MonitorCredentialVault.shared.credential(for: account.id) else { continue }
-            do {
-                let entitlement = try await fetchEntitlement(accessToken: credential.accessToken)
-                results[account.accountKey] = convertToQuotaData(entitlement: entitlement)
-            } catch {
-                continue
+        if includeMonitorCredentials {
+            for account in await MonitorCredentialVault.shared.accounts().filter({ $0.provider == .copilot && !$0.isDisabled }) {
+                guard let credential = await MonitorCredentialVault.shared.credential(for: account.id) else { continue }
+                do {
+                    let entitlement = try await fetchEntitlement(accessToken: credential.accessToken)
+                    results[account.accountKey] = convertToQuotaData(entitlement: entitlement)
+                } catch {
+                    continue
+                }
             }
         }
 

--- a/Quotio/Services/QuotaFetchers/GeminiCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/GeminiCLIQuotaFetcher.swift
@@ -27,6 +27,14 @@ nonisolated struct GeminiCLIAuthFile: Codable, Sendable {
     }
 }
 
+private extension String {
+    nonisolated var geminiFormEncoded: String {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return addingPercentEncoding(withAllowedCharacters: allowed) ?? self
+    }
+}
+
 /// Google accounts file structure (~/.gemini/google_accounts.json)
 nonisolated struct GeminiAccountsFile: Codable, Sendable {
     let active: String?
@@ -58,6 +66,11 @@ actor GeminiCLIQuotaFetcher {
     private let executor = CLIExecutor.shared
     private let quotaURL = "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota"
     private let codeAssistURL = "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist"
+    private let tokenURL = "https://oauth2.googleapis.com/token"
+    private let userInfoURL = "https://www.googleapis.com/oauth2/v2/userinfo?alt=json"
+    private let oauthClientID = "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com"
+    private let oauthClientSecret = "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"
+    private var session: URLSession
     private let requestHeaders = [
         "Authorization": "Bearer $TOKEN$",
         "Content-Type": "application/json"
@@ -111,6 +124,10 @@ actor GeminiCLIQuotaFetcher {
         )
     ]
 
+    init() {
+        session = URLSession(configuration: ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15))
+    }
+
     // Note: Gemini CLI interactions are handled by the executor, which spawns processes.
     // The current CLIExecutor implementation does not seem to support explicit proxy configuration
     // for the executed commands.
@@ -119,7 +136,7 @@ actor GeminiCLIQuotaFetcher {
     /// Update the URLSession with current proxy settings
     /// (No-op for now as Gemini CLI uses shell commands, but kept for protocol conformance)
     func updateProxyConfiguration() {
-        // Future: If GeminiFetcher starts making direct HTTP calls, update session here
+        session = URLSession(configuration: ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15))
     }
 
     /// Check if Gemini CLI is installed
@@ -245,29 +262,186 @@ actor GeminiCLIQuotaFetcher {
         return results
     }
 
-    /// Fetch account presence as ProviderQuotaData when real quota is unavailable.
+    /// Fetch Gemini quota directly from the native Gemini CLI credential.
     func fetchAsProviderQuota() async -> [String: ProviderQuotaData] {
-        guard await isInstalled() else { return [:] }
-        guard let accountInfo = getAccountInfo() else { return [:] }
-        
-        // Since Gemini CLI doesn't have a public quota API, we create a placeholder
-        // that shows the account is connected but quota is unknown
-        let models: [ModelQuota] = [
-            ModelQuota(
-                name: "gemini-quota",
-                percentage: -1, // -1 indicates unknown/unavailable
-                resetTime: ""
-            )
-        ]
-        
-        let quotaData = ProviderQuotaData(
-            models: models,
-            lastUpdated: Date(),
-            isForbidden: false,
-            planType: "Google Account" // We don't know the actual plan type
+        var results = await fetchOwnedQuotas()
+        guard let accountInfo = getAccountInfo(), var auth = readAuthFile(), var accessToken = auth.accessToken else { return results }
+        let path = NSString(string: authFilePath).expandingTildeInPath
+        if shouldRefresh(auth), let refreshToken = auth.refreshToken {
+            do {
+                let refreshed = try await refresh(refreshToken: refreshToken)
+                accessToken = refreshed.accessToken
+                auth = applying(refreshed, to: auth)
+                try persist(auth, expectedRefreshToken: refreshToken, path: path)
+            } catch {
+                Log.quota("Failed to proactively refresh Gemini CLI token")
+            }
+        }
+
+        do {
+            if results[accountInfo.email] == nil {
+                results[accountInfo.email] = try await fetchDirectQuota(accessToken: accessToken)
+            }
+            return results
+        } catch DirectGeminiError.authenticationRequired {
+            let latest = readAuthFile() ?? auth
+            guard let refreshToken = latest.refreshToken else { return results }
+            do {
+                let refreshed = try await refresh(refreshToken: refreshToken)
+                let updated = applying(refreshed, to: latest)
+                try persist(updated, expectedRefreshToken: refreshToken, path: path)
+                if results[accountInfo.email] == nil {
+                    results[accountInfo.email] = try await fetchDirectQuota(accessToken: refreshed.accessToken)
+                }
+                return results
+            } catch {
+                Log.quota("Failed to refresh Gemini CLI quota after authentication error")
+                return results
+            }
+        } catch {
+            Log.quota("Failed to fetch Gemini CLI quota directly: \(error.localizedDescription)")
+            return results
+        }
+    }
+
+    private func fetchOwnedQuotas() async -> [String: ProviderQuotaData] {
+        var results: [String: ProviderQuotaData] = [:]
+        for account in await MonitorCredentialVault.shared.accounts().filter({ $0.provider == .gemini && !$0.isDisabled }) {
+            guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { continue }
+            do {
+                if credential.expiresAt.map({ $0.timeIntervalSinceNow < 300 }) ?? false,
+                   let refreshToken = credential.refreshToken {
+                    let refreshed = try await refresh(refreshToken: refreshToken)
+                    credential.accessToken = refreshed.accessToken
+                    credential.refreshToken = refreshed.refreshToken ?? refreshToken
+                    credential.idToken = refreshed.idToken ?? credential.idToken
+                    credential.expiresAt = refreshed.expiresIn.map { Date().addingTimeInterval(TimeInterval($0)) }
+                    try await MonitorCredentialVault.shared.save(credential, metadata: account)
+                }
+                do {
+                    results[account.accountKey] = try await fetchDirectQuota(accessToken: credential.accessToken)
+                } catch DirectGeminiError.authenticationRequired {
+                    if let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id) {
+                        credential = latest
+                    }
+                    guard let refreshToken = credential.refreshToken else { continue }
+                    let refreshed = try await refresh(refreshToken: refreshToken)
+                    credential.accessToken = refreshed.accessToken
+                    credential.refreshToken = refreshed.refreshToken ?? refreshToken
+                    credential.idToken = refreshed.idToken ?? credential.idToken
+                    credential.expiresAt = refreshed.expiresIn.map { Date().addingTimeInterval(TimeInterval($0)) }
+                    try await MonitorCredentialVault.shared.save(credential, metadata: account)
+                    results[account.accountKey] = try await fetchDirectQuota(accessToken: credential.accessToken)
+                }
+            } catch {
+                Log.quota("Failed to fetch Gemini quota for Quotio credential")
+            }
+        }
+        return results
+    }
+
+    private struct DirectTokenResponse: Decodable {
+        let accessToken: String
+        let refreshToken: String?
+        let idToken: String?
+        let expiresIn: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case accessToken = "access_token"
+            case refreshToken = "refresh_token"
+            case idToken = "id_token"
+            case expiresIn = "expires_in"
+        }
+    }
+
+    private enum DirectGeminiError: LocalizedError {
+        case authenticationRequired
+        case http(Int)
+        case invalidResponse
+
+        var errorDescription: String? {
+            switch self {
+            case .authenticationRequired: "Gemini CLI login expired."
+            case .http(let status): "Gemini quota request failed with HTTP \(status)."
+            case .invalidResponse: "Gemini quota returned an invalid response."
+            }
+        }
+    }
+
+    private func shouldRefresh(_ auth: GeminiCLIAuthFile) -> Bool {
+        guard let expiry = auth.expiryDate else { return false }
+        return Date(timeIntervalSince1970: expiry / 1000).timeIntervalSinceNow < 300
+    }
+
+    private func refresh(refreshToken: String) async throws -> DirectTokenResponse {
+        var request = URLRequest(url: URL(string: tokenURL)!)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        let values = [
+            "client_id=\(oauthClientID.geminiFormEncoded)",
+            "client_secret=\(oauthClientSecret.geminiFormEncoded)",
+            "grant_type=refresh_token",
+            "refresh_token=\(refreshToken.geminiFormEncoded)",
+        ].joined(separator: "&")
+        request.httpBody = Data(values.utf8)
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+            throw DirectGeminiError.authenticationRequired
+        }
+        return try JSONDecoder().decode(DirectTokenResponse.self, from: data)
+    }
+
+    private func applying(_ response: DirectTokenResponse, to auth: GeminiCLIAuthFile) -> GeminiCLIAuthFile {
+        GeminiCLIAuthFile(
+            idToken: response.idToken ?? auth.idToken,
+            accessToken: response.accessToken,
+            scope: auth.scope,
+            refreshToken: response.refreshToken ?? auth.refreshToken,
+            tokenType: auth.tokenType,
+            expiryDate: response.expiresIn.map { Date().addingTimeInterval(TimeInterval($0)).timeIntervalSince1970 * 1000 } ?? auth.expiryDate
         )
-        
-        return [accountInfo.email: quotaData]
+    }
+
+    private func persist(_ auth: GeminiCLIAuthFile, expectedRefreshToken: String, path: String) throws {
+        guard let current = readAuthFile(), current.refreshToken == expectedRefreshToken else { return }
+        let data = try JSONEncoder().encode(auth)
+        try SecureAtomicFileWriter.write(data, to: URL(fileURLWithPath: path))
+    }
+
+    private func fetchDirectQuota(accessToken: String) async throws -> ProviderQuotaData {
+        let projectPayload = try await postJSON(
+            url: codeAssistURL,
+            accessToken: accessToken,
+            body: [
+                "metadata": [
+                    "ideType": "IDE_UNSPECIFIED",
+                    "platform": "PLATFORM_UNSPECIFIED",
+                    "pluginType": "GEMINI",
+                ],
+            ]
+        )
+        guard let projectID = stringValue(projectPayload["cloudaicompanionProject"] ?? projectPayload["projectId"] ?? projectPayload["project"]) else {
+            throw DirectGeminiError.invalidResponse
+        }
+        let quotaPayload = try await postJSON(url: quotaURL, accessToken: accessToken, body: ["project": projectID])
+        let models = buildModelQuotas(from: parseBuckets(from: quotaPayload))
+        guard !models.isEmpty else { throw DirectGeminiError.invalidResponse }
+        return ProviderQuotaData(models: models, lastUpdated: Date(), planType: resolveTierLabel(from: projectPayload))
+    }
+
+    private func postJSON(url: String, accessToken: String, body: [String: Any]) async throws -> [String: Any] {
+        var request = URLRequest(url: URL(string: url)!)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("GeminiCLI", forHTTPHeaderField: "User-Agent")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw DirectGeminiError.invalidResponse }
+        if http.statusCode == 401 || http.statusCode == 403 { throw DirectGeminiError.authenticationRequired }
+        guard 200..<300 ~= http.statusCode else { throw DirectGeminiError.http(http.statusCode) }
+        guard let value = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { throw DirectGeminiError.invalidResponse }
+        return value
     }
 
     private func fetchQuota(authIndex: String, projectId: String, apiClient: ManagementAPIClient) async throws -> ProviderQuotaData? {

--- a/Quotio/Services/QuotaFetchers/GeminiCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/GeminiCLIQuotaFetcher.swift
@@ -263,8 +263,8 @@ actor GeminiCLIQuotaFetcher {
     }
 
     /// Fetch Gemini quota directly from the native Gemini CLI credential.
-    func fetchAsProviderQuota() async -> [String: ProviderQuotaData] {
-        var results = await fetchOwnedQuotas()
+    func fetchAsProviderQuota(includeMonitorCredentials: Bool = false) async -> [String: ProviderQuotaData] {
+        var results = includeMonitorCredentials ? await fetchOwnedQuotas() : [:]
         guard let accountInfo = getAccountInfo(), var auth = readAuthFile(), var accessToken = auth.accessToken else { return results }
         let path = NSString(string: authFilePath).expandingTildeInPath
         if shouldRefresh(auth), let refreshToken = auth.refreshToken {

--- a/Quotio/Services/QuotaFetchers/KiroQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/KiroQuotaFetcher.swift
@@ -160,33 +160,105 @@ actor KiroQuotaFetcher {
     /// Scan and fetch quotas for all Kiro auth files
     func fetchAllQuotas() async -> [String: ProviderQuotaData] {
         let authService = DirectAuthFileService()
-        let allFiles = await authService.scanAllAuthFiles()
-        let kiroFiles = allFiles.filter { $0.provider == .kiro }
+        let kiroFiles = await kiroAuthFiles(using: authService)
+        var results = await fetchOwnedQuotas()
 
-        // Parallel fetching
-        return await withTaskGroup(of: (String, ProviderQuotaData?).self) { group in
-            for authFile in kiroFiles {
-                group.addTask {
-                    guard let tokenData = await authService.readAuthToken(from: authFile) else {
-                        return ("", nil)
-                    }
+        for authFile in kiroFiles {
+            guard let tokenData = await authService.readAuthToken(from: authFile) else { continue }
+            let key = authFile.email
+                ?? tokenData.extras?["profileArn"]
+                ?? authFile.filename.replacingOccurrences(of: ".json", with: "")
+            guard results[key] == nil,
+                  let quota = await fetchQuota(tokenData: tokenData, filePath: authFile.filePath) else { continue }
+            results[key] = quota
+        }
+        return results
+    }
 
-                    // Use filename as key to match Proxy's behavior (ignoring email inside JSON for key purposes)
-                    // This prevents duplicate accounts in the UI
-                    let key = authFile.filename.replacingOccurrences(of: ".json", with: "")
-
-                    let quota = await self.fetchQuota(tokenData: tokenData, filePath: authFile.filePath)
-                    return (key, quota)
-                }
+    private func fetchOwnedQuotas() async -> [String: ProviderQuotaData] {
+        var results: [String: ProviderQuotaData] = [:]
+        for account in await MonitorCredentialVault.shared.accounts().filter({ $0.provider == .kiro && !$0.isDisabled }) {
+            guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { continue }
+            if credential.expiresAt.map({ $0.timeIntervalSinceNow < 300 }) ?? false {
+                guard await refreshOwnedCredential(&credential, account: account) else { continue }
             }
-
-            var results: [String: ProviderQuotaData] = [:]
-            for await (key, quota) in group {
-                if let quota = quota, !key.isEmpty {
-                    results[key] = quota
-                }
+            var tokenData = ownedTokenData(credential)
+            let region = credential.extra["region"] ?? defaultRegion
+            var response = await fetchUsageAPI(
+                token: credential.accessToken,
+                tokenExpiresAt: credential.expiresAt,
+                profileArn: credential.extra["profileArn"],
+                region: region,
+                tokenData: tokenData
+            )
+            if (response.statusCode == 401 || response.statusCode == 403),
+               await reloadAndRefreshOwnedCredential(&credential, account: account) {
+                tokenData = ownedTokenData(credential)
+                response = await fetchUsageAPI(
+                    token: credential.accessToken,
+                    tokenExpiresAt: credential.expiresAt,
+                    profileArn: credential.extra["profileArn"],
+                    region: region,
+                    tokenData: tokenData
+                )
             }
-            return results
+            if let quota = response.quotaData { results[account.accountKey] = quota }
+        }
+        return results
+    }
+
+    private func reloadAndRefreshOwnedCredential(
+        _ credential: inout MonitorOAuthCredential,
+        account: MonitorAccount
+    ) async -> Bool {
+        if let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id) {
+            credential = latest
+        }
+        return await refreshOwnedCredential(&credential, account: account)
+    }
+
+    private func ownedTokenData(_ credential: MonitorOAuthCredential) -> AuthTokenData {
+        AuthTokenData(
+            accessToken: credential.accessToken,
+            refreshToken: credential.refreshToken,
+            expiresAt: credential.expiresAt?.ISO8601Format(),
+            clientId: credential.extra["clientId"],
+            clientSecret: credential.extra["clientSecret"],
+            authMethod: credential.extra["authMethod"] ?? "IdC",
+            extras: credential.extra
+        )
+    }
+
+    private func refreshOwnedCredential(
+        _ credential: inout MonitorOAuthCredential,
+        account: MonitorAccount
+    ) async -> Bool {
+        guard let refreshToken = credential.refreshToken,
+              let clientID = credential.extra["clientId"],
+              let clientSecret = credential.extra["clientSecret"] else { return false }
+        let region = credential.extra["region"] ?? defaultRegion
+        guard let url = URL(string: idcTokenEndpoint(region: region)) else { return false }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: [
+            "clientId": clientID,
+            "clientSecret": clientSecret,
+            "grantType": "refresh_token",
+            "refreshToken": refreshToken,
+        ])
+        guard let (data, response) = try? await session.data(for: request),
+              let http = response as? HTTPURLResponse,
+              200...299 ~= http.statusCode,
+              let token = try? JSONDecoder().decode(KiroTokenResponse.self, from: data) else { return false }
+        credential.accessToken = token.accessToken
+        credential.refreshToken = token.refreshToken ?? refreshToken
+        credential.expiresAt = Date().addingTimeInterval(TimeInterval(token.expiresIn))
+        do {
+            try await MonitorCredentialVault.shared.save(credential, metadata: account)
+            return true
+        } catch {
+            return false
         }
     }
 
@@ -194,8 +266,7 @@ actor KiroQuotaFetcher {
     
     func refreshAllTokensIfNeeded() async -> Int {
         let authService = DirectAuthFileService()
-        let allFiles = await authService.scanAllAuthFiles()
-        let kiroFiles = allFiles.filter { $0.provider == .kiro }
+        let kiroFiles = await kiroAuthFiles(using: authService)
 
         guard !kiroFiles.isEmpty else {
             return 0
@@ -217,6 +288,37 @@ actor KiroQuotaFetcher {
         }
 
         return refreshedCount
+    }
+
+    private func kiroAuthFiles(using authService: DirectAuthFileService) async -> [DirectAuthFile] {
+        var files = await authService.scanAllAuthFiles().filter { $0.provider == .kiro }
+        guard fileManager.fileExists(atPath: kiroIDEAuthPath),
+              !files.contains(where: { $0.filePath == kiroIDEAuthPath }) else {
+            return files
+        }
+
+        var email: String?
+        var expiry: Date?
+        if let data = fileManager.contents(atPath: kiroIDEAuthPath),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            email = json["email"] as? String
+            let rawExpiry = json["expiresAt"] as? String
+                ?? json["expires_at"] as? String
+                ?? json["expiry"] as? String
+            expiry = parseExpiryDate(rawExpiry)
+        }
+        files.insert(DirectAuthFile(
+            id: kiroIDEAuthPath,
+            provider: .kiro,
+            email: email,
+            login: nil,
+            expired: expiry,
+            accountType: nil,
+            filePath: kiroIDEAuthPath,
+            source: .nativeCredential,
+            filename: URL(fileURLWithPath: kiroIDEAuthPath).lastPathComponent
+        ), at: 0)
+        return files
     }
     
     private func shouldRefreshToken(_ tokenData: AuthTokenData) -> (shouldRefresh: Bool, reason: String) {
@@ -280,13 +382,31 @@ actor KiroQuotaFetcher {
 
         // Reactive refresh: If 401/403 and haven't tried refresh yet, refresh and retry
         if (result.statusCode == 401 || result.statusCode == 403) && !hasAttemptedRefresh {
-            if let (refreshed, newExpiry) = await refreshTokenWithExpiry(tokenData: tokenData, filePath: filePath) {
-                let retryResult = await fetchUsageAPI(token: refreshed, tokenExpiresAt: newExpiry, profileArn: profileArn, region: region, tokenData: tokenData)
+            let latestTokenData = await reloadTokenData(at: filePath) ?? tokenData
+            if let (refreshed, newExpiry) = await refreshTokenWithExpiry(tokenData: latestTokenData, filePath: filePath) {
+                let latestRegion = extractRegionFromProfileArn(latestTokenData.extras?["profileArn"]) ?? latestTokenData.extras?["region"] ?? defaultRegion
+                let retryResult = await fetchUsageAPI(token: refreshed, tokenExpiresAt: newExpiry, profileArn: latestTokenData.extras?["profileArn"], region: latestRegion, tokenData: latestTokenData)
                 return retryResult.quotaData ?? ProviderQuotaData(models: [], lastUpdated: Date(), isForbidden: true, planType: "Unauthorized", tokenExpiresAt: newExpiry)
             }
         }
 
         return result.quotaData
+    }
+
+    private func reloadTokenData(at filePath: String) async -> AuthTokenData? {
+        let source: DirectAuthFile.AuthFileSource = filePath.contains("/.aws/sso/cache/") ? .nativeCredential : .cliProxyApi
+        let file = DirectAuthFile(
+            id: filePath,
+            provider: .kiro,
+            email: nil,
+            login: nil,
+            expired: nil,
+            accountType: nil,
+            filePath: filePath,
+            source: source,
+            filename: URL(fileURLWithPath: filePath).lastPathComponent
+        )
+        return await DirectAuthFileService().readAuthToken(from: file)
     }
 
     /// Parse expiry date from ISO8601 string
@@ -440,12 +560,14 @@ actor KiroQuotaFetcher {
 
             await persistRefreshedToken(
                 filePath: filePath,
+                expectedRefreshToken: refreshToken,
                 newAccessToken: tokenResponse.accessToken,
                 newRefreshToken: tokenResponse.refreshToken,
                 expiresIn: tokenResponse.expiresIn
             )
             
             await syncToKiroIDEAuthFile(
+                expectedRefreshToken: refreshToken,
                 newAccessToken: tokenResponse.accessToken,
                 newRefreshToken: tokenResponse.refreshToken,
                 expiresIn: tokenResponse.expiresIn
@@ -511,6 +633,7 @@ actor KiroQuotaFetcher {
             // Persist to Quotio's auth file
             await persistRefreshedToken(
                 filePath: filePath,
+                expectedRefreshToken: refreshToken,
                 newAccessToken: tokenResponse.accessToken,
                 newRefreshToken: tokenResponse.refreshToken,
                 expiresIn: tokenResponse.expiresIn
@@ -518,6 +641,7 @@ actor KiroQuotaFetcher {
             
             // Also sync to Kiro IDE auth file if it exists
             await syncToKiroIDEAuthFile(
+                expectedRefreshToken: refreshToken,
                 newAccessToken: tokenResponse.accessToken,
                 newRefreshToken: tokenResponse.refreshToken,
                 expiresIn: tokenResponse.expiresIn
@@ -532,6 +656,7 @@ actor KiroQuotaFetcher {
     /// Sync refreshed token to Kiro IDE auth file (~/.aws/sso/cache/kiro-auth-token.json)
     /// This keeps Kiro IDE in sync when Quotio refreshes the token
     private func syncToKiroIDEAuthFile(
+        expectedRefreshToken: String,
         newAccessToken: String,
         newRefreshToken: String?,
         expiresIn: Int
@@ -541,6 +666,8 @@ actor KiroQuotaFetcher {
               var json = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] else {
             return
         }
+        let latestRefresh = json["refreshToken"] as? String ?? json["refresh_token"] as? String
+        guard latestRefresh == expectedRefreshToken else { return }
         
         // Kiro IDE uses camelCase keys (accessToken, refreshToken, expiresAt)
         json["accessToken"] = newAccessToken
@@ -556,7 +683,7 @@ actor KiroQuotaFetcher {
         
         do {
             let updatedData = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
-            try updatedData.write(to: URL(fileURLWithPath: kiroIDEAuthPath), options: .atomic)
+            try SecureAtomicFileWriter.write(updatedData, to: URL(fileURLWithPath: kiroIDEAuthPath))
         } catch {
             // Silent failure - Kiro IDE will refresh on its own if needed
         }
@@ -565,6 +692,7 @@ actor KiroQuotaFetcher {
     /// Persist refreshed token back to the auth file on disk
     private func persistRefreshedToken(
         filePath: String,
+        expectedRefreshToken: String,
         newAccessToken: String,
         newRefreshToken: String?,
         expiresIn: Int
@@ -573,6 +701,8 @@ actor KiroQuotaFetcher {
               var json = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] else {
             return
         }
+        let latestRefresh = json["refresh_token"] as? String ?? json["refreshToken"] as? String
+        guard latestRefresh == expectedRefreshToken else { return }
 
         json["access_token"] = newAccessToken
         if let newRefresh = newRefreshToken {
@@ -589,7 +719,7 @@ actor KiroQuotaFetcher {
 
         do {
             let updatedData = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
-            try updatedData.write(to: URL(fileURLWithPath: filePath), options: .atomic)
+            try SecureAtomicFileWriter.write(updatedData, to: URL(fileURLWithPath: filePath))
         } catch {
             // Silent failure - token will be refreshed again on next request
         }

--- a/Quotio/Services/QuotaFetchers/KiroQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/KiroQuotaFetcher.swift
@@ -158,10 +158,10 @@ actor KiroQuotaFetcher {
     }
 
     /// Scan and fetch quotas for all Kiro auth files
-    func fetchAllQuotas() async -> [String: ProviderQuotaData] {
+    func fetchAllQuotas(includeMonitorCredentials: Bool = false) async -> [String: ProviderQuotaData] {
         let authService = DirectAuthFileService()
         let kiroFiles = await kiroAuthFiles(using: authService)
-        var results = await fetchOwnedQuotas()
+        var results = includeMonitorCredentials ? await fetchOwnedQuotas() : [:]
 
         for authFile in kiroFiles {
             guard let tokenData = await authService.readAuthToken(from: authFile) else { continue }
@@ -425,6 +425,42 @@ actor KiroQuotaFetcher {
     private struct UsageAPIResult {
         let statusCode: Int
         let quotaData: ProviderQuotaData?
+        let accountIdentity: String?
+
+        init(
+            statusCode: Int,
+            quotaData: ProviderQuotaData?,
+            accountIdentity: String? = nil
+        ) {
+            self.statusCode = statusCode
+            self.quotaData = quotaData
+            self.accountIdentity = accountIdentity
+        }
+    }
+
+    func authenticatedAccountIdentity(
+        accessToken: String,
+        expiresAt: Date,
+        clientID: String,
+        clientSecret: String,
+        region: String
+    ) async -> String? {
+        let tokenData = AuthTokenData(
+            accessToken: accessToken,
+            refreshToken: nil,
+            expiresAt: expiresAt.ISO8601Format(),
+            clientId: clientID,
+            clientSecret: clientSecret,
+            authMethod: "IdC",
+            extras: ["region": region]
+        )
+        return await fetchUsageAPI(
+            token: accessToken,
+            tokenExpiresAt: expiresAt,
+            profileArn: nil,
+            region: region,
+            tokenData: tokenData
+        ).accountIdentity
     }
 
     private func fetchUsageAPI(token: String, tokenExpiresAt: Date?, profileArn: String?, region: String, tokenData: AuthTokenData) async -> UsageAPIResult {
@@ -490,7 +526,18 @@ actor KiroQuotaFetcher {
             do {
                 let usageResponse = try JSONDecoder().decode(KiroUsageResponse.self, from: data)
                 let planType = usageResponse.subscriptionInfo?.subscriptionTitle ?? "Standard"
-                return UsageAPIResult(statusCode: 200, quotaData: convertToQuotaData(usageResponse, planType: planType, tokenExpiresAt: tokenExpiresAt))
+                let accountIdentity = [usageResponse.userInfo?.email, usageResponse.userInfo?.userId]
+                    .compactMap { value -> String? in
+                        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+                              !value.isEmpty else { return nil }
+                        return value
+                    }
+                    .first
+                return UsageAPIResult(
+                    statusCode: 200,
+                    quotaData: convertToQuotaData(usageResponse, planType: planType, tokenExpiresAt: tokenExpiresAt),
+                    accountIdentity: accountIdentity
+                )
             } catch {
                 if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
                     let keys = json.keys.sorted().joined(separator: ",")

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -123,11 +123,24 @@ final class StatusBarMenuBuilder {
             }
         }
         
-        // Filter out CLI-based providers if CLI is not installed
-        return providers.filter { provider in
+        return Self.filterProviders(
+            providers,
+            isMonitorMode: modeManager.isMonitorMode,
+            isCLIInstalled: isCLIInstalled
+        )
+    }
+
+    nonisolated static func filterProviders(
+        _ providers: Set<AIProvider>,
+        isMonitorMode: Bool,
+        isCLIInstalled: (CLIAgent) -> Bool
+    ) -> [AIProvider] {
+        let sorted = providers.sorted { $0.displayName < $1.displayName }
+        guard !isMonitorMode else { return sorted }
+        return sorted.filter { provider in
             guard let agent = provider.cliAgent else { return true }
             return isCLIInstalled(agent)
-        }.sorted { $0.displayName < $1.displayName }
+        }
     }
     
     private func isCLIInstalled(_ agent: CLIAgent) -> Bool {

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -122,12 +122,20 @@ final class StatusBarMenuBuilder {
                 providers.insert(provider)
             }
         }
+
+        if modeManager.isMonitorMode {
+            providers.formUnion(Self.monitorProviders(viewModel.monitorAccounts))
+        }
         
         return Self.filterProviders(
             providers,
             isMonitorMode: modeManager.isMonitorMode,
             isCLIInstalled: isCLIInstalled
         )
+    }
+
+    nonisolated static func monitorProviders(_ accounts: [MonitorAccount]) -> Set<AIProvider> {
+        Set(accounts.lazy.filter { !$0.isDisabled }.map(\.provider))
     }
 
     nonisolated static func filterProviders(

--- a/Quotio/Services/Tunnel/TunnelManager.swift
+++ b/Quotio/Services/Tunnel/TunnelManager.swift
@@ -32,6 +32,7 @@ final class TunnelManager {
     // MARK: - Init
     
     private init() {
+        guard ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil else { return }
         Task {
             await refreshInstallation()
             Self.cleanupOrphans()

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -455,7 +455,7 @@ final class QuotaViewModel {
             return quotas
         }
 
-        providerQuotas[.codex] = await codex
+        providerQuotas[.codex] = await codexFetcher.reconcileLegacyAliases(in: await codex)
         providerQuotas[.claude] = await claude
         providerQuotas[.gemini] = await gemini
         providerQuotas[.copilot] = await copilot

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -22,6 +22,7 @@ final class QuotaViewModel {
     @ObservationIgnored private let warpFetcher = WarpQuotaFetcher()
     @ObservationIgnored private let clinePassFetcher = ClinePassQuotaFetcher()
     @ObservationIgnored private let directAuthService = DirectAuthFileService()
+    @ObservationIgnored private let monitorCoordinator = MonitorRefreshCoordinator()
     @ObservationIgnored private let notificationManager = NotificationManager.shared
     @ObservationIgnored private let modeManager = OperatingModeManager.shared
     @ObservationIgnored private let refreshSettings = RefreshSettingsManager.shared
@@ -71,6 +72,28 @@ final class QuotaViewModel {
     
     /// Direct auth files for quota-only mode
     var directAuthFiles: [DirectAuthFile] = []
+    var monitorAccounts: [MonitorAccount] = []
+    var monitorIssues: [AIProvider: MonitorRefreshIssue] = [:]
+
+    func monitorStatus(for account: MonitorAccount) -> (status: String?, message: String?) {
+        if let issue = monitorIssues[account.provider] {
+            return ("outdated", issue.message)
+        }
+        let updated = providerQuotas[account.provider]?[account.accountKey]?.lastUpdated
+            ?? providerQuotas[account.provider]?.values.map(\.lastUpdated).max()
+        guard let updated else { return (nil, nil) }
+        let staleAfter = refreshSettings.refreshCadence.intervalSeconds ?? 600
+        if Date().timeIntervalSince(updated) > staleAfter {
+            return (
+                "outdated",
+                String(format: "monitor.status.outdated".localized(), updated.formatted(date: .abbreviated, time: .shortened))
+            )
+        }
+        return (
+            "ready",
+            String(format: "monitor.status.updated".localized(), updated.formatted(date: .omitted, time: .shortened))
+        )
+    }
     
     /// Last quota refresh time (for quota-only mode display)
     var lastQuotaRefreshTime: Date?
@@ -292,7 +315,16 @@ final class QuotaViewModel {
     
     /// Initialize for Quota-Only Mode (no proxy)
     private func initializeQuotaOnlyMode() async {
-        // Load auth files directly from filesystem
+        if let existingClient = _apiClient {
+            await existingClient.invalidate()
+            _apiClient = nil
+        }
+        let bootstrap = await monitorCoordinator.bootstrap()
+        monitorAccounts = bootstrap.accounts
+        monitorIssues = bootstrap.issues
+        providerQuotas = bootstrap.quotas
+
+        // Keep legacy files available only as a compatibility source.
         await loadDirectAuthFiles()
         
         // Fetch quotas directly
@@ -348,30 +380,99 @@ final class QuotaViewModel {
     /// Load auth files directly from filesystem
     func loadDirectAuthFiles() async {
         directAuthFiles = await directAuthService.scanAllAuthFiles()
+        if modeManager.isMonitorMode {
+            monitorAccounts = await monitorCoordinator.discoverAccounts(merging: providerQuotas)
+        }
+    }
+
+    func setMonitorAccountDisabled(_ disabled: Bool, accountID: String) async {
+        await monitorCoordinator.setDisabled(disabled, accountID: accountID)
+        monitorAccounts = await monitorCoordinator.discoverAccounts(merging: providerQuotas)
+        syncMenuBarSelection()
+    }
+
+    func deleteMonitorAccount(accountID: String) async {
+        guard let account = monitorAccounts.first(where: { $0.id == accountID }), account.canDelete else { return }
+        await monitorCoordinator.deleteOwnedAccount(accountID: accountID)
+        providerQuotas[account.provider]?.removeValue(forKey: account.accountKey)
+        await monitorCoordinator.finish(quotas: providerQuotas)
+        monitorAccounts = await monitorCoordinator.discoverAccounts(merging: providerQuotas)
     }
     
     /// Refresh quotas directly without proxy (for Quota-Only Mode)
     /// Note: Cursor and Trae are NOT auto-refreshed - user must use "Scan for IDEs" (issue #29)
-    func refreshQuotasDirectly() async {
+    func refreshQuotasDirectly(force: Bool = false) async {
         guard !isLoadingQuotas else { return }
         
         isLoadingQuotas = true
         lastQuotaRefreshTime = Date()
         
-        // Fetch from available fetchers in parallel
-        // Note: Cursor and Trae removed from auto-refresh to address privacy concerns (issue #29)
-        // User must explicitly scan for IDEs to detect Cursor/Trae quotas
-        async let antigravity: () = refreshAntigravityQuotasInternal()
-        async let codex: () = refreshCodexQuotasInternal(includeCLIFallback: true)
-        async let copilot: () = refreshCopilotQuotasInternal()
-        async let claudeCode: () = refreshClaudeCodeQuotasInternal()
-        async let geminiCLI: () = refreshGeminiCLIQuotasInternal()
-        async let glm: () = refreshGlmQuotasInternal()
-        async let warp: () = refreshWarpQuotasInternal()
-        async let kiro: () = refreshKiroQuotasInternal()
-        async let clinePass: () = refreshClinePassQuotasInternal()
+        let previous = providerQuotas
+        let coordinator = monitorCoordinator
+        let codexFetcher = codexCLIFetcher
+        let claudeFetcher = claudeCodeFetcher
+        let geminiFetcher = geminiCLIFetcher
+        let copilotQuotaFetcher = copilotFetcher
+        let kiroQuotaFetcher = kiroFetcher
+        let glmQuotaFetcher = glmFetcher
+        let clineQuotaFetcher = clinePassFetcher
+        let warpQuotaFetcher = warpFetcher
+        let antigravityQuotaFetcher = antigravityFetcher
+        let warpTokens = WarpService.shared.tokens.filter { $0.isEnabled }
 
-        _ = await (antigravity, codex, copilot, claudeCode, geminiCLI, glm, warp, kiro, clinePass)
+        async let codex = coordinator.refresh(provider: .codex, force: force, previous: previous[.codex] ?? [:]) {
+            await codexFetcher.fetchAsProviderQuota()
+        }
+        async let claude = coordinator.refresh(provider: .claude, force: force, previous: previous[.claude] ?? [:]) {
+            await claudeFetcher.fetchAsProviderQuota()
+        }
+        async let gemini = coordinator.refresh(provider: .gemini, force: force, previous: previous[.gemini] ?? [:]) {
+            await geminiFetcher.fetchAsProviderQuota()
+        }
+        async let copilot = coordinator.refresh(provider: .copilot, force: force, previous: previous[.copilot] ?? [:]) {
+            await copilotQuotaFetcher.fetchAllCopilotQuotas()
+        }
+        async let kiro = coordinator.refresh(provider: .kiro, force: force, previous: previous[.kiro] ?? [:]) {
+            await kiroQuotaFetcher.fetchAllQuotas()
+        }
+        async let glm = coordinator.refresh(provider: .glm, force: force, previous: previous[.glm] ?? [:]) {
+            await glmQuotaFetcher.fetchAllQuotas()
+        }
+        async let clinePass = coordinator.refresh(provider: .clinePass, force: force, previous: previous[.clinePass] ?? [:]) {
+            await clineQuotaFetcher.fetchAllQuotas()
+        }
+        async let warp = coordinator.refresh(provider: .warp, force: force, previous: previous[.warp] ?? [:]) {
+            var quotas: [String: ProviderQuotaData] = [:]
+            for entry in warpTokens {
+                if let quota = try? await warpQuotaFetcher.fetchQuota(apiKey: entry.token) {
+                    quotas[entry.name] = quota
+                }
+            }
+            return quotas
+        }
+        async let antigravity = coordinator.refresh(provider: .antigravity, force: force, previous: previous[.antigravity] ?? [:]) {
+            let (quotas, _) = await antigravityQuotaFetcher.fetchAllAntigravityData()
+            return quotas
+        }
+
+        providerQuotas[.codex] = await codex
+        providerQuotas[.claude] = await claude
+        providerQuotas[.gemini] = await gemini
+        providerQuotas[.copilot] = await copilot
+        providerQuotas[.kiro] = await kiro
+        providerQuotas[.glm] = await glm
+        providerQuotas[.clinePass] = await clinePass
+        providerQuotas[.warp] = await warp
+        providerQuotas[.antigravity] = await antigravity
+        providerQuotas = providerQuotas.filter { !$0.value.isEmpty }
+
+        for account in monitorAccounts where account.isDisabled {
+            providerQuotas[account.provider]?.removeValue(forKey: account.accountKey)
+        }
+
+        monitorAccounts = await coordinator.discoverAccounts(merging: providerQuotas)
+        monitorIssues = await coordinator.currentIssues()
+        await coordinator.finish(quotas: providerQuotas)
         
         checkQuotaNotifications()
         pruneMenuBarItems()
@@ -404,8 +505,11 @@ final class QuotaViewModel {
             }
         }
         
-        for file in directAuthFiles {
-            let item = MenuBarQuotaItem(provider: file.provider.rawValue, accountKey: file.menuBarAccountKey)
+        let monitorItems = modeManager.isMonitorMode
+            ? monitorAccounts.filter { !$0.isDisabled }.map { ($0.provider, $0.accountKey) }
+            : directAuthFiles.map { ($0.provider, $0.menuBarAccountKey) }
+        for (provider, accountKey) in monitorItems {
+            let item = MenuBarQuotaItem(provider: provider.rawValue, accountKey: accountKey)
             if !seen.contains(item.id) {
                 seen.insert(item.id)
                 availableItems.append(item)
@@ -454,12 +558,7 @@ final class QuotaViewModel {
     
     /// Refresh Codex quota using CLI auth file (~/.codex/auth.json)
     private func refreshCodexCLIQuotasInternal() async {
-        // Only use CLI fetcher if proxy is not available or in quota-only mode
-        // The openAIFetcher handles Codex via proxy auth files
         guard modeManager.isMonitorMode else { return }
-
-        // Skip if OpenAI fetcher already populated codex quotas (avoids duplicate entries
-        // since OpenAIQuotaFetcher keys by filename while CodexCLIFetcher keys by JWT email)
         if let existing = providerQuotas[.codex], !existing.isEmpty { return }
 
         let quotas = await codexCLIFetcher.fetchAsProviderQuota()
@@ -470,6 +569,12 @@ final class QuotaViewModel {
     
     /// Refresh Gemini quota using CLIProxyAPI management data when available.
     private func refreshGeminiCLIQuotasInternal() async {
+        if modeManager.isMonitorMode {
+            let quotas = await geminiCLIFetcher.fetchAsProviderQuota()
+            if !quotas.isEmpty { providerQuotas[.gemini] = quotas }
+            return
+        }
+
         var quotaAuthFiles = authFiles
         var quotaClient = apiClient
         var transientClient: ManagementAPIClient?
@@ -1001,7 +1106,10 @@ final class QuotaViewModel {
     }
     
     var connectedProviders: [AIProvider] {
-        Array(Set(authFiles.compactMap { $0.providerType })).sorted { $0.displayName < $1.displayName }
+        if modeManager.isMonitorMode {
+            return Array(Set(monitorAccounts.map(\.provider))).sorted { $0.displayName < $1.displayName }
+        }
+        return Array(Set(authFiles.compactMap { $0.providerType })).sorted { $0.displayName < $1.displayName }
     }
     
     var disconnectedProviders: [AIProvider] {
@@ -1214,7 +1322,7 @@ final class QuotaViewModel {
     
     func manualRefresh() async {
         if modeManager.isMonitorMode {
-            await refreshQuotasDirectly()
+            await refreshQuotasDirectly(force: true)
         } else if proxyManager.proxyStatus.running {
             await refreshData()
         } else {
@@ -1224,6 +1332,10 @@ final class QuotaViewModel {
     }
     
     func refreshAllQuotas() async {
+        if modeManager.isMonitorMode {
+            await refreshQuotasDirectly()
+            return
+        }
         guard !isLoadingQuotas else { return }
 
         isLoadingQuotas = true
@@ -1264,6 +1376,10 @@ final class QuotaViewModel {
     /// In Remote Mode: skips local fetchers (data comes from remote proxy)
     /// Note: Cursor and Trae require explicit user scan (issue #29)
     func refreshQuotasUnified() async {
+        if modeManager.isMonitorMode {
+            await refreshQuotasDirectly()
+            return
+        }
         guard !isLoadingQuotas else { return }
         guard !modeManager.isRemoteProxyMode else { return }
 
@@ -1364,6 +1480,10 @@ final class QuotaViewModel {
     }
 
     private func refreshCodexQuotasInternal(includeCLIFallback: Bool) async {
+        if modeManager.isMonitorMode {
+            providerQuotas[.codex] = await codexCLIFetcher.fetchAsProviderQuota()
+            return
+        }
         await refreshOpenAIQuotasInternal()
         if includeCLIFallback {
             await refreshCodexCLIQuotasInternal()
@@ -1376,12 +1496,19 @@ final class QuotaViewModel {
     }
     
     func refreshQuotaForProvider(_ provider: AIProvider) async {
+        if modeManager.isMonitorMode {
+            await refreshQuotasDirectly(force: true)
+            return
+        }
         switch provider {
         case .antigravity:
             await refreshAntigravityQuotasInternal()
         case .codex:
-            await refreshOpenAIQuotasInternal()
-            await refreshCodexCLIQuotasInternal()
+            if modeManager.isMonitorMode {
+                await refreshCodexQuotasInternal(includeCLIFallback: true)
+            } else {
+                await refreshOpenAIQuotasInternal()
+            }
         case .copilot:
             await refreshCopilotQuotasInternal()
         case .claude:
@@ -1420,6 +1547,11 @@ final class QuotaViewModel {
     }
     
     func startOAuth(for provider: AIProvider, projectId: String? = nil, authMethod: AuthCommand? = nil, launchMode: OAuthLaunchMode = .manual) async {
+        if modeManager.isMonitorMode {
+            await startMonitorOAuth(for: provider)
+            return
+        }
+
         // GitHub Copilot uses Device Code Flow via CLI binary, not Management API
         if provider == .copilot {
             await startCopilotAuth()
@@ -1457,6 +1589,64 @@ final class QuotaViewModel {
             
             await pollOAuthStatus(state: state, provider: provider)
             
+        } catch {
+            oauthState = OAuthState(provider: provider, status: .error, error: error.localizedDescription)
+        }
+    }
+
+    private func startMonitorOAuth(for provider: AIProvider) async {
+        oauthState = OAuthState(provider: provider, status: .waiting)
+        if provider == .claude {
+            do {
+                let pending = try await MonitorOAuthCoordinator.shared.beginClaudeLogin()
+                oauthState = OAuthState(
+                    provider: provider,
+                    status: .polling,
+                    state: pending.state,
+                    authURL: pending.url.absoluteString
+                )
+            } catch {
+                oauthState = OAuthState(provider: provider, status: .error, error: error.localizedDescription)
+            }
+            return
+        }
+        let observer = NotificationCenter.default.addObserver(
+            forName: .monitorOAuthDeviceCode,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let code = notification.userInfo?["code"] as? String
+            let url = notification.userInfo?["url"] as? String
+            Task { @MainActor [weak self] in
+                self?.oauthState = OAuthState(
+                    provider: provider,
+                    status: .polling,
+                    state: code,
+                    error: code.map { String(format: "oauth.enterDeviceCode".localized(), $0) },
+                    authURL: url
+                )
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        do {
+            _ = try await MonitorOAuthCoordinator.shared.login(provider: provider)
+            oauthState = OAuthState(provider: provider, status: .success)
+            await refreshQuotasDirectly(force: true)
+        } catch is CancellationError {
+            oauthState = nil
+        } catch {
+            oauthState = OAuthState(provider: provider, status: .error, error: error.localizedDescription)
+        }
+    }
+
+    func completeMonitorOAuthCode(_ code: String, provider: AIProvider) async {
+        guard modeManager.isMonitorMode, provider == .claude else { return }
+        oauthState = OAuthState(provider: provider, status: .waiting)
+        do {
+            _ = try await MonitorOAuthCoordinator.shared.completeClaudeLogin(code: code)
+            oauthState = OAuthState(provider: provider, status: .success)
+            await refreshQuotasDirectly(force: true)
         } catch {
             oauthState = OAuthState(provider: provider, status: .error, error: error.localizedDescription)
         }
@@ -1590,6 +1780,7 @@ final class QuotaViewModel {
     }
     
     func cancelOAuth() {
+        Task { await MonitorOAuthCoordinator.shared.cancel() }
         oauthState = nil
     }
     

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -79,8 +79,7 @@ final class QuotaViewModel {
         if let issue = monitorIssues[account.provider] {
             return ("outdated", issue.message)
         }
-        let updated = providerQuotas[account.provider]?[account.accountKey]?.lastUpdated
-            ?? providerQuotas[account.provider]?.values.map(\.lastUpdated).max()
+        let updated = Self.monitorLastUpdated(for: account, providerQuotas: providerQuotas)
         guard let updated else { return (nil, nil) }
         let staleAfter = refreshSettings.refreshCadence.intervalSeconds ?? 600
         if Date().timeIntervalSince(updated) > staleAfter {
@@ -93,6 +92,13 @@ final class QuotaViewModel {
             "ready",
             String(format: "monitor.status.updated".localized(), updated.formatted(date: .omitted, time: .shortened))
         )
+    }
+
+    nonisolated static func monitorLastUpdated(
+        for account: MonitorAccount,
+        providerQuotas: [AIProvider: [String: ProviderQuotaData]]
+    ) -> Date? {
+        providerQuotas[account.provider]?[account.accountKey]?.lastUpdated
     }
     
     /// Last quota refresh time (for quota-only mode display)
@@ -409,6 +415,11 @@ final class QuotaViewModel {
         
         let previous = providerQuotas
         let coordinator = monitorCoordinator
+        let discoveredProviders = Set(await coordinator.discoverAccounts().map(\.provider))
+        let credentialProviders: Set<AIProvider> = [.codex, .claude, .gemini, .copilot, .kiro, .antigravity]
+        let credentialAvailability = Dictionary(uniqueKeysWithValues: credentialProviders.map {
+            ($0, discoveredProviders.contains($0) ? MonitorCredentialAvailability.present : .missing)
+        })
         let codexFetcher = codexCLIFetcher
         let claudeFetcher = claudeCodeFetcher
         let geminiFetcher = geminiCLIFetcher
@@ -420,20 +431,45 @@ final class QuotaViewModel {
         let antigravityQuotaFetcher = antigravityFetcher
         let warpTokens = WarpService.shared.tokens.filter { $0.isEnabled }
 
-        async let codex = coordinator.refresh(provider: .codex, force: force, previous: previous[.codex] ?? [:]) {
+        async let codex = coordinator.refresh(
+            provider: .codex,
+            force: force,
+            previous: previous[.codex] ?? [:],
+            credentialAvailability: credentialAvailability[.codex] ?? .unknown
+        ) {
             await codexFetcher.fetchAsProviderQuota()
         }
-        async let claude = coordinator.refresh(provider: .claude, force: force, previous: previous[.claude] ?? [:]) {
-            await claudeFetcher.fetchAsProviderQuota()
+        async let claude = coordinator.refresh(
+            provider: .claude,
+            force: force,
+            previous: previous[.claude] ?? [:],
+            credentialAvailability: credentialAvailability[.claude] ?? .unknown
+        ) {
+            await claudeFetcher.fetchAsProviderQuota(forceRefresh: force, includeMonitorCredentials: true)
         }
-        async let gemini = coordinator.refresh(provider: .gemini, force: force, previous: previous[.gemini] ?? [:]) {
-            await geminiFetcher.fetchAsProviderQuota()
+        async let gemini = coordinator.refresh(
+            provider: .gemini,
+            force: force,
+            previous: previous[.gemini] ?? [:],
+            credentialAvailability: credentialAvailability[.gemini] ?? .unknown
+        ) {
+            await geminiFetcher.fetchAsProviderQuota(includeMonitorCredentials: true)
         }
-        async let copilot = coordinator.refresh(provider: .copilot, force: force, previous: previous[.copilot] ?? [:]) {
-            await copilotQuotaFetcher.fetchAllCopilotQuotas()
+        async let copilot = coordinator.refresh(
+            provider: .copilot,
+            force: force,
+            previous: previous[.copilot] ?? [:],
+            credentialAvailability: credentialAvailability[.copilot] ?? .unknown
+        ) {
+            await copilotQuotaFetcher.fetchAllCopilotQuotas(includeMonitorCredentials: true)
         }
-        async let kiro = coordinator.refresh(provider: .kiro, force: force, previous: previous[.kiro] ?? [:]) {
-            await kiroQuotaFetcher.fetchAllQuotas()
+        async let kiro = coordinator.refresh(
+            provider: .kiro,
+            force: force,
+            previous: previous[.kiro] ?? [:],
+            credentialAvailability: credentialAvailability[.kiro] ?? .unknown
+        ) {
+            await kiroQuotaFetcher.fetchAllQuotas(includeMonitorCredentials: true)
         }
         async let glm = coordinator.refresh(provider: .glm, force: force, previous: previous[.glm] ?? [:]) {
             await glmQuotaFetcher.fetchAllQuotas()
@@ -450,8 +486,13 @@ final class QuotaViewModel {
             }
             return quotas
         }
-        async let antigravity = coordinator.refresh(provider: .antigravity, force: force, previous: previous[.antigravity] ?? [:]) {
-            let (quotas, _) = await antigravityQuotaFetcher.fetchAllAntigravityData()
+        async let antigravity = coordinator.refresh(
+            provider: .antigravity,
+            force: force,
+            previous: previous[.antigravity] ?? [:],
+            credentialAvailability: credentialAvailability[.antigravity] ?? .unknown
+        ) {
+            let (quotas, _) = await antigravityQuotaFetcher.fetchAllAntigravityData(includeMonitorCredentials: true)
             return quotas
         }
 
@@ -466,11 +507,8 @@ final class QuotaViewModel {
         providerQuotas[.antigravity] = await antigravity
         providerQuotas = providerQuotas.filter { !$0.value.isEmpty }
 
-        for account in monitorAccounts where account.isDisabled {
-            providerQuotas[account.provider]?.removeValue(forKey: account.accountKey)
-        }
-
         monitorAccounts = await coordinator.discoverAccounts(merging: providerQuotas)
+        removeDisabledMonitorQuotas()
         monitorIssues = await coordinator.currentIssues()
         await coordinator.finish(quotas: providerQuotas)
         
@@ -517,6 +555,12 @@ final class QuotaViewModel {
         }
         
         menuBarSettings.autoSelectNewAccounts(availableItems: availableItems)
+    }
+
+    private func removeDisabledMonitorQuotas() {
+        for account in monitorAccounts where account.isDisabled {
+            providerQuotas[account.provider]?.removeValue(forKey: account.accountKey)
+        }
     }
     
     func syncMenuBarSelection() {
@@ -2131,6 +2175,11 @@ final class QuotaViewModel {
         
         // Persist IDE quota data for Cursor and Trae
         savePersistedIDEQuotas()
+
+        if modeManager.isMonitorMode {
+            monitorAccounts = await monitorCoordinator.discoverAccounts(merging: providerQuotas)
+            removeDisabledMonitorQuotas()
+        }
 
         // Update menu bar items
         pruneMenuBarItems()

--- a/Quotio/Views/Components/AccountRow.swift
+++ b/Quotio/Views/Components/AccountRow.swift
@@ -13,12 +13,21 @@ enum AccountSource: Equatable {
     case proxy           // From proxy API (AuthFile)
     case direct          // From disk auth files (DirectAuthFile)
     case autoDetected    // Auto-detected from IDE (Cursor, Trae)
+    case monitor(MonitorAccountSource)
     
     var displayName: String {
         switch self {
         case .proxy: return "providers.source.proxy".localizedStatic()
         case .direct: return "providers.source.disk".localizedStatic()
         case .autoDetected: return "providers.autoDetected".localizedStatic()
+        case .monitor(let source): return source.displayName
+        }
+    }
+
+    var supportsDisable: Bool {
+        switch self {
+        case .proxy, .monitor: true
+        case .direct, .autoDetected: false
         }
     }
 }
@@ -118,6 +127,24 @@ struct AccountRowData: Identifiable, Hashable {
         )
     }
 
+    static func from(
+        monitorAccount: MonitorAccount,
+        status: String?,
+        statusMessage: String?
+    ) -> AccountRowData {
+        AccountRowData(
+            id: monitorAccount.id,
+            provider: monitorAccount.provider,
+            displayName: monitorAccount.displayName,
+            menuBarAccountKey: monitorAccount.accountKey,
+            source: .monitor(monitorAccount.source),
+            status: status,
+            statusMessage: statusMessage,
+            isDisabled: monitorAccount.isDisabled,
+            canDelete: monitorAccount.canDelete
+        )
+    }
+
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
         hasher.combine(isDisabled)
@@ -157,7 +184,7 @@ struct AccountRow: View {
     private var statusColor: Color {
         switch account.status {
         case "ready": return account.isDisabled ? .gray : .green
-        case "cooling": return .orange
+        case "cooling", "outdated": return .orange
         case "error": return .red
         default: return .gray
         }
@@ -199,6 +226,13 @@ struct AccountRow: View {
                             .font(.caption)
                             .foregroundStyle(.tertiary)
                     }
+                }
+
+                if let message = account.statusMessage, !message.isEmpty {
+                    Text(message)
+                        .font(.caption2)
+                        .foregroundStyle(account.status == "error" ? .red : .secondary)
+                        .lineLimit(1)
                 }
             }
             
@@ -254,7 +288,7 @@ struct AccountRow: View {
             )
 
             // Disable/Enable toggle button (only for proxy accounts)
-            if account.source == .proxy, let onToggleDisabled = onToggleDisabled {
+            if account.source.supportsDisable, let onToggleDisabled = onToggleDisabled {
                 Button {
                     onToggleDisabled()
                 } label: {
@@ -322,7 +356,7 @@ struct AccountRow: View {
             }
 
             // Disable/Enable toggle (only for proxy accounts)
-            if account.source == .proxy, let onToggleDisabled = onToggleDisabled {
+            if account.source.supportsDisable, let onToggleDisabled = onToggleDisabled {
                 Button {
                     onToggleDisabled()
                 } label: {

--- a/Quotio/Views/Components/CurrentModeBadge.swift
+++ b/Quotio/Views/Components/CurrentModeBadge.swift
@@ -74,7 +74,7 @@ struct CurrentModeBadge: View {
     private var statusText: String {
         switch modeManager.currentMode {
         case .monitor:
-            let count = viewModel.directAuthFiles.count
+            let count = viewModel.monitorAccounts.count
             return String(format: "sidebar.modeBadge.accounts".localized(), count)
         case .localProxy:
             if viewModel.proxyManager.proxyStatus.running {

--- a/Quotio/Views/Screens/DashboardScreen.swift
+++ b/Quotio/Views/Screens/DashboardScreen.swift
@@ -45,7 +45,7 @@ struct DashboardScreen: View {
     
     /// Unique provider count from direct auth files
     private var directProvidersCount: Int {
-        Set(viewModel.directAuthFiles.map { $0.provider }).count
+        Set(viewModel.monitorAccounts.map { $0.provider }).count
     }
     
     /// Lowest quota percentage across all providers using total usage logic
@@ -67,8 +67,8 @@ struct DashboardScreen: View {
     }
     
     /// Grouped accounts by provider (cached computation)
-    private var groupedDirectAuthFiles: [AIProvider: [DirectAuthFile]] {
-        Dictionary(grouping: viewModel.directAuthFiles) { $0.provider }
+    private var groupedMonitorAccounts: [AIProvider: [MonitorAccount]] {
+        Dictionary(grouping: viewModel.monitorAccounts) { $0.provider }
     }
     
     var body: some View {
@@ -98,7 +98,9 @@ struct DashboardScreen: View {
             ToolbarItem(placement: .primaryAction) {
                 Button {
                     Task {
-                        if modeManager.isLocalProxyMode && viewModel.proxyManager.proxyStatus.running {
+                        if modeManager.isMonitorMode {
+                            await viewModel.manualRefresh()
+                        } else if modeManager.isLocalProxyMode && viewModel.proxyManager.proxyStatus.running {
                             await viewModel.refreshData()
                         } else {
                             await viewModel.refreshQuotasUnified()
@@ -115,7 +117,13 @@ struct DashboardScreen: View {
                 selectedProvider = nil
                 projectId = ""
                 viewModel.oauthState = nil
-                Task { await viewModel.refreshData() }
+                Task {
+                    if modeManager.isMonitorMode {
+                        await viewModel.manualRefresh()
+                    } else {
+                        await viewModel.refreshData()
+                    }
+                }
             }
             .environment(viewModel)
         }
@@ -338,7 +346,7 @@ struct DashboardScreen: View {
         LazyVGrid(columns: [GridItem(.adaptive(minimum: 180), spacing: 16)], spacing: 16) {
             KPICard(
                 title: "dashboard.trackedAccounts".localized(),
-                value: "\(viewModel.directAuthFiles.count)",
+                value: "\(viewModel.monitorAccounts.count)",
                 subtitle: "dashboard.accounts".localized(),
                 icon: "person.2.fill",
                 color: .blue
@@ -420,7 +428,7 @@ struct DashboardScreen: View {
     
     private var trackedAccountsSection: some View {
         GroupBox {
-            if viewModel.directAuthFiles.isEmpty {
+            if viewModel.monitorAccounts.isEmpty {
                 VStack(spacing: 12) {
                     Image(systemName: "person.crop.circle.badge.questionmark")
                         .font(.largeTitle)
@@ -439,9 +447,8 @@ struct DashboardScreen: View {
                 .padding(.vertical, 20)
             } else {
                 VStack(alignment: .leading, spacing: 8) {
-                    // Use precomputed groupedDirectAuthFiles instead of inline Dictionary(grouping:)
-                    ForEach(AIProvider.allCases.filter { groupedDirectAuthFiles[$0] != nil }) { provider in
-                        if let accounts = groupedDirectAuthFiles[provider] {
+                    ForEach(AIProvider.allCases.filter { groupedMonitorAccounts[$0] != nil }) { provider in
+                        if let accounts = groupedMonitorAccounts[provider] {
                             HStack(spacing: 12) {
                                 ProviderIcon(provider: provider, size: 20)
                                 

--- a/Quotio/Views/Screens/ProvidersScreen.swift
+++ b/Quotio/Views/Screens/ProvidersScreen.swift
@@ -54,6 +54,16 @@ struct ProvidersScreen: View {
                 let data = AccountRowData.from(authFile: file)
                 groups[provider, default: []].append(data)
             }
+        } else if modeManager.isMonitorMode {
+            for account in viewModel.monitorAccounts where ![.glm, .warp, .clinePass].contains(account.provider) {
+                let state = viewModel.monitorStatus(for: account)
+                let data = AccountRowData.from(
+                    monitorAccount: account,
+                    status: state.status,
+                    statusMessage: state.message
+                )
+                groups[account.provider, default: []].append(data)
+            }
         } else {
             // From direct auth files (proxy not running or quota-only mode)
             for file in viewModel.directAuthFiles {
@@ -64,7 +74,7 @@ struct ProvidersScreen: View {
 
         // Add auto-detected accounts (Cursor, Trae)
         // API-key providers are added from their own storage below.
-        for (provider, quotas) in viewModel.providerQuotas {
+        for (provider, quotas) in viewModel.providerQuotas where !modeManager.isMonitorMode {
             if !provider.supportsManualAuth && provider != .glm && provider != .clinePass {
                 for (accountKey, _) in quotas {
                     let data = AccountRowData.from(provider: provider, accountKey: accountKey)
@@ -268,12 +278,16 @@ struct ProvidersScreen: View {
         ToolbarItem(placement: .automatic) {
             Button {
                 Task {
-        if modeManager.isLocalProxyMode && viewModel.proxyManager.proxyStatus.running {
+                    if modeManager.isMonitorMode {
+                        await viewModel.manualRefresh()
+                    } else if modeManager.isLocalProxyMode && viewModel.proxyManager.proxyStatus.running {
                         await viewModel.refreshData()
                     } else {
                         await viewModel.loadDirectAuthFiles()
                     }
-                    await viewModel.refreshAutoDetectedProviders()
+                    if !modeManager.isMonitorMode {
+                        await viewModel.refreshAutoDetectedProviders()
+                    }
                 }
             } label: {
                 if viewModel.isLoadingQuotas {
@@ -430,6 +444,11 @@ struct ProvidersScreen: View {
         // Only proxy accounts can be deleted via API
         guard account.canDelete else { return }
 
+        if modeManager.isMonitorMode, case .monitor = account.source {
+            await viewModel.deleteMonitorAccount(accountID: account.id)
+            return
+        }
+
         // Handle GLM accounts (stored in CustomProviderService)
         if account.provider == .glm {
             // GLM accounts are stored as custom providers
@@ -466,7 +485,11 @@ struct ProvidersScreen: View {
     }
 
     private func toggleAccountDisabled(_ account: AccountRowData) async {
-        // Only proxy accounts can be disabled via API
+        if modeManager.isMonitorMode, case .monitor = account.source {
+            await viewModel.setMonitorAccountDisabled(!account.isDisabled, accountID: account.id)
+            return
+        }
+
         guard account.source == .proxy else { return }
 
         // Find the original AuthFile to toggle
@@ -778,6 +801,8 @@ struct OAuthSheet: View {
     
     @State private var hasStartedAuth = false
     @State private var selectedKiroMethod: AuthCommand = .kiroImport
+    @State private var manualOAuthCode = ""
+    @State private var modeManager = OperatingModeManager.shared
     
     private var isPolling: Bool {
         viewModel.oauthState?.status == .polling || viewModel.oauthState?.status == .waiting
@@ -792,7 +817,8 @@ struct OAuthSheet: View {
     }
     
     private var kiroAuthMethods: [AuthCommand] {
-        [.kiroImport, .kiroGoogleLogin, .kiroAWSAuthCode, .kiroAWSLogin]
+        if modeManager.isMonitorMode { return [.kiroAWSLogin] }
+        return [.kiroImport, .kiroGoogleLogin, .kiroAWSAuthCode, .kiroAWSLogin]
     }
     
     var body: some View {
@@ -838,7 +864,8 @@ struct OAuthSheet: View {
                 .frame(maxWidth: 320)
             }
 
-            if viewModel.proxyManager.isLegacyAuthWarningNeeded(for: provider),
+            if !modeManager.isMonitorMode,
+               viewModel.proxyManager.isLegacyAuthWarningNeeded(for: provider),
                let warning = viewModel.proxyManager.selectedBinarySourceWarning {
                 HStack(alignment: .top, spacing: 8) {
                     Image(systemName: "exclamationmark.triangle.fill")
@@ -856,6 +883,19 @@ struct OAuthSheet: View {
             if let state = viewModel.oauthState, state.provider == provider {
                 OAuthStatusView(status: state.status, error: state.error, state: state.state, authURL: state.authURL, provider: provider)
                     .transition(.opacity.combined(with: .scale(scale: 0.95)))
+            }
+
+            if modeManager.isMonitorMode, provider == .claude, viewModel.oauthState?.status == .polling {
+                HStack(spacing: 8) {
+                    TextField("oauth.authorizationCode".localized(), text: $manualOAuthCode)
+                        .textFieldStyle(.roundedBorder)
+                    Button("oauth.complete".localized()) {
+                        Task { await viewModel.completeMonitorOAuthCode(manualOAuthCode, provider: provider) }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(manualOAuthCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+                .frame(maxWidth: 360)
             }
             
             HStack(spacing: 16) {
@@ -961,7 +1001,7 @@ private struct OAuthStatusView: View {
                     }
                     
                     // For Copilot Device Code flow, show device code with copy button
-                    if provider == .copilot, let deviceCode = state, !deviceCode.isEmpty {
+                    if (provider == .copilot || provider == .kiro), let deviceCode = state, !deviceCode.isEmpty {
                         VStack(spacing: 8) {
                             Text("oauth.enterCodeInBrowser".localized())
                                 .font(.subheadline)
@@ -991,7 +1031,7 @@ private struct OAuthStatusView: View {
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
-                    } else if provider == .copilot, let message = error {
+                    } else if (provider == .copilot || provider == .kiro), let message = error {
                         Text(message)
                             .font(.caption)
                             .foregroundStyle(.primary)

--- a/Quotio/Views/Screens/QuotaScreen.swift
+++ b/Quotio/Views/Screens/QuotaScreen.swift
@@ -70,7 +70,7 @@ struct QuotaScreen: View {
     /// Check if we have any data to show
     private var hasAnyData: Bool {
         if modeManager.isMonitorMode {
-            return !viewModel.providerQuotas.isEmpty || !viewModel.directAuthFiles.isEmpty
+            return !viewModel.providerQuotas.isEmpty || !viewModel.monitorAccounts.isEmpty
         }
         return !viewModel.authFiles.isEmpty || !viewModel.providerQuotas.isEmpty
     }
@@ -128,7 +128,11 @@ struct QuotaScreen: View {
                 ToolbarItem(placement: .primaryAction) {
                 Button {
                     Task {
-                        await viewModel.refreshQuotasUnified()
+                        if modeManager.isMonitorMode {
+                            await viewModel.manualRefresh()
+                        } else {
+                            await viewModel.refreshQuotasUnified()
+                        }
                     }
                 } label: {
                     Image(systemName: "arrow.clockwise")
@@ -365,18 +369,9 @@ private struct ProviderQuotaView: View {
         // Only Codex needs direct-auth email backfill because its quota key is
         // filename-based to distinguish same-email Plus/Team accounts.
         let directAuthEmailsByKey: [String: String] = provider == .codex
-            ? Dictionary(
-                grouping: viewModel.directAuthFiles
-                    .lazy
-                    .filter { $0.provider == .codex },
-                by: { $0.filename.codexFilenameKey }
-            ).reduce(into: [:]) { result, entry in
-                let (key, files) = entry
-                // Ambiguous normalized keys should keep the quota key as-is
-                // instead of guessing which email to display.
-                guard !key.isEmpty, files.count == 1 else { return }
-                result[key] = files[0].email ?? files[0].displayName
-            }
+            ? viewModel.monitorAccounts
+                .filter { $0.provider == .codex }
+                .reduce(into: [:]) { $0[$1.accountKey] = $1.displayName }
             : [:]
         for (key, data) in quotaData {
             if !existingKeys.contains(key) {

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -2,6 +2,37 @@ import XCTest
 @testable import Quotio
 
 final class MonitorRuntimeTests: XCTestCase {
+    func testLegacyCodexAccountsUseDistinctFilenameKeysForSameEmail() {
+        let plus = DirectAuthFile(
+            id: "plus",
+            provider: .codex,
+            email: "same@example.com",
+            login: nil,
+            expired: nil,
+            accountType: "plus",
+            filePath: "/tmp/codex-same@example.com-plus.json",
+            source: .cliProxyApi,
+            filename: "codex-same@example.com-plus.json"
+        )
+        let team = DirectAuthFile(
+            id: "team",
+            provider: .codex,
+            email: "same@example.com",
+            login: nil,
+            expired: nil,
+            accountType: "team",
+            filePath: "/tmp/codex-same@example.com-team.json",
+            source: .cliProxyApi,
+            filename: "codex-same@example.com-team.json"
+        )
+
+        let accounts = [plus, team].map(MonitorAccount.makeLegacy)
+
+        let expectedKeys = Set(["same@example.com-plus", "same@example.com-team"])
+        XCTAssertEqual(Set(accounts.map(\.accountKey)), expectedKeys)
+        XCTAssertEqual(Set(accounts.map(\.deduplicationKey)).count, 2)
+    }
+
     private actor Counter {
         var value = 0
         func increment() { value += 1 }

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -1,0 +1,183 @@
+import XCTest
+@testable import Quotio
+
+final class MonitorRuntimeTests: XCTestCase {
+    private actor Counter {
+        var value = 0
+        func increment() { value += 1 }
+    }
+
+    func testStableAccountIDDoesNotDependOnSource() {
+        let native = MonitorAccount.make(
+            provider: .codex,
+            accountKey: "User@Example.com",
+            source: .nativeCredential
+        )
+        let legacy = MonitorAccount.make(
+            provider: .codex,
+            accountKey: "user@example.com",
+            source: .legacyCLIProxy
+        )
+
+        XCTAssertEqual(native.id, legacy.id)
+        XCTAssertEqual(native.deduplicationKey, legacy.deduplicationKey)
+    }
+
+    func testDiscoveryPrefersQuotioThenNativeThenLegacy() {
+        let legacy = MonitorAccount.make(provider: .codex, accountKey: "same@example.com", source: .legacyCLIProxy)
+        let native = MonitorAccount.make(provider: .codex, accountKey: "same@example.com", source: .nativeCredential)
+        let owned = MonitorAccount.make(provider: .codex, accountKey: "same@example.com", source: .quotioKeychain, canDelete: true)
+
+        let selected = MonitorAccountDiscovery.selectPreferred([legacy, native, owned])
+
+        XCTAssertEqual(selected.count, 1)
+        XCTAssertEqual(selected.first?.source, .quotioKeychain)
+        XCTAssertEqual(selected.first?.canDelete, true)
+    }
+
+    func testSnapshotRoundTripUsesIsolatedTemporaryDirectory() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let url = directory.appendingPathComponent("snapshots-v1.json")
+        let store = MonitorSnapshotStore(url: url)
+        let quota = ProviderQuotaData(
+            models: [ModelQuota(name: "test", percentage: 42, resetTime: "")],
+            lastUpdated: Date(timeIntervalSince1970: 1234)
+        )
+
+        await store.store([.codex: ["account": quota]])
+        let loaded = await store.load()
+
+        XCTAssertEqual(loaded[.codex]?["account"]?.models.first?.percentage, 42)
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        XCTAssertEqual((attributes[.posixPermissions] as? NSNumber)?.intValue, 0o600)
+    }
+
+    func testMetadataRoundTripStoresOwnedAccountAndDisabledState() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("accounts-v1.json")
+        let store = MonitorMetadataStore(url: url)
+        let account = MonitorAccount.make(
+            provider: .gemini,
+            accountKey: "test@example.com",
+            source: .quotioKeychain,
+            canDelete: true
+        )
+
+        try await store.saveAccount(account)
+        try await store.setDisabled(true, accountID: account.id)
+
+        let accounts = await store.accounts()
+        let disabled = await store.disabledAccountIDs()
+        XCTAssertEqual(accounts, [account])
+        XCTAssertEqual(disabled, Set([account.id]))
+    }
+
+    func testCoordinatorRetainsLastGoodQuotaOnTransientFailure() async {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let coordinator = MonitorRefreshCoordinator(
+            snapshots: MonitorSnapshotStore(url: directory.appendingPathComponent("snapshot.json"))
+        )
+        let previous = ProviderQuotaData(
+            models: [ModelQuota(name: "test", percentage: 75, resetTime: "")],
+            lastUpdated: Date()
+        )
+
+        let result = await coordinator.refresh(
+            provider: .codex,
+            force: true,
+            previous: ["account": previous],
+            operation: { [:] }
+        )
+
+        XCTAssertEqual(result["account"]?.models.first?.percentage, 75)
+        let issues = await coordinator.currentIssues()
+        XCTAssertNotNil(issues[.codex])
+    }
+
+    func testCoordinatorCoalescesConcurrentRefreshForProvider() async {
+        let coordinator = MonitorRefreshCoordinator()
+        let counter = Counter()
+        async let first = coordinator.refresh(provider: .codex, force: true, previous: [:]) {
+            await counter.increment()
+            try? await Task.sleep(for: .milliseconds(50))
+            return ["account": ProviderQuotaData(models: [], lastUpdated: Date())]
+        }
+        async let second = coordinator.refresh(provider: .codex, force: true, previous: [:]) {
+            await counter.increment()
+            return ["other": ProviderQuotaData(models: [], lastUpdated: Date())]
+        }
+
+        _ = await (first, second)
+        let coalescedCount = await counter.value
+        XCTAssertEqual(coalescedCount, 1)
+    }
+
+    func testManualRefreshBypassesProviderBackoff() async {
+        let coordinator = MonitorRefreshCoordinator()
+        let counter = Counter()
+        let previous = ["account": ProviderQuotaData(models: [], lastUpdated: Date())]
+        _ = await coordinator.refresh(provider: .codex, force: true, previous: previous) { [:] }
+        _ = await coordinator.refresh(provider: .codex, force: false, previous: previous) {
+            await counter.increment()
+            return [:]
+        }
+        let backedOffCount = await counter.value
+        XCTAssertEqual(backedOffCount, 0)
+
+        _ = await coordinator.refresh(provider: .codex, force: true, previous: previous) {
+            await counter.increment()
+            return previous
+        }
+        let forcedCount = await counter.value
+        XCTAssertEqual(forcedCount, 1)
+    }
+
+    func testAtomicWriterRefusesSymbolicLinkDestination() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let target = directory.appendingPathComponent("target.json")
+        let link = directory.appendingPathComponent("link.json")
+        try Data("old".utf8).write(to: target)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        XCTAssertThrowsError(try SecureAtomicFileWriter.write(Data("new".utf8), to: link))
+        XCTAssertEqual(try String(contentsOf: target, encoding: .utf8), "old")
+    }
+
+    func testLoopbackCallbackReturnsCodeAndState() async throws {
+        let server = MonitorOAuthCallbackServer()
+        let port = try await server.start()
+        async let callback = server.waitForCallback(timeout: .seconds(2))
+
+        let url = URL(string: "http://127.0.0.1:\(port)/oauth2callback?code=test-code&state=test-state")!
+        _ = try await URLSession.shared.data(from: url)
+        let result = try await callback
+        let items = URLComponents(url: result, resolvingAgainstBaseURL: false)?.queryItems
+
+        XCTAssertEqual(items?.first(where: { $0.name == "code" })?.value, "test-code")
+        XCTAssertEqual(items?.first(where: { $0.name == "state" })?.value, "test-state")
+    }
+
+    func testLoopbackCallbackTimesOut() async throws {
+        let server = MonitorOAuthCallbackServer()
+        _ = try await server.start()
+        do {
+            _ = try await server.waitForCallback(timeout: .milliseconds(30))
+            XCTFail("Expected timeout")
+        } catch MonitorOAuthError.expired {
+            // Expected.
+        }
+    }
+
+    func testOAuthCallbackRejectsMismatchedState() throws {
+        let callback = URL(string: "http://localhost/callback?code=test&state=unexpected")!
+        XCTAssertThrowsError(
+            try MonitorOAuthCoordinator.authorizationCode(from: callback, expectedState: "expected")
+        ) { error in
+            guard case MonitorOAuthError.stateMismatch = error else {
+                return XCTFail("Expected state mismatch")
+            }
+        }
+    }
+}

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -2,6 +2,18 @@ import XCTest
 @testable import Quotio
 
 final class MonitorRuntimeTests: XCTestCase {
+    func testMonitorProvidersDoNotRequireInstalledCLI() {
+        let providers: Set<AIProvider> = [.codex, .claude, .gemini]
+
+        let filtered = StatusBarMenuBuilder.filterProviders(
+            providers,
+            isMonitorMode: true,
+            isCLIInstalled: { _ in false }
+        )
+
+        XCTAssertEqual(Set(filtered), providers)
+    }
+
     func testDiscoveryCanonicalizesNativeCodexAccountBeforeDeduplication() {
         let legacy = MonitorAccount.make(
             provider: .codex,

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -14,6 +14,35 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertEqual(Set(filtered), providers)
     }
 
+    func testStatusBarIncludesEnabledMonitorAccountsWithoutQuota() {
+        let enabled = MonitorAccount.make(
+            provider: .claude,
+            accountKey: "enabled@example.com",
+            source: .nativeCredential
+        )
+        var disabled = MonitorAccount.make(
+            provider: .gemini,
+            accountKey: "disabled@example.com",
+            source: .nativeCredential
+        )
+        disabled.isDisabled = true
+
+        XCTAssertEqual(StatusBarMenuBuilder.monitorProviders([enabled, disabled]), Set([.claude]))
+    }
+
+    func testMonitorAccountSourcesUseLocalizationKeys() {
+        XCTAssertEqual(
+            Set(MonitorAccountSource.allCases.map(\.localizationKey)),
+            Set([
+                "monitor.source.quotio",
+                "monitor.source.localLogin",
+                "monitor.source.cliProxyFile",
+                "monitor.source.localIDE",
+                "monitor.source.apiKey",
+            ])
+        )
+    }
+
     func testDiscoveryCanonicalizesNativeCodexAccountBeforeDeduplication() {
         let legacy = MonitorAccount.make(
             provider: .codex,
@@ -201,6 +230,23 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertEqual(disabled, Set([account.id]))
     }
 
+    func testQuotaDerivedAccountPreservesDisabledState() {
+        let account = MonitorAccount.make(
+            provider: .cursor,
+            accountKey: "cursor@example.com",
+            source: .localIDE
+        )
+
+        let derived = MonitorRefreshCoordinator.makeQuotaDerivedAccount(
+            provider: .cursor,
+            accountKey: account.accountKey,
+            source: .localIDE,
+            disabledIDs: [account.id]
+        )
+
+        XCTAssertTrue(derived.isDisabled)
+    }
+
     func testCoordinatorRetainsLastGoodQuotaOnTransientFailure() async {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let coordinator = MonitorRefreshCoordinator(
@@ -221,6 +267,77 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertEqual(result["account"]?.models.first?.percentage, 75)
         let issues = await coordinator.currentIssues()
         XCTAssertNotNil(issues[.codex])
+    }
+
+    func testCoordinatorRemovesStaleQuotaWhenCredentialsAreMissing() async {
+        let coordinator = MonitorRefreshCoordinator()
+        let previous = ["account": ProviderQuotaData(models: [], lastUpdated: Date())]
+
+        let result = await coordinator.refresh(
+            provider: .codex,
+            force: true,
+            previous: previous,
+            credentialAvailability: .missing,
+            operation: { [:] }
+        )
+
+        XCTAssertTrue(result.isEmpty)
+        let issues = await coordinator.currentIssues()
+        XCTAssertNil(issues[.codex])
+    }
+
+    func testMonitorStatusDoesNotBorrowSiblingTimestamp() {
+        let account = MonitorAccount.make(
+            provider: .claude,
+            accountKey: "failed@example.com",
+            source: .nativeCredential
+        )
+        let sibling = ProviderQuotaData(models: [], lastUpdated: Date())
+
+        let updated = QuotaViewModel.monitorLastUpdated(
+            for: account,
+            providerQuotas: [.claude: ["successful@example.com": sibling]]
+        )
+
+        XCTAssertNil(updated)
+    }
+
+    func testKiroFallbackAccountKeysDoNotCollide() {
+        let first = MonitorOAuthCoordinator.kiroAccountKey(identity: nil, clientID: "client-1")
+        let second = MonitorOAuthCoordinator.kiroAccountKey(identity: nil, clientID: "client-2")
+
+        XCTAssertNotEqual(first, second)
+        XCTAssertEqual(
+            MonitorOAuthCoordinator.kiroAccountKey(identity: "builder@example.com", clientID: "client-1"),
+            "builder@example.com"
+        )
+    }
+
+    func testNumericCamelCaseKiroExpiryIsParsed() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("kiro.json")
+        let timestamp = 1_900_000_000.0
+        let data = try JSONSerialization.data(withJSONObject: [
+            "accessToken": "test-access-token",
+            "expiresAt": timestamp,
+        ])
+        try data.write(to: url)
+        let file = DirectAuthFile(
+            id: url.path,
+            provider: .kiro,
+            email: nil,
+            login: nil,
+            expired: nil,
+            accountType: nil,
+            filePath: url.path,
+            source: .nativeCredential,
+            filename: url.lastPathComponent
+        )
+
+        let token = await DirectAuthFileService().readAuthToken(from: file)
+
+        XCTAssertEqual(token?.expiresAt, ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: timestamp)))
     }
 
     func testCoordinatorCoalescesConcurrentRefreshForProvider() async {

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -2,6 +2,37 @@ import XCTest
 @testable import Quotio
 
 final class MonitorRuntimeTests: XCTestCase {
+    func testDiscoveryCanonicalizesNativeCodexAccountBeforeDeduplication() {
+        let legacy = MonitorAccount.make(
+            provider: .codex,
+            accountKey: "same@example.com-pro",
+            displayName: "same@example.com",
+            source: .legacyCLIProxy
+        )
+        let native = MonitorAccount.make(
+            provider: .codex,
+            accountKey: "same@example.com",
+            source: .nativeCredential
+        )
+
+        let canonicalNative = MonitorAccountDiscovery.canonicalizeCodexAccount(
+            native,
+            accountID: "account-1",
+            aliases: ["account-1": "same@example.com-pro"]
+        )
+        let duplicate = MonitorAccountDiscovery.selectPreferred([legacy, canonicalNative])
+        XCTAssertEqual(duplicate.count, 1)
+        XCTAssertEqual(duplicate.first?.accountKey, "same@example.com-pro")
+        XCTAssertEqual(duplicate.first?.source, .nativeCredential)
+
+        let distinctNative = MonitorAccountDiscovery.canonicalizeCodexAccount(
+            native,
+            accountID: "account-2",
+            aliases: ["account-1": "same@example.com-pro"]
+        )
+        XCTAssertEqual(MonitorAccountDiscovery.selectPreferred([legacy, distinctNative]).count, 2)
+    }
+
     func testCodexQuotaReconciliationRemovesOnlyLegacyAliases() {
         let quota = ProviderQuotaData(models: [], lastUpdated: Date())
         let legacy = [

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -2,6 +2,60 @@ import XCTest
 @testable import Quotio
 
 final class MonitorRuntimeTests: XCTestCase {
+    func testCodexQuotaReconciliationRemovesOnlyLegacyAliases() {
+        let quota = ProviderQuotaData(models: [], lastUpdated: Date())
+        let legacy = [
+            CodexQuotaAccountIdentity(
+                key: "same@example.com-pro",
+                email: "same@example.com",
+                accountID: "account-1"
+            ),
+            CodexQuotaAccountIdentity(
+                key: "same@example.com-team",
+                email: "same@example.com",
+                accountID: "account-2"
+            ),
+        ]
+        let quotas = [
+            "same@example.com": quota,
+            "same@example.com-pro": quota,
+            "same@example.com-team": quota,
+        ]
+
+        let duplicate = CodexCLIQuotaFetcher.reconcileLegacyAliases(
+            in: quotas,
+            legacy: legacy,
+            current: [
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com",
+                    email: "same@example.com",
+                    accountID: "account-1"
+                ),
+            ]
+        )
+        XCTAssertEqual(Set(duplicate.keys), Set(["same@example.com-pro", "same@example.com-team"]))
+
+        let distinct = CodexCLIQuotaFetcher.reconcileLegacyAliases(
+            in: quotas,
+            legacy: legacy,
+            current: [
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com",
+                    email: "same@example.com",
+                    accountID: "account-3"
+                ),
+            ]
+        )
+        XCTAssertEqual(Set(distinct.keys), Set(quotas.keys))
+
+        let stale = CodexCLIQuotaFetcher.reconcileLegacyAliases(
+            in: quotas,
+            legacy: legacy,
+            current: []
+        )
+        XCTAssertEqual(Set(stale.keys), Set(["same@example.com-pro", "same@example.com-team"]))
+    }
+
     func testLegacyCodexAccountsUseDistinctFilenameKeysForSameEmail() {
         let plus = DirectAuthFile(
             id: "plus",


### PR DESCRIPTION
## Summary

- run Monitor mode quota discovery and refresh independently from CLIProxyAPI
- preserve Codex account identities and deduplicate legacy aliases across the app and menu bar
- keep Monitor providers visible even when their CLI binaries are not installed
- isolate app-hosted unit tests from production bootstrap and Keychain access
- cover the monitor runtime behavior with regression tests

## Why

Monitor mode still had two hidden runtime dependencies: the menu bar filtered providers by installed CLI binaries, and the app-hosted test target launched the production bootstrap before tests could run. This PR removes both dependencies so Monitor mode and its tests operate independently as intended.

## Validation

- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug -derivedDataPath /tmp/quotio-monitor-review-derived test` (15/15 passed)
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug -derivedDataPath /tmp/quotio-monitor-review-derived build`
