### PR TITLE
Expand Monitor mode quota providers

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -8231,6 +8231,14 @@
         }
       }
     },
+    "glm.endpoint.zaiGlobal" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Z.ai Global" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Z.ai mondial" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Z.ai Toàn cầu" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Z.ai 全球" } }
+      }
+    },
     "glm.endpointHint" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -22532,169 +22540,225 @@
     "factory.apiKey.hint" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Stored securely in Keychain and never shown again." } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Được lưu an toàn trong Keychain và không hiển thị lại." } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Stockée en toute sécurité dans le trousseau et ne sera plus jamais affichée." } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Được lưu an toàn trong Keychain và không hiển thị lại." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "安全存储在钥匙串中，之后不会再次显示。" } }
       }
     },
     "factory.apiKey.label" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Factory API Key" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Factory API Key" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Clé API Factory" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Factory API Key" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Factory API 密钥" } }
       }
     },
     "factory.apiKey.placeholder" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Enter your Factory API key" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhập Factory API key" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Saisissez votre clé API Factory" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhập Factory API key" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "输入您的 Factory API 密钥" } }
       }
     },
     "factory.apiKey.rotateHint" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Enter a replacement key. The current key is never revealed." } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhập key thay thế. Key hiện tại không bao giờ được hiển thị." } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Saisissez une clé de remplacement. La clé actuelle n’est jamais révélée." } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhập key thay thế. Key hiện tại không bao giờ được hiển thị." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "输入替换密钥。当前密钥绝不会显示。" } }
       }
     },
     "factory.connection.edit" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Rotate Factory Droid Key" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Thay Factory Droid Key" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Remplacer la clé Factory Droid" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Thay Factory Droid Key" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "更换 Factory Droid 密钥" } }
       }
     },
     "factory.connection.subtitle" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Monitor Factory Droid limits without proxy routing" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Theo dõi giới hạn Factory Droid, không dùng proxy routing" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Surveillez les limites de Factory Droid sans routage proxy" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Theo dõi giới hạn Factory Droid, không dùng proxy routing" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "无需代理路由即可监控 Factory Droid 限额" } }
       }
     },
     "factory.connection.title" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Connect Factory Droid" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Kết nối Factory Droid" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Connecter Factory Droid" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Kết nối Factory Droid" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "连接 Factory Droid" } }
       }
     },
     "factory.label.placeholder" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Account label" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhãn tài khoản" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Libellé du compte" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhãn tài khoản" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "账户标签" } }
       }
     },
     "factory.quota.billingMode" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Billing Mode" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Chế độ thanh toán" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Mode de facturation" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Chế độ thanh toán" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "计费模式" } }
       }
     },
     "factory.quota.coreFiveHour" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "5-hour" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "5 giờ" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "5 heures" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "5 giờ" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "5 小时" } }
       }
     },
     "factory.quota.coreMonthly" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Monthly" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tháng" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Mensuel" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tháng" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "每月" } }
       }
     },
     "factory.quota.coreWeekly" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Weekly" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tuần" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Hebdomadaire" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tuần" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "每周" } }
       }
     },
     "factory.quota.group.core" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Core" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Core" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Core" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Core" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "核心" } }
       }
     },
     "factory.quota.group.standard" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Standard" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Standard" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Standard" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Standard" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "标准" } }
       }
     },
     "factory.quota.standardFiveHour" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "5-hour" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "5 giờ" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "5 heures" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "5 giờ" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "5 小时" } }
       }
     },
     "factory.quota.standardMonthly" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Monthly" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tháng" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Mensuel" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tháng" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "每月" } }
       }
     },
     "factory.quota.standardWeekly" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Weekly" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tuần" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Hebdomadaire" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tuần" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "每周" } }
       }
     },
     "factory.status.legacyBilling" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Legacy billing" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Thanh toán kiểu cũ" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Facturation héritée" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Thanh toán kiểu cũ" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "旧版计费" } }
       }
     },
     "grok.status.cap" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ cap" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Giới hạn %@" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Plafond de %@" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Giới hạn %@" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "%@ 上限" } }
       }
     },
     "grok.status.disabled" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Disabled" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đã tắt" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Désactivé" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đã tắt" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "已停用" } }
       }
     },
     "openrouter.apiKey.hint" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Stored securely in Keychain and never shown again." } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Được lưu an toàn trong Keychain và không hiển thị lại." } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Stockée en toute sécurité dans le trousseau et ne sera plus jamais affichée." } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Được lưu an toàn trong Keychain và không hiển thị lại." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "安全存储在钥匙串中，之后不会再次显示。" } }
       }
     },
     "openrouter.apiKey.label" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "OpenRouter API Key" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "OpenRouter API Key" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Clé API OpenRouter" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "OpenRouter API Key" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "OpenRouter API 密钥" } }
       }
     },
     "openrouter.apiKey.placeholder" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Enter your OpenRouter API key" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhập OpenRouter API key" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Saisissez votre clé API OpenRouter" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhập OpenRouter API key" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "输入您的 OpenRouter API 密钥" } }
       }
     },
     "openrouter.apiKey.rotateHint" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Enter a replacement key. The current key is never revealed." } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhập key thay thế. Key hiện tại không bao giờ được hiển thị." } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Saisissez une clé de remplacement. La clé actuelle n’est jamais révélée." } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhập key thay thế. Key hiện tại không bao giờ được hiển thị." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "输入替换密钥。当前密钥绝不会显示。" } }
       }
     },
     "openrouter.connection.edit" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Rotate OpenRouter Key" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Thay OpenRouter Key" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Remplacer la clé OpenRouter" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Thay OpenRouter Key" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "更换 OpenRouter 密钥" } }
       }
     },
     "openrouter.connection.subtitle" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Monitor credits and API-key spend without proxy routing" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Theo dõi credits và chi tiêu API key, không dùng proxy routing" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Surveillez les crédits et les dépenses de la clé API sans routage proxy" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Theo dõi credits và chi tiêu API key, không dùng proxy routing" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "无需代理路由即可监控额度和 API 密钥支出" } }
       }
     },
     "openrouter.connection.title" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Connect OpenRouter" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Kết nối OpenRouter" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Connecter OpenRouter" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Kết nối OpenRouter" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "连接 OpenRouter" } }
       }
     },
     "openrouter.label.placeholder" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Account label" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhãn tài khoản" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Libellé du compte" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhãn tài khoản" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "账户标签" } }
       }
     },
     "openrouter.plan.freeTier" : {
@@ -22716,25 +22780,33 @@
     "quota.metric.balance" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Balance" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Số dư" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Solde" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Số dư" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "余额" } }
       }
     },
     "quota.metric.balanceValue" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ left" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Còn %@" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "%@ restant" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Còn %@" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "剩余 %@" } }
       }
     },
     "quota.metric.credits" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Credits" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Credits" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Crédits" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Credits" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "额度" } }
       }
     },
     "quota.metric.daily" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Daily" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng ngày" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Quotidien" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng ngày" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "每日" } }
       }
     },
     "quota.metric.monthly" : {
@@ -22748,49 +22820,65 @@
     "quota.metric.extraBalance" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Extra Balance" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Số dư bổ sung" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Solde supplémentaire" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Số dư bổ sung" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "额外余额" } }
       }
     },
     "quota.metric.extraUsage" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Extra Usage" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Mức dùng thêm" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Utilisation supplémentaire" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Mức dùng thêm" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "额外用量" } }
       }
     },
     "quota.metric.keyLimit" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Key Limit" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Giới hạn key" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Limite de la clé" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Giới hạn key" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "密钥限额" } }
       }
     },
     "quota.metric.session" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Session" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Phiên" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Session" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Phiên" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "会话" } }
       }
     },
     "quota.metric.spentValue" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ spent" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đã dùng %@" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "%@ dépensé" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đã dùng %@" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "已花费 %@" } }
       }
     },
     "quota.metric.thisMonth" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "This Month" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Tháng này" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ce mois-ci" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Tháng này" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "本月" } }
       }
     },
     "quota.metric.thisWeek" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "This Week" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Tuần này" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Cette semaine" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Tuần này" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "本周" } }
       }
     },
     "quota.metric.today" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Today" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hôm nay" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Aujourd’hui" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hôm nay" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "今天" } }
       }
     },
     "quota.metric.unit.credits" : {
@@ -22898,13 +22986,17 @@
     "quota.metric.webSearches" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Web Searches" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Tìm kiếm web" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Recherches web" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Tìm kiếm web" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "网页搜索" } }
       }
     },
     "quota.metric.weekly" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Weekly" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tuần" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Hebdomadaire" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tuần" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "每周" } }
       }
     },
     "warp.token.placeholder" : {

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -22529,6 +22529,126 @@
         }
       }
     },
+    "factory.apiKey.hint" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Stored securely in Keychain and never shown again." } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Được lưu an toàn trong Keychain và không hiển thị lại." } }
+      }
+    },
+    "factory.apiKey.label" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Factory API Key" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Factory API Key" } }
+      }
+    },
+    "factory.apiKey.placeholder" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enter your Factory API key" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhập Factory API key" } }
+      }
+    },
+    "factory.apiKey.rotateHint" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enter a replacement key. The current key is never revealed." } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhập key thay thế. Key hiện tại không bao giờ được hiển thị." } }
+      }
+    },
+    "factory.connection.edit" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Rotate Factory Droid Key" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Thay Factory Droid Key" } }
+      }
+    },
+    "factory.connection.subtitle" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Monitor Factory Droid limits without proxy routing" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Theo dõi giới hạn Factory Droid, không dùng proxy routing" } }
+      }
+    },
+    "factory.connection.title" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Connect Factory Droid" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Kết nối Factory Droid" } }
+      }
+    },
+    "factory.label.placeholder" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Account label" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhãn tài khoản" } }
+      }
+    },
+    "factory.quota.billingMode" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Billing Mode" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Chế độ thanh toán" } }
+      }
+    },
+    "factory.quota.coreFiveHour" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Core · 5-hour" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Core · 5 giờ" } }
+      }
+    },
+    "factory.quota.coreMonthly" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Core · Monthly" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Core · Hàng tháng" } }
+      }
+    },
+    "factory.quota.coreWeekly" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Core · Weekly" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Core · Hàng tuần" } }
+      }
+    },
+    "factory.quota.standardFiveHour" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Standard · 5-hour" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Standard · 5 giờ" } }
+      }
+    },
+    "factory.quota.standardMonthly" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Standard · Monthly" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Standard · Hàng tháng" } }
+      }
+    },
+    "factory.quota.standardWeekly" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Standard · Weekly" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Standard · Hàng tuần" } }
+      }
+    },
+    "factory.status.extraUsageBalance" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enabled · Extra usage balance" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đã bật · Số dư dùng thêm" } }
+      }
+    },
+    "factory.status.extraUsageCore" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enabled · Droid Core" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đã bật · Droid Core" } }
+      }
+    },
+    "factory.status.extraUsageDisabled" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Disabled" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đã tắt" } }
+      }
+    },
+    "factory.status.extraUsageEnabled" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enabled" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đã bật" } }
+      }
+    },
+    "factory.status.legacyBilling" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Legacy billing" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Thanh toán kiểu cũ" } }
+      }
+    },
     "grok.status.cap" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ cap" } },

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -22529,6 +22529,168 @@
         }
       }
     },
+    "grok.status.cap" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ cap" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Giới hạn %@" } }
+      }
+    },
+    "grok.status.disabled" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Disabled" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đã tắt" } }
+      }
+    },
+    "openrouter.apiKey.hint" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Stored securely in Keychain and never shown again." } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Được lưu an toàn trong Keychain và không hiển thị lại." } }
+      }
+    },
+    "openrouter.apiKey.label" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "OpenRouter API Key" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "OpenRouter API Key" } }
+      }
+    },
+    "openrouter.apiKey.placeholder" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enter your OpenRouter API key" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhập OpenRouter API key" } }
+      }
+    },
+    "openrouter.apiKey.rotateHint" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enter a replacement key. The current key is never revealed." } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhập key thay thế. Key hiện tại không bao giờ được hiển thị." } }
+      }
+    },
+    "openrouter.connection.edit" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Rotate OpenRouter Key" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Thay OpenRouter Key" } }
+      }
+    },
+    "openrouter.connection.subtitle" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Monitor credits and API-key spend without proxy routing" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Theo dõi credits và chi tiêu API key, không dùng proxy routing" } }
+      }
+    },
+    "openrouter.connection.title" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Connect OpenRouter" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Kết nối OpenRouter" } }
+      }
+    },
+    "openrouter.label.placeholder" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Account label" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhãn tài khoản" } }
+      }
+    },
+    "quota.metric.balance" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Balance" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Số dư" } }
+      }
+    },
+    "quota.metric.balanceValue" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ left" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Còn %@" } }
+      }
+    },
+    "quota.metric.credits" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Credits" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Credits" } }
+      }
+    },
+    "quota.metric.daily" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Daily" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng ngày" } }
+      }
+    },
+    "quota.metric.extraBalance" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Extra Balance" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Số dư bổ sung" } }
+      }
+    },
+    "quota.metric.extraUsage" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Extra Usage" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Mức dùng thêm" } }
+      }
+    },
+    "quota.metric.keyLimit" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Key Limit" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Giới hạn key" } }
+      }
+    },
+    "quota.metric.session" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Session" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Phiên" } }
+      }
+    },
+    "quota.metric.spentValue" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ spent" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đã dùng %@" } }
+      }
+    },
+    "quota.metric.thisMonth" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "This Month" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Tháng này" } }
+      }
+    },
+    "quota.metric.thisWeek" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "This Week" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Tuần này" } }
+      }
+    },
+    "quota.metric.today" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Today" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hôm nay" } }
+      }
+    },
+    "quota.metric.unit.credits" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ credits" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "%@ credits" } }
+      }
+    },
+    "quota.metric.unit.requests" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ requests" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "%@ yêu cầu" } }
+      }
+    },
+    "quota.metric.unit.searches" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ searches" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "%@ lượt tìm kiếm" } }
+      }
+    },
+    "quota.metric.webSearches" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Web Searches" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Tìm kiếm web" } }
+      }
+    },
+    "quota.metric.weekly" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Weekly" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tuần" } }
+      }
+    },
     "warp.token.placeholder" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -22585,38 +22585,50 @@
     },
     "factory.quota.coreFiveHour" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Core · 5-hour" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Core · 5 giờ" } }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "5-hour" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "5 giờ" } }
       }
     },
     "factory.quota.coreMonthly" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Core · Monthly" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Core · Hàng tháng" } }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Monthly" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tháng" } }
       }
     },
     "factory.quota.coreWeekly" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Core · Weekly" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Core · Hàng tuần" } }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Weekly" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tuần" } }
+      }
+    },
+    "factory.quota.group.core" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Core" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Core" } }
+      }
+    },
+    "factory.quota.group.standard" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Standard" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Standard" } }
       }
     },
     "factory.quota.standardFiveHour" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Standard · 5-hour" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Standard · 5 giờ" } }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "5-hour" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "5 giờ" } }
       }
     },
     "factory.quota.standardMonthly" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Standard · Monthly" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Standard · Hàng tháng" } }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Monthly" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tháng" } }
       }
     },
     "factory.quota.standardWeekly" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Standard · Weekly" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Standard · Hàng tuần" } }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Weekly" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tuần" } }
       }
     },
     "factory.status.extraUsageBalance" : {

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -22631,30 +22631,6 @@
         "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tuần" } }
       }
     },
-    "factory.status.extraUsageBalance" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enabled · Extra usage balance" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đã bật · Số dư dùng thêm" } }
-      }
-    },
-    "factory.status.extraUsageCore" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enabled · Droid Core" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đã bật · Droid Core" } }
-      }
-    },
-    "factory.status.extraUsageDisabled" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Disabled" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đã tắt" } }
-      }
-    },
-    "factory.status.extraUsageEnabled" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enabled" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Đã bật" } }
-      }
-    },
     "factory.status.legacyBilling" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Legacy billing" } },

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -22697,6 +22697,22 @@
         "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhãn tài khoản" } }
       }
     },
+    "openrouter.plan.freeTier" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Free tier" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Offre gratuite" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Gói miễn phí" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "免费套餐" } }
+      }
+    },
+    "openrouter.plan.payAsYouGo" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Pay as you go" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Paiement à l’usage" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Trả theo mức sử dụng" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "按量付费" } }
+      }
+    },
     "quota.metric.balance" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Balance" } },
@@ -22719,6 +22735,14 @@
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Daily" } },
         "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng ngày" } }
+      }
+    },
+    "quota.metric.monthly" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Monthly" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Mensuel" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hàng tháng" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "每月" } }
       }
     },
     "quota.metric.extraBalance" : {
@@ -22771,20 +22795,104 @@
     },
     "quota.metric.unit.credits" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ credits" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "%@ credits" } }
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : { "stringUnit" : { "state" : "translated", "value" : "%g credit" } },
+              "other" : { "stringUnit" : { "state" : "translated", "value" : "%g credits" } }
+            }
+          }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : { "stringUnit" : { "state" : "translated", "value" : "%g crédit" } },
+              "other" : { "stringUnit" : { "state" : "translated", "value" : "%g crédits" } }
+            }
+          }
+        },
+        "vi" : {
+          "variations" : {
+            "plural" : {
+              "other" : { "stringUnit" : { "state" : "translated", "value" : "%g credits" } }
+            }
+          }
+        },
+        "zh-Hans" : {
+          "variations" : {
+            "plural" : {
+              "other" : { "stringUnit" : { "state" : "translated", "value" : "%g 积分" } }
+            }
+          }
+        }
       }
     },
     "quota.metric.unit.requests" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ requests" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "%@ yêu cầu" } }
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : { "stringUnit" : { "state" : "translated", "value" : "%g request" } },
+              "other" : { "stringUnit" : { "state" : "translated", "value" : "%g requests" } }
+            }
+          }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : { "stringUnit" : { "state" : "translated", "value" : "%g requête" } },
+              "other" : { "stringUnit" : { "state" : "translated", "value" : "%g requêtes" } }
+            }
+          }
+        },
+        "vi" : {
+          "variations" : {
+            "plural" : {
+              "other" : { "stringUnit" : { "state" : "translated", "value" : "%g yêu cầu" } }
+            }
+          }
+        },
+        "zh-Hans" : {
+          "variations" : {
+            "plural" : {
+              "other" : { "stringUnit" : { "state" : "translated", "value" : "%g 个请求" } }
+            }
+          }
+        }
       }
     },
     "quota.metric.unit.searches" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ searches" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "%@ lượt tìm kiếm" } }
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : { "stringUnit" : { "state" : "translated", "value" : "%g search" } },
+              "other" : { "stringUnit" : { "state" : "translated", "value" : "%g searches" } }
+            }
+          }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : { "stringUnit" : { "state" : "translated", "value" : "%g recherche" } },
+              "other" : { "stringUnit" : { "state" : "translated", "value" : "%g recherches" } }
+            }
+          }
+        },
+        "vi" : {
+          "variations" : {
+            "plural" : {
+              "other" : { "stringUnit" : { "state" : "translated", "value" : "%g lượt tìm kiếm" } }
+            }
+          }
+        },
+        "zh-Hans" : {
+          "variations" : {
+            "plural" : {
+              "other" : { "stringUnit" : { "state" : "translated", "value" : "%g 次搜索" } }
+            }
+          }
+        }
       }
     },
     "quota.metric.webSearches" : {

--- a/Quotio/Models/CustomProviderModels.swift
+++ b/Quotio/Models/CustomProviderModels.swift
@@ -37,7 +37,7 @@ enum CustomProviderType: String, CaseIterable, Codable, Identifiable, Sendable {
         case .claudeCompatibility: return "Claude Compatible"
         case .geminiCompatibility: return "Gemini Compatible"
         case .codexCompatibility: return "Codex Compatible"
-        case .glmCompatibility: return "GLM Compatible"
+        case .glmCompatibility: return "Z.ai / GLM"
         case .clinePass: return "ClinePass"
         }
     }
@@ -65,7 +65,7 @@ enum CustomProviderType: String, CaseIterable, Codable, Identifiable, Sendable {
         case .codexCompatibility:
             return "Custom Codex-compatible endpoints"
         case .glmCompatibility:
-            return "GLM (BigModel.cn) API"
+            return "Z.ai GLM Coding Plan API"
         case .clinePass:
             return "ClinePass subscription with OpenAI-compatible routing"
         }
@@ -134,7 +134,7 @@ enum CustomProviderType: String, CaseIterable, Codable, Identifiable, Sendable {
         case .geminiCompatibility:
             return "https://generativelanguage.googleapis.com"
         case .glmCompatibility:
-            return "https://bigmodel.cn"
+            return "https://api.z.ai"
         case .clinePass:
             return "https://api.cline.bot/api/v1"
         case .openaiCompatibility, .codexCompatibility:

--- a/Quotio/Models/Models.swift
+++ b/Quotio/Models/Models.swift
@@ -19,6 +19,7 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
     case kiro = "kiro"
     case copilot = "github-copilot"
     case cursor = "cursor"
+    case factoryDroid = "factory-droid"
     case devin = "devin"
     case grok = "grok"
     case openRouter = "openrouter"
@@ -41,6 +42,7 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .kiro: return "Kiro"
         case .copilot: return "GitHub Copilot"
         case .cursor: return "Cursor"
+        case .factoryDroid: return "Factory Droid"
         case .devin: return "Devin"
         case .grok: return "Grok"
         case .openRouter: return "OpenRouter"
@@ -63,6 +65,7 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .kiro: return "cloud.fill"
         case .copilot: return "chevron.left.forwardslash.chevron.right"
         case .cursor: return "cursorarrow.rays"
+        case .factoryDroid: return "cpu"
         case .devin: return "bolt.horizontal.circle"
         case .grok: return "xmark.circle"
         case .openRouter: return "point.3.connected.trianglepath.dotted"
@@ -86,6 +89,7 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .kiro: return "kiro"
         case .copilot: return "copilot"
         case .cursor: return "cursor"
+        case .factoryDroid: return "factory-droid"
         case .devin: return "devin"
         case .grok: return "grok"
         case .openRouter: return "openrouter"
@@ -108,6 +112,7 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .kiro: return Color(hex: "9046FF") ?? .purple
         case .copilot: return Color(hex: "238636") ?? .green
         case .cursor: return Color(hex: "00D4AA") ?? .teal
+        case .factoryDroid: return Color(hex: "238636") ?? .green
         case .devin: return Color(hex: "6C5CE7") ?? .purple
         case .grok: return .primary
         case .openRouter: return Color(hex: "6B5CFF") ?? .purple
@@ -130,7 +135,7 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .kiro: return ""  // Uses CLI-based auth like Copilot
         case .copilot: return ""
         case .cursor: return ""  // Uses browser session
-        case .devin, .grok, .openRouter: return ""
+        case .factoryDroid, .devin, .grok, .openRouter: return ""
         case .trae: return ""  // Uses browser session
         case .glm: return ""
         case .warp: return ""
@@ -151,6 +156,7 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .kiro: return "K"
         case .copilot: return "CP"
         case .cursor: return "CR"
+        case .factoryDroid: return "FD"
         case .devin: return "D"
         case .grok: return "X"
         case .openRouter: return "OR"
@@ -175,7 +181,7 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .iflow: return "iflow-menubar"
         case .vertex: return "vertex-menubar"
         case .cursor: return "cursor-menubar"
-        case .devin, .grok, .openRouter: return nil
+        case .factoryDroid, .devin, .grok, .openRouter: return nil
         case .trae: return "trae-menubar"
         case .glm: return "glm-menubar"
         case .warp: return "warp-menubar"
@@ -186,7 +192,7 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
     /// Whether this provider supports quota tracking in quota-only mode
     var supportsQuotaOnlyMode: Bool {
         switch self {
-        case .claude, .codex, .cursor, .gemini, .antigravity, .copilot, .devin, .grok, .openRouter, .trae, .glm, .warp, .kiro, .clinePass:
+        case .claude, .codex, .cursor, .factoryDroid, .gemini, .antigravity, .copilot, .devin, .grok, .openRouter, .trae, .glm, .warp, .kiro, .clinePass:
             return true
         case .qwen, .iflow, .vertex:
             return false
@@ -235,10 +241,10 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         }
     }
 
-    /// Whether this provider uses API key authentication (stored in CustomProviderService)
+    /// Whether this provider uses API key authentication
     var usesAPIKeyAuth: Bool {
         switch self {
-        case .glm, .warp, .clinePass, .openRouter:
+        case .glm, .warp, .clinePass, .factoryDroid, .openRouter:
             return true
         default:
             return false
@@ -248,7 +254,7 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
     /// Whether this provider is quota-tracking only (not a real provider that can route requests)
     var isQuotaTrackingOnly: Bool {
         switch self {
-        case .cursor, .trae, .devin, .grok, .openRouter, .warp:
+        case .cursor, .trae, .factoryDroid, .devin, .grok, .openRouter, .warp:
             return true  // Only for tracking usage, not a provider
         default:
             return false

--- a/Quotio/Models/Models.swift
+++ b/Quotio/Models/Models.swift
@@ -260,6 +260,11 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
             return false
         }
     }
+
+    /// Whether the Local Proxy dashboard can route this provider through its setup flow.
+    var supportsLocalProxySetup: Bool {
+        supportsManualAuth && !isQuotaTrackingOnly
+    }
 }
 
 // MARK: - Quota Metric Presentation
@@ -277,11 +282,11 @@ nonisolated enum QuotaMetricUnit: String, Codable, Sendable, Equatable {
         case .usd:
             return value.formatted(.currency(code: "USD").precision(.fractionLength(0...2)))
         case .credits:
-            return String(format: "quota.metric.unit.credits".localizedStatic(), value.formatted(.number.precision(.fractionLength(0...2))))
+            return String.localizedStringWithFormat("quota.metric.unit.credits".localizedStatic(), value)
         case .requests:
-            return String(format: "quota.metric.unit.requests".localizedStatic(), value.formatted(.number.precision(.fractionLength(0...2))))
+            return String.localizedStringWithFormat("quota.metric.unit.requests".localizedStatic(), value)
         case .searches:
-            return String(format: "quota.metric.unit.searches".localizedStatic(), value.formatted(.number.precision(.fractionLength(0...2))))
+            return String.localizedStringWithFormat("quota.metric.unit.searches".localizedStatic(), value)
         }
     }
 }

--- a/Quotio/Models/Models.swift
+++ b/Quotio/Models/Models.swift
@@ -19,6 +19,9 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
     case kiro = "kiro"
     case copilot = "github-copilot"
     case cursor = "cursor"
+    case devin = "devin"
+    case grok = "grok"
+    case openRouter = "openrouter"
     case trae = "trae"
     case glm = "glm"
     case warp = "warp"
@@ -38,8 +41,11 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .kiro: return "Kiro"
         case .copilot: return "GitHub Copilot"
         case .cursor: return "Cursor"
+        case .devin: return "Devin"
+        case .grok: return "Grok"
+        case .openRouter: return "OpenRouter"
         case .trae: return "Trae"
-        case .glm: return "GLM"
+        case .glm: return "Z.ai"
         case .warp: return "Warp"
         case .clinePass: return "ClinePass"
         }
@@ -57,6 +63,9 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .kiro: return "cloud.fill"
         case .copilot: return "chevron.left.forwardslash.chevron.right"
         case .cursor: return "cursorarrow.rays"
+        case .devin: return "bolt.horizontal.circle"
+        case .grok: return "xmark.circle"
+        case .openRouter: return "point.3.connected.trianglepath.dotted"
         case .trae: return "cursorarrow.rays"
         case .glm: return "brain"
         case .warp: return "terminal.fill"
@@ -77,6 +86,9 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .kiro: return "kiro"
         case .copilot: return "copilot"
         case .cursor: return "cursor"
+        case .devin: return "devin"
+        case .grok: return "grok"
+        case .openRouter: return "openrouter"
         case .trae: return "trae"
         case .glm: return "glm"
         case .warp: return "warp"
@@ -96,6 +108,9 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .kiro: return Color(hex: "9046FF") ?? .purple
         case .copilot: return Color(hex: "238636") ?? .green
         case .cursor: return Color(hex: "00D4AA") ?? .teal
+        case .devin: return Color(hex: "6C5CE7") ?? .purple
+        case .grok: return .primary
+        case .openRouter: return Color(hex: "6B5CFF") ?? .purple
         case .trae: return Color(hex: "00B4D8") ?? .cyan
         case .glm: return Color(hex: "3B82F6") ?? .blue
         case .warp: return Color(hex: "01E5FF") ?? .cyan
@@ -115,6 +130,7 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .kiro: return ""  // Uses CLI-based auth like Copilot
         case .copilot: return ""
         case .cursor: return ""  // Uses browser session
+        case .devin, .grok, .openRouter: return ""
         case .trae: return ""  // Uses browser session
         case .glm: return ""
         case .warp: return ""
@@ -135,6 +151,9 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .kiro: return "K"
         case .copilot: return "CP"
         case .cursor: return "CR"
+        case .devin: return "D"
+        case .grok: return "X"
+        case .openRouter: return "OR"
         case .trae: return "TR"
         case .glm: return "G"
         case .warp: return "W"
@@ -156,6 +175,7 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .iflow: return "iflow-menubar"
         case .vertex: return "vertex-menubar"
         case .cursor: return "cursor-menubar"
+        case .devin, .grok, .openRouter: return nil
         case .trae: return "trae-menubar"
         case .glm: return "glm-menubar"
         case .warp: return "warp-menubar"
@@ -166,7 +186,7 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
     /// Whether this provider supports quota tracking in quota-only mode
     var supportsQuotaOnlyMode: Bool {
         switch self {
-        case .claude, .codex, .cursor, .gemini, .antigravity, .copilot, .trae, .glm, .warp, .kiro, .clinePass:
+        case .claude, .codex, .cursor, .gemini, .antigravity, .copilot, .devin, .grok, .openRouter, .trae, .glm, .warp, .kiro, .clinePass:
             return true
         case .qwen, .iflow, .vertex:
             return false
@@ -208,7 +228,7 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
     /// GLM and ClinePass are excluded because they should only be added via Custom Providers
     var supportsManualAuth: Bool {
         switch self {
-        case .cursor, .trae, .glm, .clinePass:
+        case .cursor, .trae, .devin, .grok, .glm, .clinePass:
             return false  // API-key providers: Custom Providers; Cursor/Trae: local app databases
         default:
             return true
@@ -218,7 +238,7 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
     /// Whether this provider uses API key authentication (stored in CustomProviderService)
     var usesAPIKeyAuth: Bool {
         switch self {
-        case .glm, .warp, .clinePass:
+        case .glm, .warp, .clinePass, .openRouter:
             return true
         default:
             return false
@@ -228,12 +248,47 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
     /// Whether this provider is quota-tracking only (not a real provider that can route requests)
     var isQuotaTrackingOnly: Bool {
         switch self {
-        case .cursor, .trae, .warp:
+        case .cursor, .trae, .devin, .grok, .openRouter, .warp:
             return true  // Only for tracking usage, not a provider
         default:
             return false
         }
     }
+}
+
+// MARK: - Quota Metric Presentation
+
+/// Optional typed value for quota rows that are not plain percentages.
+/// Existing snapshots omit this field and continue to render through ModelQuota.percentage.
+nonisolated enum QuotaMetricUnit: String, Codable, Sendable, Equatable {
+    case usd
+    case credits
+    case requests
+    case searches
+
+    func format(_ value: Double) -> String {
+        switch self {
+        case .usd:
+            return value.formatted(.currency(code: "USD").precision(.fractionLength(0...2)))
+        case .credits:
+            return String(format: "quota.metric.unit.credits".localizedStatic(), value.formatted(.number.precision(.fractionLength(0...2))))
+        case .requests:
+            return String(format: "quota.metric.unit.requests".localizedStatic(), value.formatted(.number.precision(.fractionLength(0...2))))
+        case .searches:
+            return String(format: "quota.metric.unit.searches".localizedStatic(), value.formatted(.number.precision(.fractionLength(0...2))))
+        }
+    }
+}
+
+nonisolated enum QuotaAmountSemantics: String, Codable, Sendable, Equatable {
+    case balance
+    case spent
+}
+
+nonisolated enum QuotaMetricPresentation: Codable, Sendable, Equatable {
+    case progress(used: Double, limit: Double, unit: QuotaMetricUnit)
+    case amount(value: Double, unit: QuotaMetricUnit, semantics: QuotaAmountSemantics)
+    case status(text: String)
 }
 
 // MARK: - Proxy Status

--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -285,6 +285,16 @@ nonisolated struct ModelQuota: Codable, Identifiable, Sendable {
         // Grok
         case "grok-weekly": return "quota.metric.weekly".localizedStatic()
         case "grok-extra-usage": return "quota.metric.extraUsage".localizedStatic()
+        // Factory Droid
+        case "factory-standard-five-hour": return "factory.quota.standardFiveHour".localizedStatic()
+        case "factory-standard-weekly": return "factory.quota.standardWeekly".localizedStatic()
+        case "factory-standard-monthly": return "factory.quota.standardMonthly".localizedStatic()
+        case "factory-core-five-hour": return "factory.quota.coreFiveHour".localizedStatic()
+        case "factory-core-weekly": return "factory.quota.coreWeekly".localizedStatic()
+        case "factory-core-monthly": return "factory.quota.coreMonthly".localizedStatic()
+        case "factory-extra-balance": return "quota.metric.extraBalance".localizedStatic()
+        case "factory-extra-usage": return "quota.metric.extraUsage".localizedStatic()
+        case "factory-billing-mode": return "factory.quota.billingMode".localizedStatic()
         // OpenRouter
         case "openrouter-credits": return "quota.metric.credits".localizedStatic()
         case "openrouter-balance": return "quota.metric.balance".localizedStatic()

--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -276,7 +276,9 @@ nonisolated struct ModelQuota: Codable, Identifiable, Sendable {
         case "clinepass-monthly": return "clinepass.quota.monthly".localizedStatic()
         // Z.ai / GLM Coding Plan
         case "zai-session": return "quota.metric.session".localizedStatic()
+        case "zai-daily": return "quota.metric.daily".localizedStatic()
         case "zai-weekly": return "quota.metric.weekly".localizedStatic()
+        case "zai-monthly": return "quota.metric.monthly".localizedStatic()
         case "zai-web-searches": return "quota.metric.webSearches".localizedStatic()
         // Devin
         case "devin-daily": return "quota.metric.daily".localizedStatic()

--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -293,7 +293,6 @@ nonisolated struct ModelQuota: Codable, Identifiable, Sendable {
         case "factory-core-weekly": return "factory.quota.coreWeekly".localizedStatic()
         case "factory-core-monthly": return "factory.quota.coreMonthly".localizedStatic()
         case "factory-extra-balance": return "quota.metric.extraBalance".localizedStatic()
-        case "factory-extra-usage": return "quota.metric.extraUsage".localizedStatic()
         case "factory-billing-mode": return "factory.quota.billingMode".localizedStatic()
         // OpenRouter
         case "openrouter-credits": return "quota.metric.credits".localizedStatic()

--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -129,6 +129,9 @@ nonisolated struct ModelQuota: Codable, Identifiable, Sendable {
     let percentage: Double
     let resetTime: String
 
+    /// Typed value for currency/count/status rows. Nil keeps the legacy percentage presentation.
+    var presentation: QuotaMetricPresentation?
+
     // Optional usage details for providers that support it (e.g., Cursor)
     var used: Int?
     var limit: Int?
@@ -136,6 +139,26 @@ nonisolated struct ModelQuota: Codable, Identifiable, Sendable {
 
     // Optional tooltip message (e.g., Warp bonus userFacingMessage)
     var tooltip: String?
+
+    init(
+        name: String,
+        percentage: Double,
+        resetTime: String,
+        presentation: QuotaMetricPresentation? = nil,
+        used: Int? = nil,
+        limit: Int? = nil,
+        remaining: Int? = nil,
+        tooltip: String? = nil
+    ) {
+        self.name = name
+        self.percentage = percentage
+        self.resetTime = resetTime
+        self.presentation = presentation
+        self.used = used
+        self.limit = limit
+        self.remaining = remaining
+        self.tooltip = tooltip
+    }
 
     var id: String { name }
 
@@ -155,11 +178,30 @@ nonisolated struct ModelQuota: Codable, Identifiable, Sendable {
 
     /// Formatted usage string like "150/2000" or "150 used"
     var formattedUsage: String? {
+        if let presentation {
+            switch presentation {
+            case .progress(let used, let limit, let unit):
+                return unit.format(used) + " / " + unit.format(limit)
+            case .amount(let value, let unit, let semantics):
+                let key = semantics == .balance ? "quota.metric.balanceValue" : "quota.metric.spentValue"
+                return String(format: key.localizedStatic(), unit.format(value))
+            case .status(let text):
+                return text
+            }
+        }
         guard let used = used else { return nil }
         if let limit = limit, limit > 0 {
             return "\(used)/\(limit)"
         }
         return "\(used) used"
+    }
+
+    var isStandaloneMetric: Bool {
+        guard let presentation else { return false }
+        switch presentation {
+        case .amount, .status: return true
+        case .progress: return false
+        }
     }
 
     var modelGroup: AntigravityModelGroup? {
@@ -232,6 +274,24 @@ nonisolated struct ModelQuota: Codable, Identifiable, Sendable {
         case "clinepass-five-hour": return "clinepass.quota.fiveHour".localizedStatic()
         case "clinepass-weekly": return "clinepass.quota.weekly".localizedStatic()
         case "clinepass-monthly": return "clinepass.quota.monthly".localizedStatic()
+        // Z.ai / GLM Coding Plan
+        case "zai-session": return "quota.metric.session".localizedStatic()
+        case "zai-weekly": return "quota.metric.weekly".localizedStatic()
+        case "zai-web-searches": return "quota.metric.webSearches".localizedStatic()
+        // Devin
+        case "devin-daily": return "quota.metric.daily".localizedStatic()
+        case "devin-weekly": return "quota.metric.weekly".localizedStatic()
+        case "devin-extra-balance": return "quota.metric.extraBalance".localizedStatic()
+        // Grok
+        case "grok-weekly": return "quota.metric.weekly".localizedStatic()
+        case "grok-extra-usage": return "quota.metric.extraUsage".localizedStatic()
+        // OpenRouter
+        case "openrouter-credits": return "quota.metric.credits".localizedStatic()
+        case "openrouter-balance": return "quota.metric.balance".localizedStatic()
+        case "openrouter-today": return "quota.metric.today".localizedStatic()
+        case "openrouter-week": return "quota.metric.thisWeek".localizedStatic()
+        case "openrouter-month": return "quota.metric.thisMonth".localizedStatic()
+        case "openrouter-key-limit": return "quota.metric.keyLimit".localizedStatic()
         case let name where name.hasPrefix("warp-bonus-"):
             let index = Int(String(name.dropFirst("warp-bonus-".count))) ?? 0
             return "Bonus \(index + 1)"

--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -360,6 +360,7 @@ nonisolated struct ProviderQuotaData: Codable, Sendable {
     var planType: String?
     var tokenExpiresAt: Date?  // For Kiro: token expiry time
     var analytics: QuotaAnalytics?
+    var accountDisplayName: String?
 
     init(
         models: [ModelQuota] = [],
@@ -367,7 +368,8 @@ nonisolated struct ProviderQuotaData: Codable, Sendable {
         isForbidden: Bool = false,
         planType: String? = nil,
         tokenExpiresAt: Date? = nil,
-        analytics: QuotaAnalytics? = nil
+        analytics: QuotaAnalytics? = nil,
+        accountDisplayName: String? = nil
     ) {
         self.models = models
         self.lastUpdated = lastUpdated
@@ -375,6 +377,7 @@ nonisolated struct ProviderQuotaData: Codable, Sendable {
         self.planType = planType
         self.tokenExpiresAt = tokenExpiresAt
         self.analytics = analytics
+        self.accountDisplayName = accountDisplayName
     }
 
     /// Format token expiry time in user's local timezone

--- a/Quotio/Services/GLMQuotaFetcher.swift
+++ b/Quotio/Services/GLMQuotaFetcher.swift
@@ -209,15 +209,18 @@ actor GLMQuotaFetcher {
 
     private nonisolated static func tokenWindowName(unit: Double, number: Double) -> String? {
         guard number > 0 else { return nil }
-        let durationHours: Double
         switch unit {
-        case 3: durationHours = number
-        case 4: durationHours = number * 24
-        case 5: durationHours = number * 24 * 30
-        case 6: durationHours = number * 24 * 7
+        case 3:
+            return number < 24 ? "zai-session" : "zai-daily"
+        case 4:
+            if number <= 1 { return "zai-daily" }
+            return number < 28 ? "zai-weekly" : "zai-monthly"
+        case 5:
+            return "zai-monthly"
+        case 6:
+            return number < 4 ? "zai-weekly" : "zai-monthly"
         default: return nil
         }
-        return durationHours < 24 ? "zai-session" : "zai-weekly"
     }
 
     /// Fetch quota for all configured GLM API keys

--- a/Quotio/Services/GLMQuotaFetcher.swift
+++ b/Quotio/Services/GLMQuotaFetcher.swift
@@ -10,40 +10,72 @@ import Foundation
 
 // MARK: - API Response Models
 
-struct GLMQuotaResponse: Codable, Sendable {
-    let code: Int
-    let msg: String
+nonisolated struct GLMQuotaResponse: Codable, Sendable {
+    let code: Int?
+    let msg: String?
     let data: GLMQuotaData?
-    let success: Bool
+    let success: Bool?
 }
 
-struct GLMQuotaData: Codable, Sendable {
+nonisolated struct GLMQuotaData: Codable, Sendable {
     let limits: [GLMLimit]
 }
 
-struct GLMLimit: Codable, Sendable {
-    let type: String
-    let unit: Int
-    let number: Int
-    let usage: Int
-    let currentValue: Int
-    let remaining: Int
-    let percentage: Double
+nonisolated struct GLMSubscriptionResponse: Codable, Sendable {
+    let data: [GLMSubscription]?
+}
+
+nonisolated struct GLMSubscription: Codable, Sendable {
+    let productName: String?
+}
+
+nonisolated struct GLMLimit: Codable, Sendable {
+    let type: String?
+    let name: String?
+    let unit: Double?
+    let number: Double?
+    let usage: Double?
+    let currentValue: Double?
+    let remaining: Double?
+    let percentage: Double?
     let usageDetails: [GLMUsageDetail]?
-    let nextResetTime: Int64?
+    let nextResetTime: Double?
 
     enum CodingKeys: String, CodingKey {
-        case type, unit, number, usage
+        case type, name, unit, number, usage
         case currentValue = "currentValue"
         case remaining, percentage
         case usageDetails = "usageDetails"
         case nextResetTime = "nextResetTime"
     }
+
+    init(
+        type: String,
+        unit: Int? = nil,
+        number: Int? = nil,
+        usage: Int? = nil,
+        currentValue: Int? = nil,
+        remaining: Int? = nil,
+        percentage: Double? = nil,
+        usageDetails: [GLMUsageDetail]? = nil,
+        nextResetTime: Int64? = nil
+    ) {
+        self.type = type
+        name = nil
+        self.unit = unit.map(Double.init)
+        self.number = number.map(Double.init)
+        self.usage = usage.map(Double.init)
+        self.currentValue = currentValue.map(Double.init)
+        self.remaining = remaining.map(Double.init)
+        self.percentage = percentage
+        self.usageDetails = usageDetails
+        self.nextResetTime = nextResetTime.map(Double.init)
+    }
 }
 
-struct GLMUsageDetail: Codable, Sendable {
-    let modelCode: String
-    let usage: Int
+nonisolated struct GLMUsageDetail: Codable, Sendable {
+    let modelCode: String?
+    let usage: Double?
 
     enum CodingKeys: String, CodingKey {
         case modelCode = "modelCode"
@@ -54,8 +86,6 @@ struct GLMUsageDetail: Codable, Sendable {
 // MARK: - Quota Fetcher
 
 actor GLMQuotaFetcher {
-    private let quotaAPIURL = "https://bigmodel.cn/api/monitor/usage/quota/limit"
-
     private var session: URLSession
 
     init() {
@@ -70,19 +100,15 @@ actor GLMQuotaFetcher {
     }
 
     /// Fetch quota for a single API key
-    func fetchQuota(apiKey: String) async throws -> ProviderQuotaData {
-        guard let url = URL(string: quotaAPIURL) else {
+    func fetchQuota(apiKey: String, baseURL: String) async throws -> ProviderQuotaData {
+        guard let rootURL = Self.apiRoot(from: baseURL),
+              let quotaURL = URL(string: rootURL + "/api/monitor/usage/quota/limit") else {
             throw QuotaFetchError.invalidURL
         }
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
 
-        let (data, response) = try await session.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw QuotaFetchError.invalidResponse
-        }
+        async let quotaResult = fetch(apiKey: apiKey, url: quotaURL)
+        async let subscriptionName = fetchSubscriptionName(apiKey: apiKey, rootURL: rootURL)
+        let (data, httpResponse) = try await quotaResult
 
         guard 200...299 ~= httpResponse.statusCode else {
             if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
@@ -92,55 +118,106 @@ actor GLMQuotaFetcher {
         }
 
         let decoder = JSONDecoder()
-        let quotaResponse = try await MainActor.run {
-            try decoder.decode(GLMQuotaResponse.self, from: data)
+        let quotaResponse = try decoder.decode(GLMQuotaResponse.self, from: data)
+
+        guard quotaResponse.success != false,
+              quotaResponse.code.map({ $0 == 200 }) ?? true,
+              let responseData = quotaResponse.data else {
+            throw QuotaFetchError.apiErrorMessage(quotaResponse.msg ?? "Z.ai quota unavailable")
         }
 
-        guard quotaResponse.success, quotaResponse.code == 200, let responseData = quotaResponse.data else {
-            throw QuotaFetchError.apiErrorMessage(quotaResponse.msg)
+        let planName = await subscriptionName
+        return Self.mapQuotaData(responseData, planName: planName)
+    }
+
+    private func fetch(apiKey: String, url: URL) async throws -> (Data, HTTPURLResponse) {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw QuotaFetchError.invalidResponse
         }
+        return (data, httpResponse)
+    }
 
-        return await MainActor.run {
-            var models: [ModelQuota] = []
+    private func fetchSubscriptionName(apiKey: String, rootURL: String) async -> String? {
+        guard let url = URL(string: rootURL + "/api/biz/subscription/list"),
+              let (data, response) = try? await fetch(apiKey: apiKey, url: url),
+              200...299 ~= response.statusCode else {
+            return nil
+        }
+        guard let value = (try? JSONDecoder().decode(GLMSubscriptionResponse.self, from: data))?
+            .data?.first?.productName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value
+    }
 
-            // Parse limits - GLM has TOKENS_LIMIT (main quota) and TIME_LIMIT (MCP quota)
-            for limit in responseData.limits {
-                if limit.type == "TOKENS_LIMIT" {
-                    // Token limit - show as main quota on dashboard
-                    let resetTime: String
-                    if let nextReset = limit.nextResetTime {
-                        resetTime = ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: TimeInterval(nextReset / 1000)))
-                    } else {
-                        resetTime = ""
-                    }
+    nonisolated static func apiRoot(from baseURL: String) -> String? {
+        guard let components = URLComponents(string: baseURL),
+              let scheme = components.scheme,
+              let host = components.host else { return nil }
+        var root = scheme + "://" + host
+        if let port = components.port { root += ":\(port)" }
+        return root
+    }
 
-                    // currentValue is used, usage is total limit
-                    // API returns percentage as "used", so convert to "remaining" for ModelQuota
-                    models.append(ModelQuota(
-                        name: "Tokens",
-                        percentage: 100 - limit.percentage,
-                        resetTime: resetTime,
-                        used: limit.currentValue,
-                        limit: limit.usage,
-                        remaining: limit.remaining
-                    ))
-                } else if limit.type == "TIME_LIMIT" {
-                    // MCP quota (monthly, no reset time)
-                    // currentValue is used, usage is total
-                    // API returns percentage as "used", so convert to "remaining" for ModelQuota
-                    models.append(ModelQuota(
-                        name: "MCP Usage",
-                        percentage: 100 - limit.percentage,
-                        resetTime: "",
-                        used: limit.currentValue,
-                        limit: limit.usage,
-                        remaining: limit.remaining
-                    ))
-                }
+    nonisolated static func mapQuotaData(_ data: GLMQuotaData, planName: String?) -> ProviderQuotaData {
+        var models: [ModelQuota] = []
+
+        for limit in data.limits {
+            let resetTime = limit.nextResetTime.map {
+                ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: $0 / 1000))
+            } ?? ""
+            let kind = limit.type ?? limit.name
+
+            if kind == "TOKENS_LIMIT",
+               let percentage = limit.percentage,
+               let unit = limit.unit,
+               let number = limit.number,
+               let windowName = tokenWindowName(unit: unit, number: number) {
+                models.append(ModelQuota(
+                    name: windowName,
+                    percentage: max(0, min(100, 100 - percentage)),
+                    resetTime: resetTime
+                ))
+            } else if kind == "TIME_LIMIT",
+                      let used = limit.currentValue,
+                      let quotaLimit = limit.usage,
+                      used >= 0,
+                      quotaLimit >= 0 {
+                let remainingPercent = quotaLimit > 0 ? max(0, min(100, (quotaLimit - used) / quotaLimit * 100)) : 0
+                models.append(ModelQuota(
+                    name: "zai-web-searches",
+                    percentage: remainingPercent,
+                    resetTime: resetTime,
+                    presentation: .progress(
+                        used: used,
+                        limit: quotaLimit,
+                        unit: .searches
+                    ),
+                    used: Int(used),
+                    limit: Int(quotaLimit)
+                ))
             }
-
-            return ProviderQuotaData(models: models, lastUpdated: Date())
         }
+
+        return ProviderQuotaData(models: models, lastUpdated: Date(), planType: planName)
+    }
+
+    private nonisolated static func tokenWindowName(unit: Double, number: Double) -> String? {
+        guard number > 0 else { return nil }
+        let durationHours: Double
+        switch unit {
+        case 3: durationHours = number
+        case 4: durationHours = number * 24
+        case 5: durationHours = number * 24 * 30
+        case 6: durationHours = number * 24 * 7
+        default: return nil
+        }
+        return durationHours < 24 ? "zai-session" : "zai-weekly"
     }
 
     /// Fetch quota for all configured GLM API keys
@@ -155,7 +232,10 @@ actor GLMQuotaFetcher {
                 for apiKeyEntry in provider.apiKeys {
                     group.addTask {
                         do {
-                            let quota = try await self.fetchQuota(apiKey: apiKeyEntry.apiKey)
+                            let quota = try await self.fetchQuota(
+                                apiKey: apiKeyEntry.apiKey,
+                                baseURL: provider.baseURL
+                            )
                             // Use provider name as identifier
                             return (provider.name, quota)
                         } catch {

--- a/Quotio/Services/Monitor/MonitorRuntime.swift
+++ b/Quotio/Services/Monitor/MonitorRuntime.swift
@@ -401,6 +401,8 @@ actor MonitorAccountDiscovery {
         accounts.append(contentsOf: discoverGeminiFile())
         accounts.append(contentsOf: discoverCopilotFiles())
         accounts.append(contentsOf: discoverKiroFile())
+        accounts.append(contentsOf: discoverDevinCredential())
+        accounts.append(contentsOf: discoverGrokCredentials())
         let antigravityDatabase = MonitorIdentity.expand("~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb")
         if let token = try? await AntigravityDatabaseService().getCurrentTokenInfo(),
            token.accessToken?.nilIfBlank != nil || token.refreshToken?.nilIfBlank != nil {
@@ -412,6 +414,41 @@ actor MonitorAccountDiscovery {
             ))
         }
         return accounts
+    }
+
+    private func discoverDevinCredential() -> [MonitorAccount] {
+        let credentialsPath = MonitorIdentity.expand(DevinQuotaFetcher.credentialsPath)
+        if let text = try? String(contentsOfFile: credentialsPath, encoding: .utf8),
+           DevinQuotaFetcher.parseCredentialsTOML(text) != nil {
+            return [.make(
+                provider: .devin,
+                accountKey: "Devin",
+                source: .nativeCredential,
+                credentialReference: credentialsPath
+            )]
+        }
+
+        let databasePath = MonitorIdentity.expand(DevinQuotaFetcher.stateDBPath)
+        guard DevinQuotaFetcher.loadAppCredential(path: databasePath) != nil else { return [] }
+        return [.make(
+            provider: .devin,
+            accountKey: "Devin",
+            source: .localIDE,
+            credentialReference: databasePath
+        )]
+    }
+
+    private func discoverGrokCredentials() -> [MonitorAccount] {
+        let path = MonitorIdentity.expand(GrokQuotaFetcher.authPath)
+        return GrokQuotaFetcher.loadCandidates(path: path).map { candidate in
+            .make(
+                provider: .grok,
+                accountKey: candidate.entryKey,
+                displayName: candidate.displayName,
+                source: .nativeCredential,
+                credentialReference: path + "#" + candidate.entryKey
+            )
+        }
     }
 
     private func discoverCodexFiles(aliases: [String: String]) -> [MonitorAccount] {
@@ -536,7 +573,7 @@ actor MonitorRefreshCoordinator {
             let source: MonitorAccountSource
             switch provider {
             case .cursor, .trae: source = .localIDE
-            case .glm, .warp, .clinePass: source = .apiKey
+            case .glm, .warp, .clinePass, .openRouter: source = .apiKey
             default: source = .nativeCredential
             }
             for accountKey in accountQuotas.keys {
@@ -680,6 +717,7 @@ nonisolated enum SecureAtomicFileWriter {
         } else {
             try manager.moveItem(at: temporary, to: url)
         }
+        try manager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
     }
 }
 
@@ -718,11 +756,13 @@ nonisolated enum MonitorIdentity {
 
 nonisolated enum MonitorRuntimeError: LocalizedError {
     case credentialWriteFailed
+    case invalidCredential
     case symbolicLinkRefused
 
     var errorDescription: String? {
         switch self {
         case .credentialWriteFailed: "Could not save the Monitor credential in Keychain."
+        case .invalidCredential: "The Monitor credential file is invalid."
         case .symbolicLinkRefused: "Refusing to write credentials through a symbolic link."
         }
     }

--- a/Quotio/Services/Monitor/MonitorRuntime.swift
+++ b/Quotio/Services/Monitor/MonitorRuntime.swift
@@ -401,6 +401,7 @@ actor MonitorAccountDiscovery {
         accounts.append(contentsOf: discoverGeminiFile())
         accounts.append(contentsOf: discoverCopilotFiles())
         accounts.append(contentsOf: discoverKiroFile())
+        accounts.append(contentsOf: discoverFactoryDroidCredential())
         accounts.append(contentsOf: discoverDevinCredential())
         accounts.append(contentsOf: discoverGrokCredentials())
         let antigravityDatabase = MonitorIdentity.expand("~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb")
@@ -414,6 +415,11 @@ actor MonitorAccountDiscovery {
             ))
         }
         return accounts
+    }
+
+    private func discoverFactoryDroidCredential() -> [MonitorAccount] {
+        guard let credential = FactoryDroidCredentialReader.load() else { return [] }
+        return [FactoryDroidQuotaFetcher.localAccount(for: credential)]
     }
 
     private func discoverDevinCredential() -> [MonitorAccount] {
@@ -573,7 +579,7 @@ actor MonitorRefreshCoordinator {
             let source: MonitorAccountSource
             switch provider {
             case .cursor, .trae: source = .localIDE
-            case .glm, .warp, .clinePass, .openRouter: source = .apiKey
+            case .glm, .warp, .clinePass, .factoryDroid, .openRouter: source = .apiKey
             default: source = .nativeCredential
             }
             for accountKey in accountQuotas.keys {

--- a/Quotio/Services/Monitor/MonitorRuntime.swift
+++ b/Quotio/Services/Monitor/MonitorRuntime.swift
@@ -562,15 +562,17 @@ actor MonitorRefreshCoordinator {
     }
 
     func bootstrap() async -> MonitorRefreshBatch {
-        MonitorRefreshBatch(
-            accounts: await discovery.discover(),
-            quotas: await snapshots.load(),
+        let quotas = await snapshots.load()
+        return MonitorRefreshBatch(
+            accounts: await discoverAccounts(merging: quotas),
+            quotas: quotas,
             issues: issues
         )
     }
 
     func discoverAccounts(merging quotas: [AIProvider: [String: ProviderQuotaData]] = [:]) async -> [MonitorAccount] {
         var accounts = await discovery.discover()
+        accounts = Self.applyingQuotaDisplayNames(accounts, quotas: quotas)
         let disabledIDs = await discovery.disabledAccountIDs()
         let existingKeys = Set(accounts.map(\.deduplicationKey))
         var appendedKeys = existingKeys
@@ -582,10 +584,11 @@ actor MonitorRefreshCoordinator {
             case .glm, .warp, .clinePass, .factoryDroid, .openRouter: source = .apiKey
             default: source = .nativeCredential
             }
-            for accountKey in accountQuotas.keys {
+            for (accountKey, quota) in accountQuotas {
                 let account = Self.makeQuotaDerivedAccount(
                     provider: provider,
                     accountKey: accountKey,
+                    displayName: quota.accountDisplayName,
                     source: source,
                     disabledIDs: disabledIDs
                 )
@@ -621,12 +624,39 @@ actor MonitorRefreshCoordinator {
     nonisolated static func makeQuotaDerivedAccount(
         provider: AIProvider,
         accountKey: String,
+        displayName: String? = nil,
         source: MonitorAccountSource,
         disabledIDs: Set<String>
     ) -> MonitorAccount {
-        var account = MonitorAccount.make(provider: provider, accountKey: accountKey, source: source)
+        var account = MonitorAccount.make(
+            provider: provider,
+            accountKey: accountKey,
+            displayName: displayName,
+            source: source
+        )
         account.isDisabled = disabledIDs.contains(account.id)
         return account
+    }
+
+    nonisolated static func applyingQuotaDisplayNames(
+        _ accounts: [MonitorAccount],
+        quotas: [AIProvider: [String: ProviderQuotaData]]
+    ) -> [MonitorAccount] {
+        accounts.map { account in
+            guard let displayName = quotas[account.provider]?[account.accountKey]?.accountDisplayName else {
+                return account
+            }
+            return MonitorAccount(
+                id: account.id,
+                provider: account.provider,
+                accountKey: account.accountKey,
+                displayName: displayName,
+                source: account.source,
+                credentialReference: account.credentialReference,
+                canDelete: account.canDelete,
+                isDisabled: account.isDisabled
+            )
+        }
     }
 
     func refresh(

--- a/Quotio/Services/QuotaFetchers/DevinQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/DevinQuotaFetcher.swift
@@ -170,7 +170,7 @@ actor DevinQuotaFetcher {
 
     nonisolated static func loadAppCredential(path: String = MonitorIdentity.expand(stateDBPath)) -> DevinCredential? {
         guard FileManager.default.fileExists(atPath: path) else { return nil }
-        let uri = "file://\(path)?mode=ro&immutable=1"
+        let uri = URL(fileURLWithPath: path).absoluteString + "?mode=ro"
         var db: OpaquePointer?
         guard sqlite3_open_v2(uri, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nil) == SQLITE_OK else { return nil }
         defer { sqlite3_close(db) }

--- a/Quotio/Services/QuotaFetchers/DevinQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/DevinQuotaFetcher.swift
@@ -172,7 +172,10 @@ actor DevinQuotaFetcher {
         guard FileManager.default.fileExists(atPath: path) else { return nil }
         let uri = URL(fileURLWithPath: path).absoluteString + "?mode=ro"
         var db: OpaquePointer?
-        guard sqlite3_open_v2(uri, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nil) == SQLITE_OK else { return nil }
+        guard sqlite3_open_v2(uri, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nil) == SQLITE_OK else {
+            if let db { sqlite3_close(db) }
+            return nil
+        }
         defer { sqlite3_close(db) }
 
         let sql = "SELECT value FROM ItemTable WHERE key = 'windsurfAuthStatus' LIMIT 1"
@@ -194,13 +197,33 @@ actor DevinQuotaFetcher {
             guard pieces.count == 2,
                   pieces[0].trimmingCharacters(in: .whitespacesAndNewlines) == key else { continue }
             var value = pieces[1].trimmingCharacters(in: .whitespacesAndNewlines)
-            if let comment = value.firstIndex(of: "#") { value = value[..<comment].trimmingCharacters(in: .whitespacesAndNewlines) }
+            value = tomlValueWithoutComment(value).trimmingCharacters(in: .whitespacesAndNewlines)
             if (value.first == "\"" && value.last == "\"") || (value.first == "'" && value.last == "'") {
                 value = value.dropFirst().dropLast().trimmingCharacters(in: .whitespacesAndNewlines)
             }
             return value.isEmpty ? nil : String(value)
         }
         return nil
+    }
+
+    private nonisolated static func tomlValueWithoutComment(_ value: String) -> String {
+        var activeQuote: Character?
+        var isEscaped = false
+        for index in value.indices {
+            let character = value[index]
+            if isEscaped {
+                isEscaped = false
+            } else if activeQuote == "\"" && character == "\\" {
+                isEscaped = true
+            } else if let quote = activeQuote {
+                if character == quote { activeQuote = nil }
+            } else if character == "\"" || character == "'" {
+                activeQuote = character
+            } else if character == "#" {
+                return String(value[..<index])
+            }
+        }
+        return value
     }
 
     private nonisolated static func cleanServerURL(_ value: String) -> String? {

--- a/Quotio/Services/QuotaFetchers/DevinQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/DevinQuotaFetcher.swift
@@ -1,0 +1,201 @@
+import Foundation
+import SQLite3
+
+nonisolated struct DevinCredential: Sendable, Equatable {
+    let apiKey: String
+    let apiServerURL: String?
+}
+
+nonisolated enum DevinQuotaMapper {
+    static func map(_ data: Data) -> ProviderQuotaData? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let userStatus = root["userStatus"] as? [String: Any] else { return nil }
+
+        let planStatus = userStatus["planStatus"] as? [String: Any] ?? [:]
+        let planInfo = planStatus["planInfo"] as? [String: Any] ?? [:]
+        let hideDaily = bool(planInfo["hideDailyQuota"]) == true
+        let dailyRemaining = number(planStatus["dailyQuotaRemainingPercent"])
+        let weeklyRemaining = number(planStatus["weeklyQuotaRemainingPercent"])
+        let dailyReset = hideDaily ? "" : resetTime(planStatus["dailyQuotaResetAtUnix"])
+        let weeklyReset = resetTime(planStatus["weeklyQuotaResetAtUnix"])
+        var models: [ModelQuota] = []
+
+        if !hideDaily, let dailyRemaining {
+            models.append(ModelQuota(
+                name: "devin-daily",
+                percentage: clamp(dailyRemaining),
+                resetTime: dailyReset
+            ))
+        }
+        if let weeklyRemaining {
+            models.append(ModelQuota(
+                name: "devin-weekly",
+                percentage: clamp(weeklyRemaining),
+                resetTime: weeklyReset
+            ))
+        } else if hideDaily, let dailyRemaining {
+            models.append(ModelQuota(
+                name: "devin-weekly",
+                percentage: clamp(dailyRemaining),
+                resetTime: weeklyReset
+            ))
+        }
+        if let micros = number(planStatus["overageBalanceMicros"]) {
+            models.append(ModelQuota(
+                name: "devin-extra-balance",
+                percentage: -1,
+                resetTime: "",
+                presentation: .amount(
+                    value: max(0, micros) / 1_000_000,
+                    unit: .usd,
+                    semantics: .balance
+                )
+            ))
+        }
+
+        guard !models.isEmpty else { return nil }
+        let plan = trimmed(planInfo["planName"] as? String)
+        return ProviderQuotaData(models: models, lastUpdated: Date(), planType: plan)
+    }
+
+    private static func number(_ value: Any?) -> Double? {
+        switch value {
+        case let value as NSNumber: return value.doubleValue
+        case let value as String: return Double(value)
+        default: return nil
+        }
+    }
+
+    private static func bool(_ value: Any?) -> Bool? {
+        switch value {
+        case let value as Bool: return value
+        case let value as NSNumber: return value.boolValue
+        case let value as String: return Bool(value)
+        default: return nil
+        }
+    }
+
+    private static func clamp(_ value: Double) -> Double { max(0, min(100, value)) }
+
+    private static func trimmed(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else { return nil }
+        return value
+    }
+
+    private static func resetTime(_ value: Any?) -> String {
+        guard let seconds = number(value) else { return "" }
+        return ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: seconds))
+    }
+}
+
+actor DevinQuotaFetcher {
+    static let credentialsPath = "~/.local/share/devin/credentials.toml"
+    static let stateDBPath = "~/Library/Application Support/Devin/User/globalStorage/state.vscdb"
+    static let defaultAPIServerURL = "https://server.codeium.com"
+
+    private var session: URLSession
+
+    init() {
+        session = URLSession(configuration: ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15))
+    }
+
+    func updateProxyConfiguration() {
+        session = URLSession(configuration: ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15))
+    }
+
+    func fetchAsProviderQuota() async -> [String: ProviderQuotaData] {
+        let candidates = [loadCredentialsFile(), Self.loadAppCredential()].compactMap { $0 }
+        for credential in candidates {
+            if let quota = await fetchQuota(credential: credential) {
+                return ["Devin": quota]
+            }
+        }
+        return [:]
+    }
+
+    private func fetchQuota(credential: DevinCredential) async -> ProviderQuotaData? {
+        let server = credential.apiServerURL ?? Self.defaultAPIServerURL
+        guard let url = URL(string: server + "/exa.seat_management_pb.SeatManagementService/GetUserStatus") else {
+            return nil
+        }
+        let body: [String: Any] = [
+            "metadata": [
+                "apiKey": credential.apiKey,
+                "ideName": "devin",
+                "ideVersion": "1.108.2",
+                "extensionName": "devin",
+                "extensionVersion": "1.108.2",
+                "locale": "en"
+            ]
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: body) else { return nil }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = data
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("1", forHTTPHeaderField: "Connect-Protocol-Version")
+
+        guard let (responseData, response) = try? await session.data(for: request),
+              let http = response as? HTTPURLResponse,
+              200...299 ~= http.statusCode else { return nil }
+        return DevinQuotaMapper.map(responseData)
+    }
+
+    nonisolated static func parseCredentialsTOML(_ text: String) -> DevinCredential? {
+        guard let apiKey = tomlString(text, key: "windsurf_api_key") else { return nil }
+        let server = tomlString(text, key: "api_server_url").flatMap(cleanServerURL)
+        return DevinCredential(apiKey: apiKey, apiServerURL: server)
+    }
+
+    private func loadCredentialsFile() -> DevinCredential? {
+        let path = MonitorIdentity.expand(Self.credentialsPath)
+        guard let text = try? String(contentsOfFile: path, encoding: .utf8) else { return nil }
+        return Self.parseCredentialsTOML(text)
+    }
+
+    nonisolated static func loadAppCredential(path: String = MonitorIdentity.expand(stateDBPath)) -> DevinCredential? {
+        guard FileManager.default.fileExists(atPath: path) else { return nil }
+        let uri = "file://\(path)?mode=ro&immutable=1"
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(uri, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nil) == SQLITE_OK else { return nil }
+        defer { sqlite3_close(db) }
+
+        let sql = "SELECT value FROM ItemTable WHERE key = 'windsurfAuthStatus' LIMIT 1"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else { return nil }
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW,
+              let value = sqlite3_column_text(statement, 0) else { return nil }
+        let text = String(cString: value)
+        guard let data = text.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let apiKey = trimmed(object["apiKey"] as? String) else { return nil }
+        return DevinCredential(apiKey: apiKey, apiServerURL: nil)
+    }
+
+    private nonisolated static func tomlString(_ text: String, key: String) -> String? {
+        for line in text.split(whereSeparator: \.isNewline) {
+            let pieces = line.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard pieces.count == 2,
+                  pieces[0].trimmingCharacters(in: .whitespacesAndNewlines) == key else { continue }
+            var value = pieces[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            if let comment = value.firstIndex(of: "#") { value = value[..<comment].trimmingCharacters(in: .whitespacesAndNewlines) }
+            if (value.first == "\"" && value.last == "\"") || (value.first == "'" && value.last == "'") {
+                value = value.dropFirst().dropLast().trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            return value.isEmpty ? nil : String(value)
+        }
+        return nil
+    }
+
+    private nonisolated static func cleanServerURL(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("https://") else { return nil }
+        return trimmed.hasSuffix("/") ? String(trimmed.dropLast()) : trimmed
+    }
+
+    private nonisolated static func trimmed(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else { return nil }
+        return value
+    }
+}

--- a/Quotio/Services/QuotaFetchers/DevinQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/DevinQuotaFetcher.swift
@@ -105,12 +105,28 @@ actor DevinQuotaFetcher {
 
     func fetchAsProviderQuota() async -> [String: ProviderQuotaData] {
         let candidates = [loadCredentialsFile(), Self.loadAppCredential()].compactMap { $0 }
+        var rejectedCredential: ProviderQuotaData?
         for credential in candidates {
             if let quota = await fetchQuota(credential: credential) {
+                if quota.isForbidden {
+                    rejectedCredential = quota
+                    continue
+                }
                 return ["Devin": quota]
             }
         }
+        if let rejectedCredential {
+            return ["Devin": rejectedCredential]
+        }
         return [:]
+    }
+
+    nonisolated static func quotaResult(data: Data, statusCode: Int) -> ProviderQuotaData? {
+        if statusCode == 401 || statusCode == 403 {
+            return ProviderQuotaData(isForbidden: true)
+        }
+        guard 200...299 ~= statusCode else { return nil }
+        return DevinQuotaMapper.map(data)
     }
 
     private func fetchQuota(credential: DevinCredential) async -> ProviderQuotaData? {
@@ -136,9 +152,8 @@ actor DevinQuotaFetcher {
         request.setValue("1", forHTTPHeaderField: "Connect-Protocol-Version")
 
         guard let (responseData, response) = try? await session.data(for: request),
-              let http = response as? HTTPURLResponse,
-              200...299 ~= http.statusCode else { return nil }
-        return DevinQuotaMapper.map(responseData)
+              let http = response as? HTTPURLResponse else { return nil }
+        return Self.quotaResult(data: responseData, statusCode: http.statusCode)
     }
 
     nonisolated static func parseCredentialsTOML(_ text: String) -> DevinCredential? {

--- a/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
@@ -113,8 +113,6 @@ nonisolated struct FactoryDroidQuotaResponse: Decodable, Sendable {
     let usesTokenRateLimitsBilling: Bool?
     let limits: FactoryDroidLimitPools?
     let extraUsageBalanceCents: Double?
-    let overagePreference: String?
-    let extraUsageAllowed: Bool?
 }
 
 nonisolated struct FactoryDroidAuthMeResponse: Decodable, Sendable {
@@ -211,18 +209,6 @@ nonisolated enum FactoryDroidQuotaMapper {
             ))
         }
 
-        if let allowed = response.extraUsageAllowed {
-            models.append(ModelQuota(
-                name: "factory-extra-usage",
-                percentage: -1,
-                resetTime: "",
-                presentation: .status(text: extraUsageStatus(
-                    allowed: allowed,
-                    preference: response.overagePreference
-                ))
-            ))
-        }
-
         return ProviderQuotaData(models: models, lastUpdated: now)
     }
 
@@ -246,14 +232,6 @@ nonisolated enum FactoryDroidQuotaMapper {
         }
     }
 
-    private static func extraUsageStatus(allowed: Bool, preference: String?) -> String {
-        guard allowed else { return "factory.status.extraUsageDisabled".localizedStatic() }
-        switch preference {
-        case "droidCore": return "factory.status.extraUsageCore".localizedStatic()
-        case "extraUsage": return "factory.status.extraUsageBalance".localizedStatic()
-        default: return "factory.status.extraUsageEnabled".localizedStatic()
-        }
-    }
 }
 
 actor FactoryDroidQuotaFetcher {

--- a/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
@@ -1,0 +1,278 @@
+import CryptoKit
+import Foundation
+
+nonisolated struct FactoryDroidCredential: Sendable, Equatable {
+    let accessToken: String
+    let activeOrganizationID: String?
+    let sourcePath: String
+
+    var accountKey: String {
+        activeOrganizationID ?? "Factory Droid"
+    }
+}
+
+nonisolated enum FactoryDroidCredentialReader {
+    static let credentialsDirectory = "~/.factory"
+
+    static func load(directory: URL? = nil) -> FactoryDroidCredential? {
+        let directory = directory ?? URL(
+            fileURLWithPath: MonitorIdentity.expand(credentialsDirectory),
+            isDirectory: true
+        )
+
+        let keyFileCredentials = directory.appendingPathComponent("auth.v2.file")
+        let keyFileKey = directory.appendingPathComponent("auth.v2.key")
+        if let credential = loadEncrypted(
+            credentialsURL: keyFileCredentials,
+            keyData: try? Data(contentsOf: keyFileKey)
+        ) {
+            return credential
+        }
+
+        let keyringCredentials = directory.appendingPathComponent("auth.v2.keyring")
+        let keyringKey = KeychainHelper.readExternalCredential(
+            service: "Factory CLI",
+            account: "auth-encryption-key"
+        )
+        if let credential = loadEncrypted(credentialsURL: keyringCredentials, keyData: keyringKey) {
+            return credential
+        }
+
+        let legacyURL = directory.appendingPathComponent("auth.encrypted")
+        guard let legacyData = try? Data(contentsOf: legacyURL) else { return nil }
+        if let credential = parseCredential(legacyData, sourcePath: legacyURL.path) {
+            return credential
+        }
+        guard let key = normalizedKey(keyringKey),
+              let encrypted = String(data: legacyData, encoding: .utf8),
+              let decrypted = decrypt(encrypted, key: key) else { return nil }
+        return parseCredential(decrypted, sourcePath: legacyURL.path)
+    }
+
+    static func decryptCredential(
+        encrypted: String,
+        keyData: Data,
+        sourcePath: String = "auth.v2.file"
+    ) -> FactoryDroidCredential? {
+        guard let key = normalizedKey(keyData),
+              let decrypted = decrypt(encrypted, key: key) else { return nil }
+        return parseCredential(decrypted, sourcePath: sourcePath)
+    }
+
+    private static func loadEncrypted(credentialsURL: URL, keyData: Data?) -> FactoryDroidCredential? {
+        guard let encrypted = try? String(contentsOf: credentialsURL, encoding: .utf8),
+              let keyData else { return nil }
+        return decryptCredential(
+            encrypted: encrypted.trimmingCharacters(in: .whitespacesAndNewlines),
+            keyData: keyData,
+            sourcePath: credentialsURL.path
+        )
+    }
+
+    private static func normalizedKey(_ data: Data?) -> Data? {
+        guard let data else { return nil }
+        if data.count == 32 { return data }
+        guard let string = String(data: data, encoding: .utf8),
+              let decoded = Data(base64Encoded: string.trimmingCharacters(in: .whitespacesAndNewlines)),
+              decoded.count == 32 else { return nil }
+        return decoded
+    }
+
+    private static func decrypt(_ encrypted: String, key: Data) -> Data? {
+        let pieces = encrypted.split(separator: ":", omittingEmptySubsequences: false)
+        guard pieces.count == 3,
+              let nonceData = Data(base64Encoded: String(pieces[0])),
+              let tag = Data(base64Encoded: String(pieces[1])),
+              let ciphertext = Data(base64Encoded: String(pieces[2])),
+              tag.count == 16,
+              let nonce = try? AES.GCM.Nonce(data: nonceData),
+              let sealedBox = try? AES.GCM.SealedBox(nonce: nonce, ciphertext: ciphertext, tag: tag) else {
+            return nil
+        }
+        return try? AES.GCM.open(sealedBox, using: SymmetricKey(data: key))
+    }
+
+    private static func parseCredential(_ data: Data, sourcePath: String) -> FactoryDroidCredential? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let accessToken = trimmed(json["access_token"] as? String) else { return nil }
+        return FactoryDroidCredential(
+            accessToken: accessToken,
+            activeOrganizationID: trimmed(json["active_organization_id"] as? String),
+            sourcePath: sourcePath
+        )
+    }
+
+    private static func trimmed(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value
+    }
+}
+
+nonisolated struct FactoryDroidQuotaResponse: Decodable, Sendable {
+    let usesTokenRateLimitsBilling: Bool?
+    let limits: FactoryDroidLimitPools?
+    let extraUsageBalanceCents: Double?
+    let overagePreference: String?
+    let extraUsageAllowed: Bool?
+}
+
+nonisolated struct FactoryDroidLimitPools: Decodable, Sendable {
+    let standard: FactoryDroidLimitPool?
+    let core: FactoryDroidLimitPool?
+}
+
+nonisolated struct FactoryDroidLimitPool: Decodable, Sendable {
+    let fiveHour: FactoryDroidLimitWindow?
+    let weekly: FactoryDroidLimitWindow?
+    let monthly: FactoryDroidLimitWindow?
+}
+
+nonisolated struct FactoryDroidLimitWindow: Decodable, Sendable {
+    let usedPercent: Double
+    let windowEnd: String?
+    let secondsRemaining: Double?
+}
+
+nonisolated enum FactoryDroidQuotaMapper {
+    static func map(_ response: FactoryDroidQuotaResponse, now: Date = Date()) -> ProviderQuotaData {
+        if response.usesTokenRateLimitsBilling == false {
+            return ProviderQuotaData(
+                models: [ModelQuota(
+                    name: "factory-billing-mode",
+                    percentage: -1,
+                    resetTime: "",
+                    presentation: .status(text: "factory.status.legacyBilling".localizedStatic())
+                )],
+                lastUpdated: now
+            )
+        }
+
+        var models: [ModelQuota] = []
+        append(pool: response.limits?.standard, prefix: "factory-standard", to: &models)
+        append(pool: response.limits?.core, prefix: "factory-core", to: &models)
+
+        if let cents = response.extraUsageBalanceCents {
+            models.append(ModelQuota(
+                name: "factory-extra-balance",
+                percentage: -1,
+                resetTime: "",
+                presentation: .amount(
+                    value: max(0, cents) / 100,
+                    unit: .usd,
+                    semantics: .balance
+                )
+            ))
+        }
+
+        if let allowed = response.extraUsageAllowed {
+            models.append(ModelQuota(
+                name: "factory-extra-usage",
+                percentage: -1,
+                resetTime: "",
+                presentation: .status(text: extraUsageStatus(
+                    allowed: allowed,
+                    preference: response.overagePreference
+                ))
+            ))
+        }
+
+        return ProviderQuotaData(models: models, lastUpdated: now)
+    }
+
+    private static func append(
+        pool: FactoryDroidLimitPool?,
+        prefix: String,
+        to models: inout [ModelQuota]
+    ) {
+        guard let pool else { return }
+        for (suffix, window) in [
+            ("five-hour", pool.fiveHour),
+            ("weekly", pool.weekly),
+            ("monthly", pool.monthly),
+        ] {
+            guard let window else { continue }
+            models.append(ModelQuota(
+                name: prefix + "-" + suffix,
+                percentage: max(0, min(100, 100 - window.usedPercent)),
+                resetTime: window.windowEnd ?? ""
+            ))
+        }
+    }
+
+    private static func extraUsageStatus(allowed: Bool, preference: String?) -> String {
+        guard allowed else { return "factory.status.extraUsageDisabled".localizedStatic() }
+        switch preference {
+        case "droidCore": return "factory.status.extraUsageCore".localizedStatic()
+        case "extraUsage": return "factory.status.extraUsageBalance".localizedStatic()
+        default: return "factory.status.extraUsageEnabled".localizedStatic()
+        }
+    }
+}
+
+actor FactoryDroidQuotaFetcher {
+    private let vault: MonitorCredentialStore
+    private let metadata: MonitorMetadataStore
+    private var session: URLSession
+    private let limitsURL = URL(string: "https://api.factory.ai/api/billing/limits")!
+
+    init(
+        vault: MonitorCredentialStore = MonitorCredentialVault.shared,
+        metadata: MonitorMetadataStore = .shared
+    ) {
+        self.vault = vault
+        self.metadata = metadata
+        session = URLSession(configuration: ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15))
+    }
+
+    func updateProxyConfiguration() {
+        session = URLSession(configuration: ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15))
+    }
+
+    func fetchAllQuotas() async -> [String: ProviderQuotaData] {
+        var results: [String: ProviderQuotaData] = [:]
+        let disabledAccountIDs = await metadata.disabledAccountIDs()
+
+        if let localCredential = FactoryDroidCredentialReader.load() {
+            let account = Self.localAccount(for: localCredential)
+            if !disabledAccountIDs.contains(account.id),
+               let quota = await fetch(accessToken: localCredential.accessToken) {
+                results[account.accountKey] = quota
+            }
+        }
+
+        for account in await vault.accounts()
+        where account.provider == .factoryDroid && !disabledAccountIDs.contains(account.id) {
+            guard let credential = await vault.credential(for: account.id),
+                  let quota = await fetch(accessToken: credential.accessToken) else { continue }
+            results[account.accountKey] = quota
+        }
+        return results
+    }
+
+    nonisolated static func localAccount(for credential: FactoryDroidCredential) -> MonitorAccount {
+        .make(
+            provider: .factoryDroid,
+            accountKey: credential.accountKey,
+            displayName: "Factory Droid",
+            source: .nativeCredential,
+            credentialReference: credential.sourcePath
+        )
+    }
+
+    private func fetch(accessToken: String) async -> ProviderQuotaData? {
+        var request = URLRequest(url: limitsURL)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        guard let (data, response) = try? await session.data(for: request),
+              let http = response as? HTTPURLResponse else { return nil }
+        if http.statusCode == 401 || http.statusCode == 403 {
+            return ProviderQuotaData(isForbidden: true)
+        }
+        guard 200...299 ~= http.statusCode,
+              let decoded = try? JSONDecoder().decode(FactoryDroidQuotaResponse.self, from: data) else {
+            return nil
+        }
+        return FactoryDroidQuotaMapper.map(decoded)
+    }
+}

--- a/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
@@ -117,6 +117,20 @@ nonisolated struct FactoryDroidQuotaResponse: Decodable, Sendable {
     let extraUsageAllowed: Bool?
 }
 
+nonisolated struct FactoryDroidAuthMeResponse: Decodable, Sendable {
+    struct UserProfile: Decodable, Sendable {
+        let email: String?
+    }
+
+    let userProfile: UserProfile?
+
+    var email: String? {
+        guard let email = userProfile?.email?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !email.isEmpty else { return nil }
+        return email
+    }
+}
+
 nonisolated struct FactoryDroidLimitPools: Decodable, Sendable {
     let standard: FactoryDroidLimitPool?
     let core: FactoryDroidLimitPool?
@@ -132,6 +146,38 @@ nonisolated struct FactoryDroidLimitWindow: Decodable, Sendable {
     let usedPercent: Double
     let windowEnd: String?
     let secondsRemaining: Double?
+}
+
+nonisolated enum FactoryDroidQuotaGroup: String, CaseIterable, Identifiable, Sendable {
+    case standard
+    case core
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .standard: "factory.quota.group.standard".localizedStatic()
+        case .core: "factory.quota.group.core".localizedStatic()
+        }
+    }
+
+    fileprivate var modelPrefix: String { "factory-\(rawValue)-" }
+}
+
+nonisolated struct FactoryDroidQuotaSection: Identifiable, Sendable {
+    let group: FactoryDroidQuotaGroup
+    let models: [ModelQuota]
+
+    var id: FactoryDroidQuotaGroup { group }
+    var title: String { group.title }
+
+    static func sections(from models: [ModelQuota]) -> [FactoryDroidQuotaSection] {
+        FactoryDroidQuotaGroup.allCases.compactMap { group in
+            let groupModels = models.filter { $0.name.hasPrefix(group.modelPrefix) }
+            guard !groupModels.isEmpty else { return nil }
+            return FactoryDroidQuotaSection(group: group, models: groupModels)
+        }
+    }
 }
 
 nonisolated enum FactoryDroidQuotaMapper {
@@ -215,6 +261,7 @@ actor FactoryDroidQuotaFetcher {
     private let metadata: MonitorMetadataStore
     private var session: URLSession
     private let limitsURL = URL(string: "https://api.factory.ai/api/billing/limits")!
+    private let profileURL = URL(string: "https://api.factory.ai/api/app/auth/me")!
 
     init(
         vault: MonitorCredentialStore = MonitorCredentialVault.shared,
@@ -261,6 +308,8 @@ actor FactoryDroidQuotaFetcher {
     }
 
     private func fetch(accessToken: String) async -> ProviderQuotaData? {
+        async let profile = fetchProfile(accessToken: accessToken)
+
         var request = URLRequest(url: limitsURL)
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
@@ -273,6 +322,18 @@ actor FactoryDroidQuotaFetcher {
               let decoded = try? JSONDecoder().decode(FactoryDroidQuotaResponse.self, from: data) else {
             return nil
         }
-        return FactoryDroidQuotaMapper.map(decoded)
+        var quota = FactoryDroidQuotaMapper.map(decoded)
+        quota.accountDisplayName = await profile?.email
+        return quota
+    }
+
+    private func fetchProfile(accessToken: String) async -> FactoryDroidAuthMeResponse? {
+        var request = URLRequest(url: profileURL)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        guard let (data, response) = try? await session.data(for: request),
+              let http = response as? HTTPURLResponse,
+              200...299 ~= http.statusCode else { return nil }
+        return try? JSONDecoder().decode(FactoryDroidAuthMeResponse.self, from: data)
     }
 }

--- a/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
@@ -193,8 +193,8 @@ nonisolated enum FactoryDroidQuotaMapper {
         }
 
         var models: [ModelQuota] = []
-        append(pool: response.limits?.standard, prefix: "factory-standard", to: &models)
-        append(pool: response.limits?.core, prefix: "factory-core", to: &models)
+        append(pool: response.limits?.standard, prefix: "factory-standard", now: now, to: &models)
+        append(pool: response.limits?.core, prefix: "factory-core", now: now, to: &models)
 
         if let cents = response.extraUsageBalanceCents {
             models.append(ModelQuota(
@@ -215,6 +215,7 @@ nonisolated enum FactoryDroidQuotaMapper {
     private static func append(
         pool: FactoryDroidLimitPool?,
         prefix: String,
+        now: Date,
         to models: inout [ModelQuota]
     ) {
         guard let pool else { return }
@@ -224,12 +225,21 @@ nonisolated enum FactoryDroidQuotaMapper {
             ("monthly", pool.monthly),
         ] {
             guard let window else { continue }
+            let usedPercent = isExpired(window.windowEnd, now: now) ? 0 : window.usedPercent
             models.append(ModelQuota(
                 name: prefix + "-" + suffix,
-                percentage: max(0, min(100, 100 - window.usedPercent)),
+                percentage: max(0, min(100, 100 - usedPercent)),
                 resetTime: window.windowEnd ?? ""
             ))
         }
+    }
+
+    private static func isExpired(_ windowEnd: String?, now: Date) -> Bool {
+        guard let windowEnd else { return false }
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let endDate = fractional.date(from: windowEnd) ?? ISO8601DateFormatter().date(from: windowEnd)
+        return endDate.map { $0 < now } ?? false
     }
 
 }

--- a/Quotio/Services/QuotaFetchers/GrokQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/GrokQuotaFetcher.swift
@@ -1,0 +1,249 @@
+import Foundation
+
+nonisolated struct GrokAuthCandidate: Sendable, Equatable {
+    let entryKey: String
+    let accessToken: String
+    let refreshToken: String?
+    let idToken: String?
+    let clientID: String
+    let expiresAt: Date?
+
+    var displayName: String {
+        MonitorIdentity.jwtString(idToken, claim: "email") ?? "Grok " + String(entryKey.prefix(8))
+    }
+}
+
+nonisolated enum GrokQuotaMapper {
+    static let weeklyPeriodType = "USAGE_PERIOD_TYPE_WEEKLY"
+
+    static func mapBilling(_ data: Data, plan: String?) -> ProviderQuotaData? {
+        guard let body = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let config = body["config"] as? [String: Any],
+              let period = config["currentPeriod"] as? [String: Any],
+              let periodType = period["type"] as? String else { return nil }
+
+        var models: [ModelQuota] = []
+        if periodType == weeklyPeriodType,
+           let endString = period["end"] as? String,
+           parseDate(endString) != nil {
+            let used = number(config["creditUsagePercent"]) ?? 0
+            models.append(ModelQuota(
+                name: "grok-weekly",
+                percentage: max(0, min(100, 100 - used)),
+                resetTime: ISO8601DateFormatter().string(from: parseDate(endString)!)
+            ))
+        }
+
+        let cap = number((config["onDemandCap"] as? [String: Any])?["val"]) ?? 0
+        let status = cap > 0
+            ? String(format: "grok.status.cap".localizedStatic(), formatUnits(cap))
+            : "grok.status.disabled".localizedStatic()
+        models.append(ModelQuota(
+            name: "grok-extra-usage",
+            percentage: -1,
+            resetTime: "",
+            presentation: .status(text: status)
+        ))
+        return ProviderQuotaData(models: models, lastUpdated: Date(), planType: plan)
+    }
+
+    static func planName(_ data: Data) -> String? {
+        guard let body = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return trimmed(body["subscription_tier_display"] as? String)
+    }
+
+    private static func number(_ value: Any?) -> Double? {
+        switch value {
+        case let value as NSNumber: return value.doubleValue
+        case let value as String: return Double(value)
+        default: return nil
+        }
+    }
+
+    private static func parseDate(_ value: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fractional.date(from: value) ?? ISO8601DateFormatter().date(from: value)
+    }
+
+    private static func formatUnits(_ value: Double) -> String {
+        value.rounded() == value ? String(Int(value)) : String(value)
+    }
+
+    private static func trimmed(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else { return nil }
+        return value
+    }
+}
+
+actor GrokQuotaFetcher {
+    static let authPath = "~/.grok/auth.json"
+    static let defaultClientID = "b1a00492-073a-47ea-816f-4c329264a828"
+
+    private let billingURL = URL(string: "https://cli-chat-proxy.grok.com/v1/billing?format=credits")!
+    private let settingsURL = URL(string: "https://cli-chat-proxy.grok.com/v1/settings")!
+    private let refreshURL = URL(string: "https://auth.x.ai/oauth2/token")!
+    private var session: URLSession
+
+    init() {
+        session = URLSession(configuration: ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15))
+    }
+
+    func updateProxyConfiguration() {
+        session = URLSession(configuration: ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15))
+    }
+
+    func fetchAllQuotas() async -> [String: ProviderQuotaData] {
+        var results: [String: ProviderQuotaData] = [:]
+        for candidate in Self.loadCandidates() {
+            if let quota = await fetchQuota(candidate) {
+                results[candidate.entryKey] = quota
+            }
+        }
+        return results
+    }
+
+    nonisolated static func loadCandidates(path: String = MonitorIdentity.expand(authPath)) -> [GrokAuthCandidate] {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return [] }
+        return root.compactMap { key, raw in
+            guard let entry = raw as? [String: Any],
+                  let token = trimmed(entry["key"] as? String) else { return nil }
+            let entryClientID = trimmed(entry["oidc_client_id"] as? String)
+                ?? trimmed(key.split(separator: "::").last.map(String.init))
+                ?? defaultClientID
+            return GrokAuthCandidate(
+                entryKey: key,
+                accessToken: token,
+                refreshToken: trimmed((entry["refresh_token"] as? String) ?? (entry["refresh"] as? String)),
+                idToken: trimmed(entry["id_token"] as? String),
+                clientID: entryClientID,
+                expiresAt: expiryDate(entry: entry, token: token)
+            )
+        }.sorted { $0.entryKey < $1.entryKey }
+    }
+
+    private func fetchQuota(_ original: GrokAuthCandidate) async -> ProviderQuotaData? {
+        var candidate = original
+        if let expiry = candidate.expiresAt, expiry.timeIntervalSinceNow <= 300,
+           let refreshed = await refresh(candidate) {
+            candidate = refreshed
+        }
+
+        var billing = await get(billingURL, token: candidate.accessToken)
+        if billing?.1.statusCode == 401 || billing?.1.statusCode == 403,
+           let refreshed = await refresh(candidate) {
+            candidate = refreshed
+            billing = await get(billingURL, token: candidate.accessToken)
+        }
+        guard let (billingData, billingResponse) = billing,
+              200...299 ~= billingResponse.statusCode else { return nil }
+
+        let plan: String?
+        if let (settingsData, settingsResponse) = await get(settingsURL, token: candidate.accessToken),
+           200...299 ~= settingsResponse.statusCode {
+            plan = GrokQuotaMapper.planName(settingsData)
+        } else {
+            plan = nil
+        }
+        return GrokQuotaMapper.mapBilling(billingData, plan: plan)
+    }
+
+    private func get(_ url: URL, token: String) async -> (Data, HTTPURLResponse)? {
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("xai-grok-cli", forHTTPHeaderField: "X-XAI-Token-Auth")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Quotio", forHTTPHeaderField: "User-Agent")
+        guard let (data, response) = try? await session.data(for: request),
+              let http = response as? HTTPURLResponse else { return nil }
+        return (data, http)
+    }
+
+    private func refresh(_ candidate: GrokAuthCandidate) async -> GrokAuthCandidate? {
+        guard let refreshToken = candidate.refreshToken else { return nil }
+        let body = "grant_type=refresh_token&client_id=\(Self.formEncoded(candidate.clientID))&refresh_token=\(Self.formEncoded(refreshToken))"
+        var request = URLRequest(url: refreshURL)
+        request.httpMethod = "POST"
+        request.httpBody = Data(body.utf8)
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        guard let (data, response) = try? await session.data(for: request),
+              let http = response as? HTTPURLResponse,
+              200...299 ~= http.statusCode,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let accessToken = Self.trimmed(json["access_token"] as? String) else { return nil }
+
+        let rotatedRefresh = Self.trimmed(json["refresh_token"] as? String) ?? refreshToken
+        let idToken = Self.trimmed(json["id_token"] as? String) ?? candidate.idToken
+        let expiresIn = (json["expires_in"] as? NSNumber)?.doubleValue ?? 3600
+        let expiresAt = Date().addingTimeInterval(expiresIn)
+        do {
+            try Self.persistRotatedCredential(
+                entryKey: candidate.entryKey,
+                accessToken: accessToken,
+                refreshToken: rotatedRefresh,
+                idToken: idToken,
+                expiresAt: expiresAt
+            )
+        } catch {
+            Log.quota("Failed to persist refreshed Grok credential: \(error.localizedDescription)")
+        }
+        return GrokAuthCandidate(
+            entryKey: candidate.entryKey,
+            accessToken: accessToken,
+            refreshToken: rotatedRefresh,
+            idToken: idToken,
+            clientID: candidate.clientID,
+            expiresAt: expiresAt
+        )
+    }
+
+    nonisolated static func persistRotatedCredential(
+        path: String = MonitorIdentity.expand(authPath),
+        entryKey: String,
+        accessToken: String,
+        refreshToken: String?,
+        idToken: String?,
+        expiresAt: Date
+    ) throws {
+        let url = URL(fileURLWithPath: path)
+        guard let data = try? Data(contentsOf: url),
+              var root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              var entry = root[entryKey] as? [String: Any] else {
+            throw MonitorRuntimeError.invalidCredential
+        }
+        entry["key"] = accessToken
+        if let refreshToken { entry["refresh_token"] = refreshToken }
+        if let idToken { entry["id_token"] = idToken }
+        entry["expires_at"] = ISO8601DateFormatter().string(from: expiresAt)
+        root[entryKey] = entry
+        let updated = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+        try SecureAtomicFileWriter.write(updated, to: url)
+    }
+
+    private nonisolated static func expiryDate(entry: [String: Any], token: String) -> Date? {
+        for key in ["expires_at", "expires"] {
+            guard let value = entry[key] as? String else { continue }
+            let fractional = ISO8601DateFormatter()
+            fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let date = fractional.date(from: value) ?? ISO8601DateFormatter().date(from: value) { return date }
+        }
+        let pieces = token.split(separator: ".", omittingEmptySubsequences: false)
+        guard pieces.count > 1 else { return nil }
+        var payload = String(pieces[1]).replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        payload += String(repeating: "=", count: (4 - payload.count % 4) % 4)
+        guard let data = Data(base64Encoded: payload),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let exp = json["exp"] as? NSNumber else { return nil }
+        return Date(timeIntervalSince1970: exp.doubleValue)
+    }
+
+    private nonisolated static func trimmed(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else { return nil }
+        return value
+    }
+
+    private nonisolated static func formEncoded(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed.subtracting(CharacterSet(charactersIn: "+&="))) ?? value
+    }
+}

--- a/Quotio/Services/QuotaFetchers/GrokQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/GrokQuotaFetcher.swift
@@ -103,6 +103,21 @@ actor GrokQuotaFetcher {
         return results
     }
 
+    nonisolated static func quotaResult(
+        data: Data,
+        statusCode: Int,
+        plan: String?,
+        displayName: String
+    ) -> ProviderQuotaData? {
+        if statusCode == 401 || statusCode == 403 {
+            return ProviderQuotaData(isForbidden: true, accountDisplayName: displayName)
+        }
+        guard 200...299 ~= statusCode,
+              var quota = GrokQuotaMapper.mapBilling(data, plan: plan) else { return nil }
+        quota.accountDisplayName = displayName
+        return quota
+    }
+
     nonisolated static func loadCandidates(path: String = MonitorIdentity.expand(authPath)) -> [GrokAuthCandidate] {
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return [] }
@@ -136,8 +151,16 @@ actor GrokQuotaFetcher {
             candidate = refreshed
             billing = await get(billingURL, token: candidate.accessToken)
         }
-        guard let (billingData, billingResponse) = billing,
-              200...299 ~= billingResponse.statusCode else { return nil }
+        guard let (billingData, billingResponse) = billing else { return nil }
+        if billingResponse.statusCode == 401 || billingResponse.statusCode == 403 {
+            return Self.quotaResult(
+                data: billingData,
+                statusCode: billingResponse.statusCode,
+                plan: nil,
+                displayName: candidate.displayName
+            )
+        }
+        guard 200...299 ~= billingResponse.statusCode else { return nil }
 
         let plan: String?
         if let (settingsData, settingsResponse) = await get(settingsURL, token: candidate.accessToken),
@@ -146,7 +169,12 @@ actor GrokQuotaFetcher {
         } else {
             plan = nil
         }
-        return GrokQuotaMapper.mapBilling(billingData, plan: plan)
+        return Self.quotaResult(
+            data: billingData,
+            statusCode: billingResponse.statusCode,
+            plan: plan,
+            displayName: candidate.displayName
+        )
     }
 
     private func get(_ url: URL, token: String) async -> (Data, HTTPURLResponse)? {

--- a/Quotio/Services/QuotaFetchers/GrokQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/GrokQuotaFetcher.swift
@@ -125,7 +125,7 @@ actor GrokQuotaFetcher {
             guard let entry = raw as? [String: Any],
                   let token = trimmed(entry["key"] as? String) else { return nil }
             let entryClientID = trimmed(entry["oidc_client_id"] as? String)
-                ?? trimmed(key.split(separator: "::").last.map(String.init))
+                ?? clientID(fromEntryKey: key)
                 ?? defaultClientID
             return GrokAuthCandidate(
                 entryKey: key,
@@ -136,6 +136,11 @@ actor GrokQuotaFetcher {
                 expiresAt: expiryDate(entry: entry, token: token)
             )
         }.sorted { $0.entryKey < $1.entryKey }
+    }
+
+    private nonisolated static func clientID(fromEntryKey key: String) -> String? {
+        guard let separator = key.range(of: "::", options: .backwards) else { return nil }
+        return trimmed(String(key[separator.upperBound...]))
     }
 
     private func fetchQuota(_ original: GrokAuthCandidate) async -> ProviderQuotaData? {

--- a/Quotio/Services/QuotaFetchers/OpenRouterQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/OpenRouterQuotaFetcher.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+nonisolated struct OpenRouterEndpointResult: Sendable {
+    let data: Data?
+    let statusCode: Int?
+
+    var succeeded: Bool {
+        guard let statusCode else { return false }
+        return 200...299 ~= statusCode && data != nil
+    }
+
+    var isAuthenticationFailure: Bool {
+        statusCode == 401 || statusCode == 403
+    }
+}
+
+nonisolated enum OpenRouterQuotaMapper {
+    static func map(
+        credits: OpenRouterEndpointResult,
+        key: OpenRouterEndpointResult,
+        now: Date = Date()
+    ) -> ProviderQuotaData? {
+        guard credits.succeeded || key.succeeded else {
+            if credits.isAuthenticationFailure && key.isAuthenticationFailure {
+                return ProviderQuotaData(isForbidden: true)
+            }
+            return nil
+        }
+
+        var models: [ModelQuota] = []
+        var plan: String?
+
+        if let data = credits.data, credits.succeeded,
+           let body = object(data) {
+            let payload = dictionary(body["data"]) ?? body
+            let purchased = max(0, number(payload["total_credits"]) ?? 0)
+            if let spentValue = number(payload["total_usage"]) {
+                let spent = max(0, spentValue)
+                if purchased > 0 {
+                    models.append(ModelQuota(
+                        name: "openrouter-credits",
+                        percentage: remainingPercentage(used: spent, limit: purchased),
+                        resetTime: "",
+                        presentation: .progress(used: spent, limit: purchased, unit: .usd)
+                    ))
+                }
+                models.append(amount("openrouter-balance", value: max(0, purchased - spent), semantics: .balance))
+            } else if let balance = number(payload["balance"]) {
+                models.append(amount("openrouter-balance", value: balance, semantics: .balance))
+            }
+        }
+
+        if let data = key.data, key.succeeded,
+           let body = object(data) {
+            let payload = dictionary(body["data"]) ?? body
+            let isFree = bool(payload["is_free_tier"])
+            plan = isFree == true ? "Free tier" : "Pay as you go"
+            for (name, field) in [
+                ("openrouter-today", "usage_daily"),
+                ("openrouter-week", "usage_weekly"),
+                ("openrouter-month", "usage_monthly"),
+            ] {
+                if let value = number(payload[field]) {
+                    models.append(amount(name, value: max(0, value), semantics: .spent))
+                }
+            }
+            if let limit = number(payload["limit"]), limit > 0 {
+                let used = number(payload["usage"]) ?? max(0, limit - (number(payload["limit_remaining"]) ?? limit))
+                models.append(ModelQuota(
+                    name: "openrouter-key-limit",
+                    percentage: remainingPercentage(used: used, limit: limit),
+                    resetTime: "",
+                    presentation: .progress(used: used, limit: limit, unit: .usd)
+                ))
+            }
+        }
+
+        guard !models.isEmpty else { return ProviderQuotaData(models: [], lastUpdated: now, planType: plan) }
+        return ProviderQuotaData(models: models, lastUpdated: now, planType: plan)
+    }
+
+    private static func amount(_ name: String, value: Double, semantics: QuotaAmountSemantics) -> ModelQuota {
+        ModelQuota(
+            name: name,
+            percentage: -1,
+            resetTime: "",
+            presentation: .amount(value: value, unit: .usd, semantics: semantics)
+        )
+    }
+
+    private static func remainingPercentage(used: Double, limit: Double) -> Double {
+        max(0, min(100, (limit - used) / limit * 100))
+    }
+
+    private static func object(_ data: Data) -> [String: Any]? {
+        try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    private static func dictionary(_ value: Any?) -> [String: Any]? { value as? [String: Any] }
+
+    private static func number(_ value: Any?) -> Double? {
+        switch value {
+        case let value as NSNumber: value.doubleValue
+        case let value as String: Double(value)
+        default: nil
+        }
+    }
+
+    private static func bool(_ value: Any?) -> Bool? {
+        switch value {
+        case let value as Bool: value
+        case let value as NSNumber: value.boolValue
+        case let value as String: Bool(value)
+        default: nil
+        }
+    }
+}
+
+actor OpenRouterQuotaFetcher {
+    private let vault: MonitorCredentialStore
+    private let metadata: MonitorMetadataStore
+    private var session: URLSession
+    private let creditsURL = URL(string: "https://openrouter.ai/api/v1/credits")!
+    private let keyURL = URL(string: "https://openrouter.ai/api/v1/key")!
+
+    init(
+        vault: MonitorCredentialStore = MonitorCredentialVault.shared,
+        metadata: MonitorMetadataStore = .shared
+    ) {
+        self.vault = vault
+        self.metadata = metadata
+        session = URLSession(configuration: ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15))
+    }
+
+    func updateProxyConfiguration() {
+        session = URLSession(configuration: ProxyConfigurationService.createProxiedConfigurationStatic(timeout: 15))
+    }
+
+    func fetchAllQuotas() async -> [String: ProviderQuotaData] {
+        var results: [String: ProviderQuotaData] = [:]
+        let disabledAccountIDs = await metadata.disabledAccountIDs()
+        for account in await vault.accounts()
+        where account.provider == .openRouter && !disabledAccountIDs.contains(account.id) {
+            guard let credential = await vault.credential(for: account.id) else { continue }
+            async let credits = fetch(creditsURL, apiKey: credential.accessToken)
+            async let key = fetch(keyURL, apiKey: credential.accessToken)
+            if let quota = OpenRouterQuotaMapper.map(credits: await credits, key: await key) {
+                results[account.accountKey] = quota
+            }
+        }
+        return results
+    }
+
+    private func fetch(_ url: URL, apiKey: String) async -> OpenRouterEndpointResult {
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        guard let (data, response) = try? await session.data(for: request),
+              let http = response as? HTTPURLResponse else {
+            return OpenRouterEndpointResult(data: nil, statusCode: nil)
+        }
+        return OpenRouterEndpointResult(data: data, statusCode: http.statusCode)
+    }
+}

--- a/Quotio/Services/QuotaFetchers/OpenRouterQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/OpenRouterQuotaFetcher.swift
@@ -21,7 +21,7 @@ nonisolated enum OpenRouterQuotaMapper {
         now: Date = Date()
     ) -> ProviderQuotaData? {
         guard credits.succeeded || key.succeeded else {
-            if credits.isAuthenticationFailure && key.isAuthenticationFailure {
+            if credits.isAuthenticationFailure || key.isAuthenticationFailure {
                 return ProviderQuotaData(isForbidden: true)
             }
             return nil

--- a/Quotio/Services/QuotaFetchers/OpenRouterQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/OpenRouterQuotaFetcher.swift
@@ -54,7 +54,7 @@ nonisolated enum OpenRouterQuotaMapper {
            let body = object(data) {
             let payload = dictionary(body["data"]) ?? body
             let isFree = bool(payload["is_free_tier"])
-            plan = isFree == true ? "Free tier" : "Pay as you go"
+            plan = (isFree == true ? "openrouter.plan.freeTier" : "openrouter.plan.payAsYouGo").localizedStatic()
             for (name, field) in [
                 ("openrouter-today", "usage_daily"),
                 ("openrouter-week", "usage_weekly"),

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -1005,28 +1005,45 @@ private struct MenuAccountCardView: View {
             if isAntigravity {
                 return antigravityGroups.map { ModelBadgeData(name: $0.name, percentage: $0.percentage, resetTime: $0.resetTime) }
             } else {
-                return data.models.map { ModelBadgeData(name: $0.displayName, percentage: $0.percentage, resetTime: $0.resetTime) }
+                return data.models.filter { !$0.isStandaloneMetric }.map {
+                    ModelBadgeData(name: $0.displayName, percentage: $0.percentage, resetTime: $0.resetTime)
+                }
             }
         }()
+        let standaloneModels = isAntigravity ? [] : data.models.filter(\.isStandaloneMetric)
         
         let displayStyle = settings.quotaDisplayStyle
         
-        return Group {
-            if models.isEmpty {
+        return VStack(spacing: 8) {
+            if models.isEmpty && standaloneModels.isEmpty {
                 Text("dashboard.noQuotaData".localized())
                     .font(.caption)
                     .foregroundStyle(.tertiary)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding(.vertical, 8)
-            } else if displayStyle == .lowestBar {
+            } else if !models.isEmpty && displayStyle == .lowestBar {
                 // Modern Lowest Bar: Big highlighted row for bottleneck, others compact
                 LowestBarLayout(models: models)
-            } else if displayStyle == .ring {
+            } else if !models.isEmpty && displayStyle == .ring {
                 // Ring Grid
                 RingGridLayout(models: models)
-            } else {
+            } else if !models.isEmpty {
                 // Standard Card Grid (Bars)
                 CardGridLayout(models: models)
+            }
+
+            ForEach(standaloneModels) { model in
+                HStack(spacing: 8) {
+                    Text(model.displayName)
+                        .font(.system(size: 10, weight: .medium, design: .rounded))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(model.formattedUsage ?? "—")
+                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(.primary)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 5)
             }
         }
     }
@@ -2333,19 +2350,19 @@ private struct MenuModelDetailView: View {
                     .foregroundStyle(.tertiary)
             }
 
-            if displayStyle != .ring {
+            if !model.isStandaloneMetric && displayStyle != .ring {
                 Text(String(format: "%.0f%% %@", displayPercent, displayMode.suffixKey.localized()))
                     .font(.system(size: 10, weight: .semibold, design: .rounded))
                     .foregroundStyle(statusColor)
             }
 
-            if model.formattedResetTime != "—" && !model.formattedResetTime.isEmpty {
+            if !model.isStandaloneMetric && model.formattedResetTime != "—" && !model.formattedResetTime.isEmpty {
                 Text(model.formattedResetTime)
                     .font(.system(size: 9, design: .rounded))
                     .foregroundStyle(.tertiary)
             }
 
-            if displayStyle == .ring {
+            if !model.isStandaloneMetric && displayStyle == .ring {
                 RingProgressView(percent: displayPercent, size: 14, lineWidth: 2, tint: statusColor)
             }
         }
@@ -2433,7 +2450,10 @@ private extension AIProvider {
         case .iflow: return "iFlow"
         case .vertex: return "Vertex"
         case .kiro: return "Kiro"
-        case .glm: return "GLM"
+        case .devin: return "Devin"
+        case .grok: return "Grok"
+        case .openRouter: return "OpenRouter"
+        case .glm: return "Z.ai"
         case .warp: return "Warp"
         case .clinePass: return "ClinePass"
         }

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -222,7 +222,8 @@ final class StatusBarMenuBuilder {
 
     private func accountsForProvider(_ provider: AIProvider) -> [(email: String, data: ProviderQuotaData)] {
         guard let quotas = viewModel.providerQuotas[provider] else { return [] }
-        return quotas.map { ($0.key, $0.value) }.sorted { $0.email < $1.email }
+        return quotas.map { ($0.value.accountDisplayName ?? $0.key, $0.value) }
+            .sorted { $0.email < $1.email }
     }
 
     // MARK: - Header Item
@@ -1011,8 +1012,9 @@ private struct MenuAccountCardView: View {
             }
         }()
         let standaloneModels = isAntigravity ? [] : data.models.filter(\.isStandaloneMetric)
-        
-        let displayStyle = settings.quotaDisplayStyle
+        let factorySections = provider == .factoryDroid
+            ? FactoryDroidQuotaSection.sections(from: data.models.filter { !$0.isStandaloneMetric })
+            : []
         
         return VStack(spacing: 8) {
             if models.isEmpty && standaloneModels.isEmpty {
@@ -1021,15 +1023,17 @@ private struct MenuAccountCardView: View {
                     .foregroundStyle(.tertiary)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding(.vertical, 8)
-            } else if !models.isEmpty && displayStyle == .lowestBar {
-                // Modern Lowest Bar: Big highlighted row for bottleneck, others compact
-                LowestBarLayout(models: models)
-            } else if !models.isEmpty && displayStyle == .ring {
-                // Ring Grid
-                RingGridLayout(models: models)
+            } else if !factorySections.isEmpty {
+                ForEach(factorySections) { section in
+                    VStack(alignment: .leading, spacing: 6) {
+                        FactoryDroidMenuSectionHeader(title: section.title)
+                        quotaLayout(models: section.models.map {
+                            ModelBadgeData(name: $0.displayName, percentage: $0.percentage, resetTime: $0.resetTime)
+                        })
+                    }
+                }
             } else if !models.isEmpty {
-                // Standard Card Grid (Bars)
-                CardGridLayout(models: models)
+                quotaLayout(models: models)
             }
 
             ForEach(standaloneModels) { model in
@@ -1045,6 +1049,18 @@ private struct MenuAccountCardView: View {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 5)
             }
+        }
+    }
+
+    @ViewBuilder
+    private func quotaLayout(models: [ModelBadgeData]) -> some View {
+        switch settings.quotaDisplayStyle {
+        case .lowestBar:
+            LowestBarLayout(models: models)
+        case .ring:
+            RingGridLayout(models: models)
+        case .card:
+            CardGridLayout(models: models)
         }
     }
     
@@ -1098,6 +1114,21 @@ private struct MenuAccountCardView: View {
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
         return formatter.string(from: date)
+    }
+}
+
+private struct FactoryDroidMenuSectionHeader: View {
+    let title: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(title)
+                .font(.system(size: 9, weight: .semibold, design: .rounded))
+                .foregroundStyle(.secondary)
+            Rectangle()
+                .fill(Color.primary.opacity(0.08))
+                .frame(height: 1)
+        }
     }
 }
 

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -2450,6 +2450,7 @@ private extension AIProvider {
         case .iflow: return "iFlow"
         case .vertex: return "Vertex"
         case .kiro: return "Kiro"
+        case .factoryDroid: return "Factory Droid"
         case .devin: return "Devin"
         case .grok: return "Grok"
         case .openRouter: return "OpenRouter"

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -21,6 +21,7 @@ final class QuotaViewModel {
     @ObservationIgnored private let glmFetcher = GLMQuotaFetcher()
     @ObservationIgnored private let warpFetcher = WarpQuotaFetcher()
     @ObservationIgnored private let clinePassFetcher = ClinePassQuotaFetcher()
+    @ObservationIgnored private let factoryDroidFetcher = FactoryDroidQuotaFetcher()
     @ObservationIgnored private let devinFetcher = DevinQuotaFetcher()
     @ObservationIgnored private let grokFetcher = GrokQuotaFetcher()
     @ObservationIgnored private let openRouterFetcher = OpenRouterQuotaFetcher()
@@ -253,6 +254,7 @@ final class QuotaViewModel {
         await clinePassFetcher.updateProxyConfiguration()
         await traeFetcher.updateProxyConfiguration()
         await kiroFetcher.updateProxyConfiguration()
+        await factoryDroidFetcher.updateProxyConfiguration()
         await devinFetcher.updateProxyConfiguration()
         await grokFetcher.updateProxyConfiguration()
         await openRouterFetcher.updateProxyConfiguration()
@@ -412,21 +414,44 @@ final class QuotaViewModel {
     }
 
     func saveOpenRouterAccount(label: String, apiKey: String, existingAccountID: String? = nil) async throws {
+        try await saveMonitorAPIKeyAccount(
+            provider: .openRouter,
+            label: label,
+            apiKey: apiKey,
+            existingAccountID: existingAccountID
+        )
+    }
+
+    func saveFactoryDroidAccount(label: String, apiKey: String, existingAccountID: String? = nil) async throws {
+        try await saveMonitorAPIKeyAccount(
+            provider: .factoryDroid,
+            label: label,
+            apiKey: apiKey,
+            existingAccountID: existingAccountID
+        )
+    }
+
+    private func saveMonitorAPIKeyAccount(
+        provider: AIProvider,
+        label: String,
+        apiKey: String,
+        existingAccountID: String?
+    ) async throws {
         let trimmedLabel = label.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedLabel.isEmpty, !trimmedKey.isEmpty else { throw MonitorRuntimeError.invalidCredential }
 
         let account: MonitorAccount
         if let existingAccountID,
-           let existing = monitorAccounts.first(where: { $0.id == existingAccountID && $0.provider == .openRouter }) {
+           let existing = monitorAccounts.first(where: { $0.id == existingAccountID && $0.provider == provider }) {
             account = existing
             _ = await MonitorCredentialVault.shared.credential(for: existing.id)
         } else {
             guard !monitorAccounts.contains(where: {
-                $0.provider == .openRouter && $0.accountKey.caseInsensitiveCompare(trimmedLabel) == .orderedSame
+                $0.provider == provider && $0.accountKey.caseInsensitiveCompare(trimmedLabel) == .orderedSame
             }) else { throw MonitorRuntimeError.invalidCredential }
             account = .make(
-                provider: .openRouter,
+                provider: provider,
                 accountKey: trimmedLabel,
                 source: .quotioKeychain,
                 credentialReference: "keychain",
@@ -464,7 +489,7 @@ final class QuotaViewModel {
         let discoveredAccountKeys = Dictionary(grouping: discoveredAccounts, by: \.provider)
             .mapValues { Set($0.map(\.accountKey)) }
         let credentialProviders: Set<AIProvider> = [
-            .codex, .claude, .gemini, .copilot, .kiro, .antigravity, .devin, .grok, .openRouter,
+            .codex, .claude, .gemini, .copilot, .kiro, .antigravity, .factoryDroid, .devin, .grok, .openRouter,
         ]
         let credentialAvailability = Dictionary(uniqueKeysWithValues: credentialProviders.map {
             ($0, discoveredProviders.contains($0) ? MonitorCredentialAvailability.present : .missing)
@@ -478,10 +503,14 @@ final class QuotaViewModel {
         let clineQuotaFetcher = clinePassFetcher
         let warpQuotaFetcher = warpFetcher
         let antigravityQuotaFetcher = antigravityFetcher
+        let factoryDroidQuotaFetcher = factoryDroidFetcher
         let devinQuotaFetcher = devinFetcher
         let grokQuotaFetcher = grokFetcher
         let openRouterQuotaFetcher = openRouterFetcher
         let warpTokens = WarpService.shared.tokens.filter { $0.isEnabled }
+        let factoryDroidPrevious = previous[.factoryDroid]?.filter {
+            discoveredAccountKeys[.factoryDroid]?.contains($0.key) == true
+        } ?? [:]
         let devinPrevious = previous[.devin]?.filter {
             discoveredAccountKeys[.devin]?.contains($0.key) == true
         } ?? [:]
@@ -556,6 +585,14 @@ final class QuotaViewModel {
             let (quotas, _) = await antigravityQuotaFetcher.fetchAllAntigravityData(includeMonitorCredentials: true)
             return quotas
         }
+        async let factoryDroid = coordinator.refresh(
+            provider: .factoryDroid,
+            force: force,
+            previous: factoryDroidPrevious,
+            credentialAvailability: credentialAvailability[.factoryDroid] ?? .unknown
+        ) {
+            await factoryDroidQuotaFetcher.fetchAllQuotas()
+        }
         async let devin = coordinator.refresh(
             provider: .devin,
             force: force,
@@ -590,6 +627,7 @@ final class QuotaViewModel {
         providerQuotas[.clinePass] = await clinePass
         providerQuotas[.warp] = await warp
         providerQuotas[.antigravity] = await antigravity
+        providerQuotas[.factoryDroid] = await factoryDroid
         providerQuotas[.devin] = await devin
         providerQuotas[.grok] = await grok
         providerQuotas[.openRouter] = await openRouter

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -444,8 +444,25 @@ final class QuotaViewModel {
         let account: MonitorAccount
         if let existingAccountID,
            let existing = monitorAccounts.first(where: { $0.id == existingAccountID && $0.provider == provider }) {
-            account = existing
+            guard !monitorAccounts.contains(where: {
+                $0.id != existing.id
+                    && $0.provider == provider
+                    && $0.accountKey.caseInsensitiveCompare(trimmedLabel) == .orderedSame
+            }) else { throw MonitorRuntimeError.invalidCredential }
+            account = MonitorAccount(
+                id: existing.id,
+                provider: existing.provider,
+                accountKey: trimmedLabel,
+                displayName: trimmedLabel,
+                source: existing.source,
+                credentialReference: existing.credentialReference,
+                canDelete: existing.canDelete,
+                isDisabled: existing.isDisabled
+            )
             _ = await MonitorCredentialVault.shared.credential(for: existing.id)
+            if existing.accountKey != trimmedLabel {
+                providerQuotas[provider]?.removeValue(forKey: existing.accountKey)
+            }
         } else {
             guard !monitorAccounts.contains(where: {
                 $0.provider == provider && $0.accountKey.caseInsensitiveCompare(trimmedLabel) == .orderedSame

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -21,6 +21,9 @@ final class QuotaViewModel {
     @ObservationIgnored private let glmFetcher = GLMQuotaFetcher()
     @ObservationIgnored private let warpFetcher = WarpQuotaFetcher()
     @ObservationIgnored private let clinePassFetcher = ClinePassQuotaFetcher()
+    @ObservationIgnored private let devinFetcher = DevinQuotaFetcher()
+    @ObservationIgnored private let grokFetcher = GrokQuotaFetcher()
+    @ObservationIgnored private let openRouterFetcher = OpenRouterQuotaFetcher()
     @ObservationIgnored private let directAuthService = DirectAuthFileService()
     @ObservationIgnored private let monitorCoordinator = MonitorRefreshCoordinator()
     @ObservationIgnored private let notificationManager = NotificationManager.shared
@@ -250,6 +253,9 @@ final class QuotaViewModel {
         await clinePassFetcher.updateProxyConfiguration()
         await traeFetcher.updateProxyConfiguration()
         await kiroFetcher.updateProxyConfiguration()
+        await devinFetcher.updateProxyConfiguration()
+        await grokFetcher.updateProxyConfiguration()
+        await openRouterFetcher.updateProxyConfiguration()
     }
 
     private func setupRefreshCadenceCallback() {
@@ -404,6 +410,44 @@ final class QuotaViewModel {
         await monitorCoordinator.finish(quotas: providerQuotas)
         monitorAccounts = await monitorCoordinator.discoverAccounts(merging: providerQuotas)
     }
+
+    func saveOpenRouterAccount(label: String, apiKey: String, existingAccountID: String? = nil) async throws {
+        let trimmedLabel = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedLabel.isEmpty, !trimmedKey.isEmpty else { throw MonitorRuntimeError.invalidCredential }
+
+        let account: MonitorAccount
+        if let existingAccountID,
+           let existing = monitorAccounts.first(where: { $0.id == existingAccountID && $0.provider == .openRouter }) {
+            account = existing
+            _ = await MonitorCredentialVault.shared.credential(for: existing.id)
+        } else {
+            guard !monitorAccounts.contains(where: {
+                $0.provider == .openRouter && $0.accountKey.caseInsensitiveCompare(trimmedLabel) == .orderedSame
+            }) else { throw MonitorRuntimeError.invalidCredential }
+            account = .make(
+                provider: .openRouter,
+                accountKey: trimmedLabel,
+                source: .quotioKeychain,
+                credentialReference: "keychain",
+                canDelete: true
+            )
+        }
+
+        try await MonitorCredentialVault.shared.save(
+            MonitorOAuthCredential(
+                accessToken: trimmedKey,
+                refreshToken: nil,
+                idToken: nil,
+                accountID: nil,
+                expiresAt: nil,
+                extra: [:]
+            ),
+            metadata: account
+        )
+        monitorAccounts = await monitorCoordinator.discoverAccounts(merging: providerQuotas)
+        await refreshQuotasDirectly(force: true)
+    }
     
     /// Refresh quotas directly without proxy (for Quota-Only Mode)
     /// Note: Cursor and Trae are NOT auto-refreshed - user must use "Scan for IDEs" (issue #29)
@@ -415,8 +459,13 @@ final class QuotaViewModel {
         
         let previous = providerQuotas
         let coordinator = monitorCoordinator
-        let discoveredProviders = Set(await coordinator.discoverAccounts().map(\.provider))
-        let credentialProviders: Set<AIProvider> = [.codex, .claude, .gemini, .copilot, .kiro, .antigravity]
+        let discoveredAccounts = await coordinator.discoverAccounts()
+        let discoveredProviders = Set(discoveredAccounts.map(\.provider))
+        let discoveredAccountKeys = Dictionary(grouping: discoveredAccounts, by: \.provider)
+            .mapValues { Set($0.map(\.accountKey)) }
+        let credentialProviders: Set<AIProvider> = [
+            .codex, .claude, .gemini, .copilot, .kiro, .antigravity, .devin, .grok, .openRouter,
+        ]
         let credentialAvailability = Dictionary(uniqueKeysWithValues: credentialProviders.map {
             ($0, discoveredProviders.contains($0) ? MonitorCredentialAvailability.present : .missing)
         })
@@ -429,7 +478,19 @@ final class QuotaViewModel {
         let clineQuotaFetcher = clinePassFetcher
         let warpQuotaFetcher = warpFetcher
         let antigravityQuotaFetcher = antigravityFetcher
+        let devinQuotaFetcher = devinFetcher
+        let grokQuotaFetcher = grokFetcher
+        let openRouterQuotaFetcher = openRouterFetcher
         let warpTokens = WarpService.shared.tokens.filter { $0.isEnabled }
+        let devinPrevious = previous[.devin]?.filter {
+            discoveredAccountKeys[.devin]?.contains($0.key) == true
+        } ?? [:]
+        let grokPrevious = previous[.grok]?.filter {
+            discoveredAccountKeys[.grok]?.contains($0.key) == true
+        } ?? [:]
+        let openRouterPrevious = previous[.openRouter]?.filter {
+            discoveredAccountKeys[.openRouter]?.contains($0.key) == true
+        } ?? [:]
 
         async let codex = coordinator.refresh(
             provider: .codex,
@@ -495,6 +556,30 @@ final class QuotaViewModel {
             let (quotas, _) = await antigravityQuotaFetcher.fetchAllAntigravityData(includeMonitorCredentials: true)
             return quotas
         }
+        async let devin = coordinator.refresh(
+            provider: .devin,
+            force: force,
+            previous: devinPrevious,
+            credentialAvailability: credentialAvailability[.devin] ?? .unknown
+        ) {
+            await devinQuotaFetcher.fetchAsProviderQuota()
+        }
+        async let grok = coordinator.refresh(
+            provider: .grok,
+            force: force,
+            previous: grokPrevious,
+            credentialAvailability: credentialAvailability[.grok] ?? .unknown
+        ) {
+            await grokQuotaFetcher.fetchAllQuotas()
+        }
+        async let openRouter = coordinator.refresh(
+            provider: .openRouter,
+            force: force,
+            previous: openRouterPrevious,
+            credentialAvailability: credentialAvailability[.openRouter] ?? .unknown
+        ) {
+            await openRouterQuotaFetcher.fetchAllQuotas()
+        }
 
         providerQuotas[.codex] = await codexFetcher.reconcileLegacyAliases(in: await codex)
         providerQuotas[.claude] = await claude
@@ -505,6 +590,9 @@ final class QuotaViewModel {
         providerQuotas[.clinePass] = await clinePass
         providerQuotas[.warp] = await warp
         providerQuotas[.antigravity] = await antigravity
+        providerQuotas[.devin] = await devin
+        providerQuotas[.grok] = await grok
+        providerQuotas[.openRouter] = await openRouter
         providerQuotas = providerQuotas.filter { !$0.value.isEmpty }
 
         monitorAccounts = await coordinator.discoverAccounts(merging: providerQuotas)

--- a/Quotio/Views/Components/AccountRow.swift
+++ b/Quotio/Views/Components/AccountRow.swift
@@ -141,7 +141,8 @@ struct AccountRowData: Identifiable, Hashable {
             status: status,
             statusMessage: statusMessage,
             isDisabled: monitorAccount.isDisabled,
-            canDelete: monitorAccount.canDelete
+            canDelete: monitorAccount.canDelete,
+            canEdit: monitorAccount.provider == .openRouter
         )
     }
 

--- a/Quotio/Views/Components/AccountRow.swift
+++ b/Quotio/Views/Components/AccountRow.swift
@@ -142,7 +142,8 @@ struct AccountRowData: Identifiable, Hashable {
             statusMessage: statusMessage,
             isDisabled: monitorAccount.isDisabled,
             canDelete: monitorAccount.canDelete,
-            canEdit: monitorAccount.provider == .openRouter
+            canEdit: monitorAccount.source == .quotioKeychain
+                && [.factoryDroid, .openRouter].contains(monitorAccount.provider)
         )
     }
 

--- a/Quotio/Views/Components/GLMAPIKeySheet.swift
+++ b/Quotio/Views/Components/GLMAPIKeySheet.swift
@@ -238,7 +238,7 @@ enum GLMEndpoint: String, CaseIterable, Codable, Identifiable, Sendable {
 
     var displayName: String {
         switch self {
-        case .zai: return "Z.ai Global"
+        case .zai: return "glm.endpoint.zaiGlobal".localizedStatic()
         case .bigmodel: return "bigmodel.cn"
         }
     }

--- a/Quotio/Views/Components/GLMAPIKeySheet.swift
+++ b/Quotio/Views/Components/GLMAPIKeySheet.swift
@@ -188,20 +188,43 @@ struct GLMAPIKeySheet: View {
             return
         }
 
-        // Build provider using GLM type (similar to Gemini compatibility)
-        let newProvider = CustomProvider(
-            id: provider?.id ?? UUID(),
-            name: provider?.name ?? "Z.ai",
-            type: .glmCompatibility,
-            baseURL: endpoint.baseURL,
-            apiKeys: [CustomAPIKeyEntry(apiKey: trimmedKey)],
-            isEnabled: true,
-            createdAt: provider?.createdAt ?? Date(),
-            updatedAt: Date()
+        let newProvider = GLMProviderEditor.updatedProvider(
+            provider,
+            apiKey: trimmedKey,
+            endpoint: endpoint
         )
 
         onSave(newProvider)
         dismiss()
+    }
+}
+
+enum GLMProviderEditor {
+    static func updatedProvider(
+        _ existing: CustomProvider?,
+        apiKey: String,
+        endpoint: GLMEndpoint,
+        now: Date = Date()
+    ) -> CustomProvider {
+        guard var provider = existing else {
+            return CustomProvider(
+                name: "Z.ai",
+                type: .glmCompatibility,
+                baseURL: endpoint.baseURL,
+                apiKeys: [CustomAPIKeyEntry(apiKey: apiKey)],
+                createdAt: now,
+                updatedAt: now
+            )
+        }
+
+        provider.baseURL = endpoint.baseURL
+        if provider.apiKeys.isEmpty {
+            provider.apiKeys.append(CustomAPIKeyEntry(apiKey: apiKey))
+        } else {
+            provider.apiKeys[0].apiKey = apiKey
+        }
+        provider.updatedAt = now
+        return provider
     }
 }
 

--- a/Quotio/Views/Components/GLMAPIKeySheet.swift
+++ b/Quotio/Views/Components/GLMAPIKeySheet.swift
@@ -18,7 +18,7 @@ struct GLMAPIKeySheet: View {
     // MARK: - Form State
 
     @State private var apiKey: String = ""
-    @State private var endpoint: GLMEndpoint = .bigmodel
+    @State private var endpoint: GLMEndpoint = .zai
 
     @State private var validationError: String?
     @State private var showValidationAlert = false
@@ -133,7 +133,6 @@ struct GLMAPIKeySheet: View {
                 }
                 .pickerStyle(.menu)
                 .labelsHidden()
-                .disabled(true) // Only bigmodel.cn is supported
             }
         }
         .padding(16)
@@ -174,6 +173,8 @@ struct GLMAPIKeySheet: View {
         // Determine endpoint from base URL
         if provider.baseURL.contains("bigmodel.cn") {
             endpoint = .bigmodel
+        } else {
+            endpoint = .zai
         }
     }
 
@@ -190,7 +191,7 @@ struct GLMAPIKeySheet: View {
         // Build provider using GLM type (similar to Gemini compatibility)
         let newProvider = CustomProvider(
             id: provider?.id ?? UUID(),
-            name: "GLM",
+            name: provider?.name ?? "Z.ai",
             type: .glmCompatibility,
             baseURL: endpoint.baseURL,
             apiKeys: [CustomAPIKeyEntry(apiKey: trimmedKey)],
@@ -207,18 +208,21 @@ struct GLMAPIKeySheet: View {
 // MARK: - GLM Endpoint
 
 enum GLMEndpoint: String, CaseIterable, Codable, Identifiable, Sendable {
+    case zai
     case bigmodel
 
     var id: String { rawValue }
 
     var displayName: String {
         switch self {
+        case .zai: return "Z.ai Global"
         case .bigmodel: return "bigmodel.cn"
         }
     }
 
     var baseURL: String {
         switch self {
+        case .zai: return "https://api.z.ai"
         case .bigmodel: return "https://bigmodel.cn"
         }
     }

--- a/Quotio/Views/Components/MonitorAPIKeyConnectionSheet.swift
+++ b/Quotio/Views/Components/MonitorAPIKeyConnectionSheet.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
-struct OpenRouterConnectionSheet: View {
+struct MonitorAPIKeyConnectionSheet: View {
     @Environment(\.dismiss) private var dismiss
 
+    let provider: AIProvider
     let account: MonitorAccount?
     let onSave: (String, String) async throws -> Void
 
@@ -12,15 +13,18 @@ struct OpenRouterConnectionSheet: View {
     @State private var isSaving = false
 
     private var isEditing: Bool { account != nil }
+    private var localizationPrefix: String {
+        provider == .factoryDroid ? "factory" : "openrouter"
+    }
 
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 16) {
-                ProviderIcon(provider: .openRouter, size: 32)
+                ProviderIcon(provider: provider, size: 32)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(isEditing ? "openrouter.connection.edit".localized() : "openrouter.connection.title".localized())
+                    Text(localized(isEditing ? "connection.edit" : "connection.title"))
                         .font(.headline)
-                    Text("openrouter.connection.subtitle".localized())
+                    Text(localized("connection.subtitle"))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -35,18 +39,18 @@ struct OpenRouterConnectionSheet: View {
                     Text("customProviders.providerName".localized())
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
-                    TextField("openrouter.label.placeholder".localized(), text: $label)
+                    TextField(localized("label.placeholder"), text: $label)
                         .textFieldStyle(.roundedBorder)
                         .disabled(isEditing)
                 }
 
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("openrouter.apiKey.label".localized())
+                    Text(localized("apiKey.label"))
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
-                    SecureField("openrouter.apiKey.placeholder".localized(), text: $apiKey)
+                    SecureField(localized("apiKey.placeholder"), text: $apiKey)
                         .textFieldStyle(.roundedBorder)
-                    Text(isEditing ? "openrouter.apiKey.rotateHint".localized() : "openrouter.apiKey.hint".localized())
+                    Text(localized(isEditing ? "apiKey.rotateHint" : "apiKey.hint"))
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                 }
@@ -78,6 +82,10 @@ struct OpenRouterConnectionSheet: View {
         }
         .frame(width: 450, height: 360)
         .onAppear { label = account?.accountKey ?? "" }
+    }
+
+    private func localized(_ suffix: String) -> String {
+        (localizationPrefix + "." + suffix).localized()
     }
 
     private func save() async {

--- a/Quotio/Views/Components/OpenRouterConnectionSheet.swift
+++ b/Quotio/Views/Components/OpenRouterConnectionSheet.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+struct OpenRouterConnectionSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let account: MonitorAccount?
+    let onSave: (String, String) async throws -> Void
+
+    @State private var label = ""
+    @State private var apiKey = ""
+    @State private var errorMessage: String?
+    @State private var isSaving = false
+
+    private var isEditing: Bool { account != nil }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 16) {
+                ProviderIcon(provider: .openRouter, size: 32)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(isEditing ? "openrouter.connection.edit".localized() : "openrouter.connection.title".localized())
+                        .font(.headline)
+                    Text("openrouter.connection.subtitle".localized())
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+            .padding(20)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 20) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("customProviders.providerName".localized())
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    TextField("openrouter.label.placeholder".localized(), text: $label)
+                        .textFieldStyle(.roundedBorder)
+                        .disabled(isEditing)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("openrouter.apiKey.label".localized())
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    SecureField("openrouter.apiKey.placeholder".localized(), text: $apiKey)
+                        .textFieldStyle(.roundedBorder)
+                    Text(isEditing ? "openrouter.apiKey.rotateHint".localized() : "openrouter.apiKey.hint".localized())
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+
+                Spacer()
+            }
+            .padding(24)
+
+            Divider()
+
+            HStack {
+                Button("action.cancel".localized()) { dismiss() }
+                Spacer()
+                Button(isEditing ? "action.save".localized() : "action.connect".localized()) {
+                    Task { await save() }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    || apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    || isSaving)
+            }
+            .padding(20)
+        }
+        .frame(width: 450, height: 360)
+        .onAppear { label = account?.accountKey ?? "" }
+    }
+
+    private func save() async {
+        isSaving = true
+        defer { isSaving = false }
+        do {
+            try await onSave(label, apiKey)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Quotio/Views/Screens/DashboardScreen.swift
+++ b/Quotio/Views/Screens/DashboardScreen.swift
@@ -592,8 +592,9 @@ struct DashboardScreen: View {
         let alert = NSAlert()
         alert.messageText = "providers.addProvider".localized()
         alert.informativeText = "onboarding.addProviderDesc".localized()
-        
-        for provider in AIProvider.allCases {
+
+        let providers = AIProvider.allCases.filter(\.supportsLocalProxySetup)
+        for provider in providers {
             alert.addButton(withTitle: provider.displayName)
         }
         alert.addButton(withTitle: "action.cancel".localized())
@@ -601,8 +602,8 @@ struct DashboardScreen: View {
         let response = alert.runModal()
         let index = response.rawValue - 1000
         
-        if index >= 0 && index < AIProvider.allCases.count {
-            let provider = AIProvider.allCases[index]
+        if index >= 0 && index < providers.count {
+            let provider = providers[index]
             if provider == .vertex {
                 isImporterPresented = true
             } else {
@@ -670,7 +671,7 @@ struct DashboardScreen: View {
                         ProviderChip(provider: provider, count: viewModel.authFilesByProvider[provider]?.count ?? 0)
                     }
                     
-                    ForEach(viewModel.disconnectedProviders.filter { $0.supportsManualAuth }) { provider in
+                    ForEach(viewModel.disconnectedProviders.filter(\.supportsLocalProxySetup)) { provider in
                         Button {
                             if provider == .vertex {
                                 isImporterPresented = true

--- a/Quotio/Views/Screens/ProvidersScreen.swift
+++ b/Quotio/Views/Screens/ProvidersScreen.swift
@@ -23,6 +23,10 @@ struct ProvidersScreen: View {
     @State private var customProviderSheetMode: CustomProviderSheetMode?
     @State private var showWarpConnectionSheet = false
     @State private var editingWarpToken: WarpService.WarpToken?
+    @State private var showGLMConnectionSheet = false
+    @State private var editingGLMProvider: CustomProvider?
+    @State private var showOpenRouterConnectionSheet = false
+    @State private var editingOpenRouterAccount: MonitorAccount?
     @State private var showAddProviderPopover = false
     @State private var switchingAccount: AccountRowData?
     @State private var modeManager = OperatingModeManager.shared
@@ -35,10 +39,12 @@ struct ProvidersScreen: View {
     /// Providers that can be added manually
     private var addableProviders: [AIProvider] {
         if modeManager.isLocalProxyMode {
-            return AIProvider.allCases.filter { $0.supportsManualAuth || $0 == .clinePass }
+            return AIProvider.allCases.filter {
+                $0 != .openRouter && ($0.supportsManualAuth || $0 == .clinePass)
+            }
         } else {
             return AIProvider.allCases.filter {
-                $0.supportsQuotaOnlyMode && ($0.supportsManualAuth || $0 == .clinePass)
+                $0.supportsQuotaOnlyMode && ($0.supportsManualAuth || $0 == .glm || $0 == .clinePass)
             }
         }
     }
@@ -233,6 +239,29 @@ struct ProvidersScreen: View {
                 Task { await viewModel.refreshAutoDetectedProviders() }
             }
         }
+        .sheet(isPresented: $showGLMConnectionSheet) {
+            GLMAPIKeySheet(provider: editingGLMProvider) { provider in
+                if customProviderService.providers.contains(where: { $0.id == provider.id }) {
+                    customProviderService.updateProvider(provider)
+                } else {
+                    customProviderService.addProvider(provider)
+                }
+                editingGLMProvider = nil
+                syncCustomProvidersToConfig()
+                Task { await viewModel.refreshQuotaForProvider(.glm) }
+            }
+            .environment(viewModel)
+        }
+        .sheet(isPresented: $showOpenRouterConnectionSheet) {
+            OpenRouterConnectionSheet(account: editingOpenRouterAccount) { label, apiKey in
+                try await viewModel.saveOpenRouterAccount(
+                    label: label,
+                    apiKey: apiKey,
+                    existingAccountID: editingOpenRouterAccount?.id
+                )
+                editingOpenRouterAccount = nil
+            }
+        }
         .sheet(isPresented: $showAddProviderPopover) {
             AddProviderPopover(
                 providers: addableProviders,
@@ -332,6 +361,8 @@ struct ProvidersScreen: View {
                                 handleEditClinePassAccount(account)
                             } else if provider == .warp {
                                 handleEditWarpAccount(account)
+                            } else if provider == .openRouter {
+                                handleEditOpenRouterAccount(account)
                             }
                         },
                         onSwitchAccount: provider == .antigravity ? { account in
@@ -422,6 +453,16 @@ struct ProvidersScreen: View {
             customProviderSheetMode = .add(.clinePass)
             return
         }
+        if provider == .glm {
+            editingGLMProvider = nil
+            showGLMConnectionSheet = true
+            return
+        }
+        if provider == .openRouter {
+            editingOpenRouterAccount = nil
+            showOpenRouterConnectionSheet = true
+            return
+        }
 
         // In Local Proxy Mode, require proxy to be running for OAuth
         if modeManager.isLocalProxyMode && !viewModel.proxyManager.proxyStatus.running {
@@ -499,9 +540,9 @@ struct ProvidersScreen: View {
     }
 
     private func handleEditGlmAccount(_ account: AccountRowData) {
-        // Find the GLM provider by ID and open edit sheet using CustomProviderSheet
         if let glmProvider = customProviderService.providers.first(where: { $0.id.uuidString == account.id }) {
-            customProviderSheetMode = .edit(glmProvider)
+            editingGLMProvider = glmProvider
+            showGLMConnectionSheet = true
         }
     }
 
@@ -517,6 +558,12 @@ struct ProvidersScreen: View {
             editingWarpToken = token
             showWarpConnectionSheet = true
         }
+    }
+
+    private func handleEditOpenRouterAccount(_ account: AccountRowData) {
+        guard let monitorAccount = viewModel.monitorAccounts.first(where: { $0.id == account.id }) else { return }
+        editingOpenRouterAccount = monitorAccount
+        showOpenRouterConnectionSheet = true
     }
 
     private func syncCustomProvidersToConfig() {

--- a/Quotio/Views/Screens/ProvidersScreen.swift
+++ b/Quotio/Views/Screens/ProvidersScreen.swift
@@ -25,8 +25,8 @@ struct ProvidersScreen: View {
     @State private var editingWarpToken: WarpService.WarpToken?
     @State private var showGLMConnectionSheet = false
     @State private var editingGLMProvider: CustomProvider?
-    @State private var showOpenRouterConnectionSheet = false
-    @State private var editingOpenRouterAccount: MonitorAccount?
+    @State private var monitorAPIKeyProvider: AIProvider?
+    @State private var editingMonitorAPIKeyAccount: MonitorAccount?
     @State private var showAddProviderPopover = false
     @State private var switchingAccount: AccountRowData?
     @State private var modeManager = OperatingModeManager.shared
@@ -40,7 +40,7 @@ struct ProvidersScreen: View {
     private var addableProviders: [AIProvider] {
         if modeManager.isLocalProxyMode {
             return AIProvider.allCases.filter {
-                $0 != .openRouter && ($0.supportsManualAuth || $0 == .clinePass)
+                ![.factoryDroid, .openRouter].contains($0) && ($0.supportsManualAuth || $0 == .clinePass)
             }
         } else {
             return AIProvider.allCases.filter {
@@ -252,14 +252,22 @@ struct ProvidersScreen: View {
             }
             .environment(viewModel)
         }
-        .sheet(isPresented: $showOpenRouterConnectionSheet) {
-            OpenRouterConnectionSheet(account: editingOpenRouterAccount) { label, apiKey in
-                try await viewModel.saveOpenRouterAccount(
-                    label: label,
-                    apiKey: apiKey,
-                    existingAccountID: editingOpenRouterAccount?.id
-                )
-                editingOpenRouterAccount = nil
+        .sheet(item: $monitorAPIKeyProvider) { provider in
+            MonitorAPIKeyConnectionSheet(provider: provider, account: editingMonitorAPIKeyAccount) { label, apiKey in
+                if provider == .factoryDroid {
+                    try await viewModel.saveFactoryDroidAccount(
+                        label: label,
+                        apiKey: apiKey,
+                        existingAccountID: editingMonitorAPIKeyAccount?.id
+                    )
+                } else {
+                    try await viewModel.saveOpenRouterAccount(
+                        label: label,
+                        apiKey: apiKey,
+                        existingAccountID: editingMonitorAPIKeyAccount?.id
+                    )
+                }
+                editingMonitorAPIKeyAccount = nil
             }
         }
         .sheet(isPresented: $showAddProviderPopover) {
@@ -361,8 +369,8 @@ struct ProvidersScreen: View {
                                 handleEditClinePassAccount(account)
                             } else if provider == .warp {
                                 handleEditWarpAccount(account)
-                            } else if provider == .openRouter {
-                                handleEditOpenRouterAccount(account)
+                            } else if [.factoryDroid, .openRouter].contains(provider) {
+                                handleEditMonitorAPIKeyAccount(account)
                             }
                         },
                         onSwitchAccount: provider == .antigravity ? { account in
@@ -458,9 +466,9 @@ struct ProvidersScreen: View {
             showGLMConnectionSheet = true
             return
         }
-        if provider == .openRouter {
-            editingOpenRouterAccount = nil
-            showOpenRouterConnectionSheet = true
+        if [.factoryDroid, .openRouter].contains(provider) {
+            editingMonitorAPIKeyAccount = nil
+            monitorAPIKeyProvider = provider
             return
         }
 
@@ -560,10 +568,10 @@ struct ProvidersScreen: View {
         }
     }
 
-    private func handleEditOpenRouterAccount(_ account: AccountRowData) {
+    private func handleEditMonitorAPIKeyAccount(_ account: AccountRowData) {
         guard let monitorAccount = viewModel.monitorAccounts.first(where: { $0.id == account.id }) else { return }
-        editingOpenRouterAccount = monitorAccount
-        showOpenRouterConnectionSheet = true
+        editingMonitorAPIKeyAccount = monitorAccount
+        monitorAPIKeyProvider = monitorAccount.provider
     }
 
     private func syncCustomProvidersToConfig() {

--- a/Quotio/Views/Screens/QuotaScreen.swift
+++ b/Quotio/Views/Screens/QuotaScreen.swift
@@ -866,24 +866,36 @@ private struct AccountQuotaCardV2: View {
     
     @ViewBuilder
     private func standardContentByStyle(data: ProviderQuotaData) -> some View {
-        switch displayStyle {
-        case .lowestBar:
-            StandardLowestBarLayout(models: data.models)
-        case .ring:
-            StandardRingLayout(models: data.models)
-        case .card:
-            VStack(spacing: 12) {
-                ForEach(data.models) { model in
-                    UsageRowV2(
-                        name: model.displayName,
-                        icon: nil,
-                        usedPercent: model.usedPercentage,
-                        used: model.used,
-                        limit: model.limit,
-                        resetTime: model.formattedResetTime,
-                        tooltip: model.tooltip
-                    )
+        let meterModels = data.models.filter { !$0.isStandaloneMetric }
+        let standaloneModels = data.models.filter(\.isStandaloneMetric)
+
+        VStack(spacing: 12) {
+            if !meterModels.isEmpty {
+                switch displayStyle {
+                case .lowestBar:
+                    StandardLowestBarLayout(models: meterModels)
+                case .ring:
+                    StandardRingLayout(models: meterModels)
+                case .card:
+                    VStack(spacing: 12) {
+                        ForEach(meterModels) { model in
+                            UsageRowV2(
+                                name: model.displayName,
+                                icon: nil,
+                                usedPercent: model.usedPercentage,
+                                used: model.used,
+                                limit: model.limit,
+                                formattedUsage: model.presentation == nil ? nil : model.formattedUsage,
+                                resetTime: model.formattedResetTime,
+                                tooltip: model.tooltip
+                            )
+                        }
+                    }
                 }
+            }
+
+            ForEach(standaloneModels) { model in
+                StandaloneMetricRow(model: model)
             }
         }
     }
@@ -1531,6 +1543,7 @@ private struct UsageRowV2: View {
     let usedPercent: Double
     let used: Int?
     let limit: Int?
+    let formattedUsage: String?
     let resetTime: String
     let tooltip: String?
     
@@ -1567,7 +1580,12 @@ private struct UsageRowV2: View {
                 
                 Spacer()
                 
-                if let used = used {
+                if let formattedUsage {
+                    Text(formattedUsage)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .monospacedDigit()
+                } else if let used = used {
                     if let limit = limit, limit > 0 {
                         Text(String(used) + "/" + String(limit))
                             .font(.caption)
@@ -1608,6 +1626,26 @@ private struct UsageRowV2: View {
                 .frame(height: 6)
             }
         }
+    }
+}
+
+private struct StandaloneMetricRow: View {
+    let model: ModelQuota
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text(model.displayName)
+                .font(.subheadline)
+                .fontWeight(.medium)
+            Spacer()
+            Text(model.formattedUsage ?? "—")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+        .padding(.vertical, 2)
+        .help(model.tooltip ?? "")
     }
 }
 

--- a/Quotio/Views/Screens/QuotaScreen.swift
+++ b/Quotio/Views/Screens/QuotaScreen.swift
@@ -377,7 +377,7 @@ private struct ProviderQuotaView: View {
             if !existingKeys.contains(key) {
                 accounts.append(AccountInfo(
                     key: key,
-                    email: directAuthEmailsByKey[key] ?? key,
+                    email: data.accountDisplayName ?? directAuthEmailsByKey[key] ?? key,
                     status: "active",
                     statusColor: .green,
                     authFile: nil,
@@ -868,35 +868,66 @@ private struct AccountQuotaCardV2: View {
     private func standardContentByStyle(data: ProviderQuotaData) -> some View {
         let meterModels = data.models.filter { !$0.isStandaloneMetric }
         let standaloneModels = data.models.filter(\.isStandaloneMetric)
+        let factorySections = provider == .factoryDroid
+            ? FactoryDroidQuotaSection.sections(from: meterModels)
+            : []
 
         VStack(spacing: 12) {
-            if !meterModels.isEmpty {
-                switch displayStyle {
-                case .lowestBar:
-                    StandardLowestBarLayout(models: meterModels)
-                case .ring:
-                    StandardRingLayout(models: meterModels)
-                case .card:
-                    VStack(spacing: 12) {
-                        ForEach(meterModels) { model in
-                            UsageRowV2(
-                                name: model.displayName,
-                                icon: nil,
-                                usedPercent: model.usedPercentage,
-                                used: model.used,
-                                limit: model.limit,
-                                formattedUsage: model.presentation == nil ? nil : model.formattedUsage,
-                                resetTime: model.formattedResetTime,
-                                tooltip: model.tooltip
-                            )
-                        }
+            if !factorySections.isEmpty {
+                ForEach(factorySections) { section in
+                    VStack(alignment: .leading, spacing: 8) {
+                        FactoryDroidQuotaSectionHeader(title: section.title)
+                        meterContentByStyle(models: section.models)
                     }
                 }
+            } else if !meterModels.isEmpty {
+                meterContentByStyle(models: meterModels)
             }
 
             ForEach(standaloneModels) { model in
                 StandaloneMetricRow(model: model)
             }
+        }
+    }
+
+    @ViewBuilder
+    private func meterContentByStyle(models: [ModelQuota]) -> some View {
+        switch displayStyle {
+        case .lowestBar:
+            StandardLowestBarLayout(models: models)
+        case .ring:
+            StandardRingLayout(models: models)
+        case .card:
+            VStack(spacing: 12) {
+                ForEach(models) { model in
+                    UsageRowV2(
+                        name: model.displayName,
+                        icon: nil,
+                        usedPercent: model.usedPercentage,
+                        used: model.used,
+                        limit: model.limit,
+                        formattedUsage: model.presentation == nil ? nil : model.formattedUsage,
+                        resetTime: model.formattedResetTime,
+                        tooltip: model.tooltip
+                    )
+                }
+            }
+        }
+    }
+}
+
+private struct FactoryDroidQuotaSectionHeader: View {
+    let title: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(title)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+            Rectangle()
+                .fill(Color.primary.opacity(0.08))
+                .frame(height: 1)
         }
     }
 }

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -332,11 +332,13 @@ final class MonitorRuntimeTests: XCTestCase {
         }
         """#.utf8)
         let response = try JSONDecoder().decode(FactoryDroidQuotaResponse.self, from: payload)
+        let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-07-20T18:30:00Z"))
 
-        let quota = FactoryDroidQuotaMapper.map(response)
+        let quota = FactoryDroidQuotaMapper.map(response, now: now)
 
         XCTAssertEqual(quota.models.count, 7)
-        XCTAssertEqual(quota.models.first(where: { $0.name == "factory-standard-five-hour" })?.percentage, 0)
+        XCTAssertEqual(quota.models.first(where: { $0.name == "factory-standard-five-hour" })?.percentage, 100)
+        XCTAssertEqual(quota.models.first(where: { $0.name == "factory-core-five-hour" })?.percentage, 0)
         XCTAssertEqual(quota.models.first(where: { $0.name == "factory-standard-weekly" })?.percentage, 37)
         XCTAssertEqual(quota.models.first(where: { $0.name == "factory-core-weekly" })?.percentage, 49)
         let sections = FactoryDroidQuotaSection.sections(from: quota.models)

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -506,7 +506,12 @@ final class MonitorRuntimeTests: XCTestCase {
         let path = directory.appendingPathComponent("state.vscdb").path
         var database: OpaquePointer?
         XCTAssertEqual(sqlite3_open(path, &database), SQLITE_OK)
-        defer { sqlite3_close(database) }
+        defer {
+            sqlite3_close(database)
+            try? FileManager.default.removeItem(at: directory)
+        }
+        XCTAssertEqual(sqlite3_exec(database, "PRAGMA journal_mode=WAL", nil, nil, nil), SQLITE_OK)
+        XCTAssertEqual(sqlite3_exec(database, "PRAGMA wal_autocheckpoint=0", nil, nil, nil), SQLITE_OK)
         XCTAssertEqual(sqlite3_exec(database, "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)", nil, nil, nil), SQLITE_OK)
         XCTAssertEqual(sqlite3_exec(database, "INSERT INTO ItemTable VALUES ('windsurfAuthStatus', '{\"apiKey\":\"app-token\"}')", nil, nil, nil), SQLITE_OK)
 
@@ -531,6 +536,21 @@ final class MonitorRuntimeTests: XCTestCase {
 
         XCTAssertEqual(candidates.map(\.entryKey), ["account-a::client-a", "account-b::client-b"])
         XCTAssertEqual(candidates.map(\.clientID), ["client-a", "client-b"])
+    }
+
+    func testGrokUsesDefaultClientIDWhenEntryKeyHasNoSuffix() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("auth.json")
+        let data = try JSONSerialization.data(withJSONObject: [
+            "account-without-client": ["key": "token", "refresh_token": "refresh"],
+        ])
+        try data.write(to: url)
+
+        let candidate = try XCTUnwrap(GrokQuotaFetcher.loadCandidates(path: url.path).first)
+
+        XCTAssertEqual(candidate.clientID, GrokQuotaFetcher.defaultClientID)
     }
 
     func testGrokMapsOnlyWeeklyPeriodAndStatusCap() throws {
@@ -650,9 +670,18 @@ final class MonitorRuntimeTests: XCTestCase {
 
         let forbidden = try XCTUnwrap(OpenRouterQuotaMapper.map(
             credits: OpenRouterEndpointResult(data: Data(), statusCode: 401),
-            key: OpenRouterEndpointResult(data: Data(), statusCode: 403)
+            key: OpenRouterEndpointResult(data: nil, statusCode: 503)
         ))
         XCTAssertTrue(forbidden.isForbidden)
+    }
+
+    @MainActor
+    func testZAIEndpointLabelUsesLocalization() {
+        let previousLanguage = UserDefaults.standard.string(forKey: "appLanguage")
+        UserDefaults.standard.set("vi", forKey: "appLanguage")
+        defer { UserDefaults.standard.set(previousLanguage, forKey: "appLanguage") }
+
+        XCTAssertEqual(GLMEndpoint.zai.displayName, "Z.ai Toàn cầu")
     }
 
     func testMonitorCredentialVaultAddsRotatesAndDeletesAPIKeys() async throws {

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -16,6 +16,13 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertEqual(Set(filtered), providers)
     }
 
+    func testMonitorOnlyProvidersDoNotOfferLocalProxySetup() {
+        for provider in [AIProvider.factoryDroid, .devin, .grok, .openRouter, .warp] {
+            XCTAssertFalse(provider.supportsLocalProxySetup)
+        }
+        XCTAssertTrue(AIProvider.claude.supportsLocalProxySetup)
+    }
+
     func testStatusBarIncludesEnabledMonitorAccountsWithoutQuota() {
         let enabled = MonitorAccount.make(
             provider: .claude,
@@ -240,6 +247,19 @@ final class MonitorRuntimeTests: XCTestCase {
         }
     }
 
+    func testCountMetricUnitsUseEnglishSingularAndPluralForms() {
+        let previousLanguage = UserDefaults.standard.string(forKey: "appLanguage")
+        UserDefaults.standard.set("en", forKey: "appLanguage")
+        defer { UserDefaults.standard.set(previousLanguage, forKey: "appLanguage") }
+
+        XCTAssertEqual(QuotaMetricUnit.credits.format(1), "1 credit")
+        XCTAssertEqual(QuotaMetricUnit.credits.format(2), "2 credits")
+        XCTAssertEqual(QuotaMetricUnit.requests.format(1), "1 request")
+        XCTAssertEqual(QuotaMetricUnit.requests.format(2), "2 requests")
+        XCTAssertEqual(QuotaMetricUnit.searches.format(1), "1 search")
+        XCTAssertEqual(QuotaMetricUnit.searches.format(2), "2 searches")
+    }
+
     func testFactoryDroidDecryptsLocalCredentialFile() throws {
         let keyData = Data((0..<32).map(UInt8.init))
         let nonce = try AES.GCM.Nonce(data: Data((32..<48).map(UInt8.init)))
@@ -366,17 +386,21 @@ final class MonitorRuntimeTests: XCTestCase {
     func testZAIQuotaMappingClassifiesWindowsAndSearches() {
         let data = GLMQuotaData(limits: [
             GLMLimit(type: "TOKENS_LIMIT", unit: 3, number: 5, usage: 100, currentValue: 20, remaining: 80, percentage: 20, usageDetails: nil, nextResetTime: nil),
+            GLMLimit(type: "TOKENS_LIMIT", unit: 4, number: 1, usage: 100, currentValue: 30, remaining: 70, percentage: 30, usageDetails: nil, nextResetTime: nil),
             GLMLimit(type: "TOKENS_LIMIT", unit: 4, number: 7, usage: 100, currentValue: 60, remaining: 40, percentage: 60, usageDetails: nil, nextResetTime: nil),
+            GLMLimit(type: "TOKENS_LIMIT", unit: 5, number: 1, usage: 100, currentValue: 10, remaining: 90, percentage: 10, usageDetails: nil, nextResetTime: nil),
             GLMLimit(type: "TIME_LIMIT", unit: 4, number: 1, usage: 1000, currentValue: 125, remaining: 875, percentage: 12.5, usageDetails: nil, nextResetTime: nil),
         ])
 
         let quota = GLMQuotaFetcher.mapQuotaData(data, planName: "GLM Coding Pro")
 
         XCTAssertEqual(quota.planType, "GLM Coding Pro")
-        XCTAssertEqual(quota.models.map(\.name), ["zai-session", "zai-weekly", "zai-web-searches"])
+        XCTAssertEqual(quota.models.map(\.name), ["zai-session", "zai-daily", "zai-weekly", "zai-monthly", "zai-web-searches"])
         XCTAssertEqual(quota.models[0].percentage, 80)
-        XCTAssertEqual(quota.models[1].percentage, 40)
-        XCTAssertEqual(quota.models[2].presentation, .progress(used: 125, limit: 1000, unit: .searches))
+        XCTAssertEqual(quota.models[1].percentage, 70)
+        XCTAssertEqual(quota.models[2].percentage, 40)
+        XCTAssertEqual(quota.models[3].percentage, 90)
+        XCTAssertEqual(quota.models[4].presentation, .progress(used: 125, limit: 1000, unit: .searches))
         XCTAssertEqual(GLMQuotaFetcher.apiRoot(from: "https://bigmodel.cn/api/paas/v4"), "https://bigmodel.cn")
     }
 
@@ -388,6 +412,49 @@ final class MonitorRuntimeTests: XCTestCase {
 
         XCTAssertEqual(quota.models.map(\.name), ["zai-weekly", "zai-web-searches"])
         XCTAssertEqual(quota.models[1].presentation, .progress(used: 0, limit: 1000, unit: .searches))
+    }
+
+    @MainActor
+    func testGLMEditorPreservesExistingProviderConfiguration() {
+        let createdAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let updatedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let firstKeyID = UUID()
+        let secondKey = CustomAPIKeyEntry(apiKey: "second-key", proxyURL: "https://second.proxy")
+        let existing = CustomProvider(
+            name: "Existing Z.ai",
+            type: .glmCompatibility,
+            baseURL: GLMEndpoint.bigmodel.baseURL,
+            prefix: "existing-prefix",
+            apiKeys: [
+                CustomAPIKeyEntry(id: firstKeyID, apiKey: "first-key", proxyURL: "https://first.proxy"),
+                secondKey,
+            ],
+            limitToSelectedModels: false,
+            isEnabled: false,
+            createdAt: createdAt,
+            updatedAt: createdAt
+        )
+
+        let updated = GLMProviderEditor.updatedProvider(
+            existing,
+            apiKey: "rotated-key",
+            endpoint: .zai,
+            now: updatedAt
+        )
+
+        XCTAssertEqual(updated.id, existing.id)
+        XCTAssertEqual(updated.name, "Existing Z.ai")
+        XCTAssertEqual(updated.baseURL, GLMEndpoint.zai.baseURL)
+        XCTAssertEqual(updated.prefix, "existing-prefix")
+        XCTAssertEqual(updated.apiKeys.count, 2)
+        XCTAssertEqual(updated.apiKeys[0].id, firstKeyID)
+        XCTAssertEqual(updated.apiKeys[0].apiKey, "rotated-key")
+        XCTAssertEqual(updated.apiKeys[0].proxyURL, "https://first.proxy")
+        XCTAssertEqual(updated.apiKeys[1], secondKey)
+        XCTAssertFalse(updated.limitToSelectedModels)
+        XCTAssertFalse(updated.isEnabled)
+        XCTAssertEqual(updated.createdAt, createdAt)
+        XCTAssertEqual(updated.updatedAt, updatedAt)
     }
 
     func testDevinMappingPreservesRemainingConventionAndWeeklyFallback() throws {
@@ -409,6 +476,12 @@ final class MonitorRuntimeTests: XCTestCase {
             .amount(value: 0, unit: .usd, semantics: .balance)
         )
         XCTAssertEqual(quota.planType, "Max")
+    }
+
+    func testDevinRejectedCredentialReturnsForbiddenQuota() throws {
+        XCTAssertTrue(try XCTUnwrap(DevinQuotaFetcher.quotaResult(data: Data(), statusCode: 401)).isForbidden)
+        XCTAssertTrue(try XCTUnwrap(DevinQuotaFetcher.quotaResult(data: Data(), statusCode: 403)).isForbidden)
+        XCTAssertNil(DevinQuotaFetcher.quotaResult(data: Data(), statusCode: 500))
     }
 
     func testDevinTOMLParsesNativeCredentialAndHTTPSOnlyServer() {
@@ -484,6 +557,31 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertNil(legacyQuota.models.first(where: { $0.name == "grok-weekly" }))
     }
 
+    func testGrokQuotaResultMarksRejectedCredentialsAndSetsDisplayName() throws {
+        let forbidden = try XCTUnwrap(GrokQuotaFetcher.quotaResult(
+            data: Data(),
+            statusCode: 403,
+            plan: nil,
+            displayName: "person@example.com"
+        ))
+        XCTAssertTrue(forbidden.isForbidden)
+        XCTAssertEqual(forbidden.accountDisplayName, "person@example.com")
+
+        let billing = try JSONSerialization.data(withJSONObject: [
+            "config": [
+                "creditUsagePercent": 25,
+                "currentPeriod": ["type": "USAGE_PERIOD_TYPE_WEEKLY", "end": "2030-01-08T00:00:00Z"],
+            ],
+        ])
+        let quota = try XCTUnwrap(GrokQuotaFetcher.quotaResult(
+            data: billing,
+            statusCode: 200,
+            plan: "SuperGrok",
+            displayName: "person@example.com"
+        ))
+        XCTAssertEqual(quota.accountDisplayName, "person@example.com")
+    }
+
     func testGrokAtomicRotationPreservesSiblingAndUnknownFields() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -521,6 +619,22 @@ final class MonitorRuntimeTests: XCTestCase {
 
         XCTAssertEqual(quota.models.first(where: { $0.name == "openrouter-credits" })?.presentation, .progress(used: 40.10, limit: 100.25, unit: .usd))
         XCTAssertEqual(quota.models.first(where: { $0.name == "openrouter-balance" })?.presentation, .amount(value: 60.15, unit: .usd, semantics: .balance))
+    }
+
+    func testOpenRouterPlanLabelsUseLocalization() throws {
+        let previousLanguage = UserDefaults.standard.string(forKey: "appLanguage")
+        UserDefaults.standard.set("vi", forKey: "appLanguage")
+        defer { UserDefaults.standard.set(previousLanguage, forKey: "appLanguage") }
+        let key = OpenRouterEndpointResult(
+            data: try JSONSerialization.data(withJSONObject: ["data": ["is_free_tier": true]]),
+            statusCode: 200
+        )
+        let quota = try XCTUnwrap(OpenRouterQuotaMapper.map(
+            credits: OpenRouterEndpointResult(data: nil, statusCode: 500),
+            key: key
+        ))
+
+        XCTAssertEqual(quota.planType, "Gói miễn phí")
     }
 
     func testOpenRouterZeroBalanceAndAuthenticationFailure() throws {

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -1,9 +1,10 @@
 import XCTest
+import SQLite3
 @testable import Quotio
 
 final class MonitorRuntimeTests: XCTestCase {
     func testMonitorProvidersDoNotRequireInstalledCLI() {
-        let providers: Set<AIProvider> = [.codex, .claude, .gemini]
+        let providers: Set<AIProvider> = [.codex, .claude, .gemini, .devin, .grok, .openRouter]
 
         let filtered = StatusBarMenuBuilder.filterProviders(
             providers,
@@ -207,6 +208,234 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertEqual(loaded[.codex]?["account"]?.models.first?.percentage, 42)
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         XCTAssertEqual((attributes[.posixPermissions] as? NSNumber)?.intValue, 0o600)
+    }
+
+    func testLegacyModelQuotaDecodesWithoutMetricPresentation() throws {
+        let data = Data(#"{"name":"legacy","percentage":42,"resetTime":"","used":3,"limit":10}"#.utf8)
+
+        let model = try JSONDecoder().decode(ModelQuota.self, from: data)
+
+        XCTAssertNil(model.presentation)
+        XCTAssertEqual(model.percentage, 42)
+        XCTAssertEqual(model.used, 3)
+        XCTAssertEqual(model.limit, 10)
+    }
+
+    func testMetricPresentationsRoundTrip() throws {
+        let values: [QuotaMetricPresentation] = [
+            .progress(used: 1.25, limit: 10.5, unit: .usd),
+            .amount(value: 4.75, unit: .credits, semantics: .balance),
+            .status(text: "Enabled"),
+        ]
+
+        for value in values {
+            let decoded = try JSONDecoder().decode(
+                QuotaMetricPresentation.self,
+                from: JSONEncoder().encode(value)
+            )
+            XCTAssertEqual(decoded, value)
+        }
+    }
+
+    func testZAIQuotaMappingClassifiesWindowsAndSearches() {
+        let data = GLMQuotaData(limits: [
+            GLMLimit(type: "TOKENS_LIMIT", unit: 3, number: 5, usage: 100, currentValue: 20, remaining: 80, percentage: 20, usageDetails: nil, nextResetTime: nil),
+            GLMLimit(type: "TOKENS_LIMIT", unit: 4, number: 7, usage: 100, currentValue: 60, remaining: 40, percentage: 60, usageDetails: nil, nextResetTime: nil),
+            GLMLimit(type: "TIME_LIMIT", unit: 4, number: 1, usage: 1000, currentValue: 125, remaining: 875, percentage: 12.5, usageDetails: nil, nextResetTime: nil),
+        ])
+
+        let quota = GLMQuotaFetcher.mapQuotaData(data, planName: "GLM Coding Pro")
+
+        XCTAssertEqual(quota.planType, "GLM Coding Pro")
+        XCTAssertEqual(quota.models.map(\.name), ["zai-session", "zai-weekly", "zai-web-searches"])
+        XCTAssertEqual(quota.models[0].percentage, 80)
+        XCTAssertEqual(quota.models[1].percentage, 40)
+        XCTAssertEqual(quota.models[2].presentation, .progress(used: 125, limit: 1000, unit: .searches))
+        XCTAssertEqual(GLMQuotaFetcher.apiRoot(from: "https://bigmodel.cn/api/paas/v4"), "https://bigmodel.cn")
+    }
+
+    func testZAIQuotaResponseDecodesOptionalLiveFields() throws {
+        let payload = Data(#"{"code":200,"data":{"limits":[{"type":"TOKENS_LIMIT","unit":6,"number":1,"percentage":25},{"type":"TIME_LIMIT","usage":1000,"currentValue":0}]},"success":true}"#.utf8)
+
+        let response = try JSONDecoder().decode(GLMQuotaResponse.self, from: payload)
+        let quota = GLMQuotaFetcher.mapQuotaData(try XCTUnwrap(response.data), planName: nil)
+
+        XCTAssertEqual(quota.models.map(\.name), ["zai-weekly", "zai-web-searches"])
+        XCTAssertEqual(quota.models[1].presentation, .progress(used: 0, limit: 1000, unit: .searches))
+    }
+
+    func testDevinMappingPreservesRemainingConventionAndWeeklyFallback() throws {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "userStatus": [
+                "planStatus": [
+                    "planInfo": ["planName": "Max", "hideDailyQuota": true],
+                    "dailyQuotaRemainingPercent": 30,
+                    "overageBalanceMicros": "0",
+                ],
+            ],
+        ])
+
+        let quota = try XCTUnwrap(DevinQuotaMapper.map(data))
+
+        XCTAssertEqual(quota.models.first(where: { $0.name == "devin-weekly" })?.percentage, 30)
+        XCTAssertEqual(
+            quota.models.first(where: { $0.name == "devin-extra-balance" })?.presentation,
+            .amount(value: 0, unit: .usd, semantics: .balance)
+        )
+        XCTAssertEqual(quota.planType, "Max")
+    }
+
+    func testDevinTOMLParsesNativeCredentialAndHTTPSOnlyServer() {
+        let native = DevinQuotaFetcher.parseCredentialsTOML("""
+        windsurf_api_key = "native-token"
+        api_server_url = "https://server.codeium.test/"
+        """)
+        let insecure = DevinQuotaFetcher.parseCredentialsTOML("""
+        windsurf_api_key = "native-token"
+        api_server_url = "http://server.codeium.test"
+        """)
+
+        XCTAssertEqual(native, DevinCredential(apiKey: "native-token", apiServerURL: "https://server.codeium.test"))
+        XCTAssertNil(insecure?.apiServerURL)
+    }
+
+    func testDevinReadsSQLiteAppCredential() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let path = directory.appendingPathComponent("state.vscdb").path
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(path, &database), SQLITE_OK)
+        defer { sqlite3_close(database) }
+        XCTAssertEqual(sqlite3_exec(database, "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)", nil, nil, nil), SQLITE_OK)
+        XCTAssertEqual(sqlite3_exec(database, "INSERT INTO ItemTable VALUES ('windsurfAuthStatus', '{\"apiKey\":\"app-token\"}')", nil, nil, nil), SQLITE_OK)
+
+        XCTAssertEqual(
+            DevinQuotaFetcher.loadAppCredential(path: path),
+            DevinCredential(apiKey: "app-token", apiServerURL: nil)
+        )
+    }
+
+    func testGrokParsesMultipleAccountsAndSkipsInvalidEntries() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("auth.json")
+        let data = try JSONSerialization.data(withJSONObject: [
+            "account-a::client-a": ["key": "token-a", "refresh_token": "refresh-a"],
+            "account-b::client-b": ["key": "token-b"],
+            "invalid": ["refresh_token": "refresh-only"],
+        ])
+        try data.write(to: url)
+
+        let candidates = GrokQuotaFetcher.loadCandidates(path: url.path)
+
+        XCTAssertEqual(candidates.map(\.entryKey), ["account-a::client-a", "account-b::client-b"])
+        XCTAssertEqual(candidates.map(\.clientID), ["client-a", "client-b"])
+    }
+
+    func testGrokMapsOnlyWeeklyPeriodAndStatusCap() throws {
+        let weekly = try JSONSerialization.data(withJSONObject: [
+            "config": [
+                "creditUsagePercent": 25,
+                "currentPeriod": ["type": "USAGE_PERIOD_TYPE_WEEKLY", "end": "2030-01-08T00:00:00Z"],
+                "onDemandCap": ["val": 2500],
+            ],
+        ])
+        let legacy = try JSONSerialization.data(withJSONObject: [
+            "config": [
+                "creditUsagePercent": 25,
+                "currentPeriod": ["type": "USAGE_PERIOD_TYPE_MONTHLY", "end": "2030-02-01T00:00:00Z"],
+            ],
+        ])
+
+        let weeklyQuota = try XCTUnwrap(GrokQuotaMapper.mapBilling(weekly, plan: "SuperGrok"))
+        let legacyQuota = try XCTUnwrap(GrokQuotaMapper.mapBilling(legacy, plan: nil))
+
+        XCTAssertEqual(weeklyQuota.models.first(where: { $0.name == "grok-weekly" })?.percentage, 75)
+        XCTAssertEqual(
+            weeklyQuota.models.first(where: { $0.name == "grok-extra-usage" })?.presentation,
+            .status(text: String(format: "grok.status.cap".localizedStatic(), "2500"))
+        )
+        XCTAssertNil(legacyQuota.models.first(where: { $0.name == "grok-weekly" }))
+    }
+
+    func testGrokAtomicRotationPreservesSiblingAndUnknownFields() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("auth.json")
+        let original: [String: Any] = [
+            "target": ["key": "old", "refresh_token": "old-refresh", "unknown": "keep"],
+            "sibling": ["key": "sibling-token", "custom": 42],
+        ]
+        try JSONSerialization.data(withJSONObject: original).write(to: url)
+
+        try GrokQuotaFetcher.persistRotatedCredential(
+            path: url.path,
+            entryKey: "target",
+            accessToken: "new",
+            refreshToken: "new-refresh",
+            idToken: nil,
+            expiresAt: Date(timeIntervalSince1970: 1_900_000_000)
+        )
+
+        let updated = try XCTUnwrap(MonitorIdentity.json(at: url.path))
+        XCTAssertEqual((updated["target"] as? [String: Any])?["unknown"] as? String, "keep")
+        XCTAssertEqual((updated["sibling"] as? [String: Any])?["key"] as? String, "sibling-token")
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        XCTAssertEqual((attributes[.posixPermissions] as? NSNumber)?.intValue, 0o600)
+    }
+
+    func testOpenRouterPartialSuccessKeepsDecimalMetrics() throws {
+        let credits = OpenRouterEndpointResult(
+            data: try JSONSerialization.data(withJSONObject: ["data": ["total_credits": 100.25, "total_usage": 40.10]]),
+            statusCode: 200
+        )
+        let failedKey = OpenRouterEndpointResult(data: nil, statusCode: 503)
+
+        let quota = try XCTUnwrap(OpenRouterQuotaMapper.map(credits: credits, key: failedKey))
+
+        XCTAssertEqual(quota.models.first(where: { $0.name == "openrouter-credits" })?.presentation, .progress(used: 40.10, limit: 100.25, unit: .usd))
+        XCTAssertEqual(quota.models.first(where: { $0.name == "openrouter-balance" })?.presentation, .amount(value: 60.15, unit: .usd, semantics: .balance))
+    }
+
+    func testOpenRouterZeroBalanceAndAuthenticationFailure() throws {
+        let zeroCredits = OpenRouterEndpointResult(
+            data: try JSONSerialization.data(withJSONObject: ["data": ["total_credits": 0, "total_usage": 0]]),
+            statusCode: 200
+        )
+        let failedKey = OpenRouterEndpointResult(data: nil, statusCode: 500)
+        let zero = try XCTUnwrap(OpenRouterQuotaMapper.map(credits: zeroCredits, key: failedKey))
+        XCTAssertEqual(zero.models.first?.presentation, .amount(value: 0, unit: .usd, semantics: .balance))
+
+        let forbidden = try XCTUnwrap(OpenRouterQuotaMapper.map(
+            credits: OpenRouterEndpointResult(data: Data(), statusCode: 401),
+            key: OpenRouterEndpointResult(data: Data(), statusCode: 403)
+        ))
+        XCTAssertTrue(forbidden.isForbidden)
+    }
+
+    func testMonitorCredentialVaultAddsRotatesAndDeletesOpenRouterKey() async throws {
+        let metadataURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("accounts.json")
+        let vault = MonitorCredentialVault(metadata: MonitorMetadataStore(url: metadataURL))
+        let account = MonitorAccount.make(
+            provider: .openRouter,
+            accountKey: "Test " + UUID().uuidString,
+            source: .quotioKeychain,
+            canDelete: true
+        )
+        let first = MonitorOAuthCredential(accessToken: "first", refreshToken: nil, idToken: nil, accountID: nil, expiresAt: nil, extra: [:])
+        let second = MonitorOAuthCredential(accessToken: "second", refreshToken: nil, idToken: nil, accountID: nil, expiresAt: nil, extra: [:])
+
+        try await vault.save(first, metadata: account)
+        let loadedFirst = await vault.credential(for: account.id)
+        XCTAssertEqual(loadedFirst?.accessToken, "first")
+        try await vault.save(second, metadata: account)
+        let loadedSecond = await vault.credential(for: account.id)
+        XCTAssertEqual(loadedSecond?.accessToken, "second")
+        await vault.delete(accountID: account.id)
+        let deleted = await vault.credential(for: account.id)
+        XCTAssertNil(deleted)
     }
 
     func testMetadataRoundTripStoresOwnedAccountAndDisabledState() async throws {

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -315,7 +315,7 @@ final class MonitorRuntimeTests: XCTestCase {
 
         let quota = FactoryDroidQuotaMapper.map(response)
 
-        XCTAssertEqual(quota.models.count, 8)
+        XCTAssertEqual(quota.models.count, 7)
         XCTAssertEqual(quota.models.first(where: { $0.name == "factory-standard-five-hour" })?.percentage, 0)
         XCTAssertEqual(quota.models.first(where: { $0.name == "factory-standard-weekly" })?.percentage, 37)
         XCTAssertEqual(quota.models.first(where: { $0.name == "factory-core-weekly" })?.percentage, 49)
@@ -334,10 +334,7 @@ final class MonitorRuntimeTests: XCTestCase {
             quota.models.first(where: { $0.name == "factory-extra-balance" })?.presentation,
             .amount(value: 0, unit: .usd, semantics: .balance)
         )
-        XCTAssertEqual(
-            quota.models.first(where: { $0.name == "factory-extra-usage" })?.presentation,
-            .status(text: "factory.status.extraUsageCore".localizedStatic())
-        )
+        XCTAssertNil(quota.models.first(where: { $0.name == "factory-extra-usage" }))
     }
 
     func testFactoryDroidAuthMeExtractsUserProfileEmail() throws {

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -495,9 +495,17 @@ final class MonitorRuntimeTests: XCTestCase {
         windsurf_api_key = "native-token"
         api_server_url = "http://server.codeium.test"
         """)
+        let quotedHash = DevinQuotaFetcher.parseCredentialsTOML("""
+        windsurf_api_key = "native#token" # account credential
+        api_server_url = "https://server.codeium.test/path#fragment" # API endpoint
+        """)
 
         XCTAssertEqual(native, DevinCredential(apiKey: "native-token", apiServerURL: "https://server.codeium.test"))
         XCTAssertNil(insecure?.apiServerURL)
+        XCTAssertEqual(
+            quotedHash,
+            DevinCredential(apiKey: "native#token", apiServerURL: "https://server.codeium.test/path#fragment")
+        )
     }
 
     func testDevinReadsSQLiteAppCredential() throws {

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -200,13 +200,15 @@ final class MonitorRuntimeTests: XCTestCase {
         let store = MonitorSnapshotStore(url: url)
         let quota = ProviderQuotaData(
             models: [ModelQuota(name: "test", percentage: 42, resetTime: "")],
-            lastUpdated: Date(timeIntervalSince1970: 1234)
+            lastUpdated: Date(timeIntervalSince1970: 1234),
+            accountDisplayName: "factory@example.com"
         )
 
         await store.store([.codex: ["account": quota]])
         let loaded = await store.load()
 
         XCTAssertEqual(loaded[.codex]?["account"]?.models.first?.percentage, 42)
+        XCTAssertEqual(loaded[.codex]?["account"]?.accountDisplayName, "factory@example.com")
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         XCTAssertEqual((attributes[.posixPermissions] as? NSNumber)?.intValue, 0o600)
     }
@@ -317,6 +319,17 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertEqual(quota.models.first(where: { $0.name == "factory-standard-five-hour" })?.percentage, 0)
         XCTAssertEqual(quota.models.first(where: { $0.name == "factory-standard-weekly" })?.percentage, 37)
         XCTAssertEqual(quota.models.first(where: { $0.name == "factory-core-weekly" })?.percentage, 49)
+        let sections = FactoryDroidQuotaSection.sections(from: quota.models)
+        XCTAssertEqual(sections.map(\.group), [.standard, .core])
+        XCTAssertEqual(sections.map { $0.models.count }, [3, 3])
+        XCTAssertEqual(
+            sections[0].models.map(\.name),
+            ["factory-standard-five-hour", "factory-standard-weekly", "factory-standard-monthly"]
+        )
+        XCTAssertEqual(
+            sections[1].models.map(\.name),
+            ["factory-core-five-hour", "factory-core-weekly", "factory-core-monthly"]
+        )
         XCTAssertEqual(
             quota.models.first(where: { $0.name == "factory-extra-balance" })?.presentation,
             .amount(value: 0, unit: .usd, semantics: .balance)
@@ -325,6 +338,20 @@ final class MonitorRuntimeTests: XCTestCase {
             quota.models.first(where: { $0.name == "factory-extra-usage" })?.presentation,
             .status(text: "factory.status.extraUsageCore".localizedStatic())
         )
+    }
+
+    func testFactoryDroidAuthMeExtractsUserProfileEmail() throws {
+        let response = try JSONDecoder().decode(
+            FactoryDroidAuthMeResponse.self,
+            from: Data(#"{"organization":{"id":"org-123"},"userProfile":{"email":" factory@example.com ","firstName":"Factory"}}"#.utf8)
+        )
+        let missing = try JSONDecoder().decode(
+            FactoryDroidAuthMeResponse.self,
+            from: Data(#"{"userProfile":{"email":"  "}}"#.utf8)
+        )
+
+        XCTAssertEqual(response.email, "factory@example.com")
+        XCTAssertNil(missing.email)
     }
 
     func testFactoryDroidMapsLegacyBillingStatus() throws {
@@ -578,6 +605,25 @@ final class MonitorRuntimeTests: XCTestCase {
         )
 
         XCTAssertTrue(derived.isDisabled)
+    }
+
+    func testQuotaDisplayNameEnrichmentPreservesFactoryAccountIdentity() {
+        let account = MonitorAccount.make(
+            provider: .factoryDroid,
+            accountKey: "org-123",
+            displayName: "Factory Droid",
+            source: .nativeCredential
+        )
+        let quota = ProviderQuotaData(accountDisplayName: "factory@example.com")
+
+        let enriched = MonitorRefreshCoordinator.applyingQuotaDisplayNames(
+            [account],
+            quotas: [.factoryDroid: [account.accountKey: quota]]
+        )
+
+        XCTAssertEqual(enriched.first?.displayName, "factory@example.com")
+        XCTAssertEqual(enriched.first?.accountKey, account.accountKey)
+        XCTAssertEqual(enriched.first?.id, account.id)
     }
 
     func testCoordinatorRetainsLastGoodQuotaOnTransientFailure() async {

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -1,10 +1,11 @@
-import XCTest
+import CryptoKit
 import SQLite3
+import XCTest
 @testable import Quotio
 
 final class MonitorRuntimeTests: XCTestCase {
     func testMonitorProvidersDoNotRequireInstalledCLI() {
-        let providers: Set<AIProvider> = [.codex, .claude, .gemini, .devin, .grok, .openRouter]
+        let providers: Set<AIProvider> = [.codex, .claude, .gemini, .factoryDroid, .devin, .grok, .openRouter]
 
         let filtered = StatusBarMenuBuilder.filterProviders(
             providers,
@@ -237,6 +238,107 @@ final class MonitorRuntimeTests: XCTestCase {
         }
     }
 
+    func testFactoryDroidDecryptsLocalCredentialFile() throws {
+        let keyData = Data((0..<32).map(UInt8.init))
+        let nonce = try AES.GCM.Nonce(data: Data((32..<48).map(UInt8.init)))
+        let cleartext = Data(#"{"access_token":"local-token","refresh_token":"refresh","active_organization_id":"org-123"}"#.utf8)
+        let sealed = try AES.GCM.seal(cleartext, using: SymmetricKey(data: keyData), nonce: nonce)
+        let encrypted = [
+            Data(nonce).base64EncodedString(),
+            sealed.tag.base64EncodedString(),
+            sealed.ciphertext.base64EncodedString(),
+        ].joined(separator: ":")
+
+        let credential = FactoryDroidCredentialReader.decryptCredential(
+            encrypted: encrypted,
+            keyData: Data(keyData.base64EncodedString().utf8),
+            sourcePath: "/tmp/auth.v2.file"
+        )
+
+        XCTAssertEqual(credential, FactoryDroidCredential(
+            accessToken: "local-token",
+            activeOrganizationID: "org-123",
+            sourcePath: "/tmp/auth.v2.file"
+        ))
+    }
+
+    func testFactoryDroidLoadsKeyFileCredentialFromDirectory() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let keyData = Data(repeating: 7, count: 32)
+        let nonce = try AES.GCM.Nonce(data: Data(repeating: 8, count: 16))
+        let cleartext = Data(#"{"access_token":"directory-token","active_organization_id":"org-directory"}"#.utf8)
+        let sealed = try AES.GCM.seal(cleartext, using: SymmetricKey(data: keyData), nonce: nonce)
+        let encrypted = [
+            Data(nonce).base64EncodedString(),
+            sealed.tag.base64EncodedString(),
+            sealed.ciphertext.base64EncodedString(),
+        ].joined(separator: ":")
+        try Data(encrypted.utf8).write(to: directory.appendingPathComponent("auth.v2.file"))
+        try Data(keyData.base64EncodedString().utf8).write(to: directory.appendingPathComponent("auth.v2.key"))
+
+        let credential = FactoryDroidCredentialReader.load(directory: directory)
+
+        XCTAssertEqual(credential?.accessToken, "directory-token")
+        XCTAssertEqual(credential?.accountKey, "org-directory")
+        XCTAssertEqual(
+            FactoryDroidQuotaFetcher.localAccount(for: try XCTUnwrap(credential)).provider,
+            .factoryDroid
+        )
+    }
+
+    func testFactoryDroidMapsStandardCoreAndExtraUsage() throws {
+        let payload = Data(#"""
+        {
+          "usesTokenRateLimitsBilling": true,
+          "limits": {
+            "standard": {
+              "fiveHour": {"usedPercent": 100, "windowEnd": "2026-07-20T17:59:00.865Z", "secondsRemaining": 5382},
+              "weekly": {"usedPercent": 63, "windowEnd": "2026-07-25T16:37:06.931Z", "secondsRemaining": 432468},
+              "monthly": {"usedPercent": 16, "windowEnd": "2026-08-17T16:37:06.931Z", "secondsRemaining": 2419668}
+            },
+            "core": {
+              "fiveHour": {"usedPercent": 100, "windowEnd": "2026-07-20T19:01:10.798Z", "secondsRemaining": 9112},
+              "weekly": {"usedPercent": 51, "windowEnd": "2026-07-27T14:01:10.798Z", "secondsRemaining": 595912},
+              "monthly": {"usedPercent": 19, "windowEnd": "2026-08-19T14:01:10.798Z", "secondsRemaining": 2583112}
+            }
+          },
+          "extraUsageBalanceCents": 0,
+          "overagePreference": "droidCore",
+          "extraUsageAllowed": true
+        }
+        """#.utf8)
+        let response = try JSONDecoder().decode(FactoryDroidQuotaResponse.self, from: payload)
+
+        let quota = FactoryDroidQuotaMapper.map(response)
+
+        XCTAssertEqual(quota.models.count, 8)
+        XCTAssertEqual(quota.models.first(where: { $0.name == "factory-standard-five-hour" })?.percentage, 0)
+        XCTAssertEqual(quota.models.first(where: { $0.name == "factory-standard-weekly" })?.percentage, 37)
+        XCTAssertEqual(quota.models.first(where: { $0.name == "factory-core-weekly" })?.percentage, 49)
+        XCTAssertEqual(
+            quota.models.first(where: { $0.name == "factory-extra-balance" })?.presentation,
+            .amount(value: 0, unit: .usd, semantics: .balance)
+        )
+        XCTAssertEqual(
+            quota.models.first(where: { $0.name == "factory-extra-usage" })?.presentation,
+            .status(text: "factory.status.extraUsageCore".localizedStatic())
+        )
+    }
+
+    func testFactoryDroidMapsLegacyBillingStatus() throws {
+        let response = try JSONDecoder().decode(
+            FactoryDroidQuotaResponse.self,
+            from: Data(#"{"usesTokenRateLimitsBilling":false}"#.utf8)
+        )
+
+        let quota = FactoryDroidQuotaMapper.map(response)
+
+        XCTAssertEqual(quota.models.first?.name, "factory-billing-mode")
+        XCTAssertTrue(quota.models.first?.isStandaloneMetric == true)
+    }
+
     func testZAIQuotaMappingClassifiesWindowsAndSearches() {
         let data = GLMQuotaData(limits: [
             GLMLimit(type: "TOKENS_LIMIT", unit: 3, number: 5, usage: 100, currentValue: 20, remaining: 80, percentage: 20, usageDetails: nil, nextResetTime: nil),
@@ -413,29 +515,31 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertTrue(forbidden.isForbidden)
     }
 
-    func testMonitorCredentialVaultAddsRotatesAndDeletesOpenRouterKey() async throws {
-        let metadataURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathComponent("accounts.json")
-        let vault = MonitorCredentialVault(metadata: MonitorMetadataStore(url: metadataURL))
-        let account = MonitorAccount.make(
-            provider: .openRouter,
-            accountKey: "Test " + UUID().uuidString,
-            source: .quotioKeychain,
-            canDelete: true
-        )
-        let first = MonitorOAuthCredential(accessToken: "first", refreshToken: nil, idToken: nil, accountID: nil, expiresAt: nil, extra: [:])
-        let second = MonitorOAuthCredential(accessToken: "second", refreshToken: nil, idToken: nil, accountID: nil, expiresAt: nil, extra: [:])
+    func testMonitorCredentialVaultAddsRotatesAndDeletesAPIKeys() async throws {
+        for provider in [AIProvider.factoryDroid, .openRouter] {
+            let metadataURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathComponent("accounts.json")
+            let vault = MonitorCredentialVault(metadata: MonitorMetadataStore(url: metadataURL))
+            let account = MonitorAccount.make(
+                provider: provider,
+                accountKey: "Test " + UUID().uuidString,
+                source: .quotioKeychain,
+                canDelete: true
+            )
+            let first = MonitorOAuthCredential(accessToken: "first", refreshToken: nil, idToken: nil, accountID: nil, expiresAt: nil, extra: [:])
+            let second = MonitorOAuthCredential(accessToken: "second", refreshToken: nil, idToken: nil, accountID: nil, expiresAt: nil, extra: [:])
 
-        try await vault.save(first, metadata: account)
-        let loadedFirst = await vault.credential(for: account.id)
-        XCTAssertEqual(loadedFirst?.accessToken, "first")
-        try await vault.save(second, metadata: account)
-        let loadedSecond = await vault.credential(for: account.id)
-        XCTAssertEqual(loadedSecond?.accessToken, "second")
-        await vault.delete(accountID: account.id)
-        let deleted = await vault.credential(for: account.id)
-        XCTAssertNil(deleted)
+            try await vault.save(first, metadata: account)
+            let loadedFirst = await vault.credential(for: account.id)
+            XCTAssertEqual(loadedFirst?.accessToken, "first")
+            try await vault.save(second, metadata: account)
+            let loadedSecond = await vault.credential(for: account.id)
+            XCTAssertEqual(loadedSecond?.accessToken, "second")
+            await vault.delete(accountID: account.id)
+            let deleted = await vault.credential(for: account.id)
+            XCTAssertNil(deleted)
+        }
     }
 
     func testMetadataRoundTripStoresOwnedAccountAndDisabledState() async throws {


### PR DESCRIPTION
## Summary

- add Monitor quota support for Devin, Grok, OpenRouter, and Factory Droid
- upgrade the existing GLM integration for Z.ai-compatible endpoints and richer quota buckets
- add progress, amount, and status metric presentations without breaking saved snapshots
- integrate provider discovery, secure API-key accounts, periodic refresh, menu filtering, and quota rendering
- keep Factory Droid focused on Standard/Core limits and Extra Balance without a redundant Extra Usage status row

## User impact

Monitor mode can track more provider accounts independently of Local Proxy. API-key providers use the existing credential vault, while supported local apps and CLIs can be discovered from their native credentials.

## Validation

- `xcodebuild test -project Quotio.xcodeproj -scheme Quotio -destination 'platform=macOS'` — 41 tests passed
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build`
- `git diff --check`

Live-account refresh and light/dark-mode visual checks remain pending.
