### PR TITLE
feat: add scoped account and provider quota refresh

### DIFF
--- a/Quotio/Models/Models.swift
+++ b/Quotio/Models/Models.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 // MARK: - Provider Types
 
-nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
+nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable, Sendable {
     case gemini = "gemini-cli"
     case claude = "claude"
     case codex = "codex"
@@ -267,6 +267,12 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable {
     }
 }
 
+/// Stable identity for one account in the provider quota dictionary.
+nonisolated struct QuotaAccountID: Hashable, Sendable {
+    let provider: AIProvider
+    let accountKey: String
+}
+
 // MARK: - Quota Metric Presentation
 
 /// Optional typed value for quota rows that are not plain percentages.
@@ -326,6 +332,15 @@ extension String {
         }
         return key
     }
+
+    nonisolated var copilotFilenameKey: String? {
+        guard hasPrefix("github-copilot-") else { return nil }
+        var key = String(dropFirst("github-copilot-".count))
+        if key.hasSuffix(".json") {
+            key = String(key.dropLast(".json".count))
+        }
+        return key.isEmpty ? nil : key
+    }
 }
 
 nonisolated struct AuthFile: Codable, Identifiable, Hashable, Sendable {
@@ -372,6 +387,14 @@ nonisolated struct AuthFile: Codable, Identifiable, Hashable, Sendable {
             // Codex proxy filenames encode the concrete subscription variant,
             // so filename-based keys keep same-email Plus/Team accounts distinct.
             return name.codexFilenameKey
+        }
+        if providerType == .copilot {
+            if let account, !account.isEmpty {
+                return account
+            }
+            if let filenameKey = name.copilotFilenameKey {
+                return filenameKey
+            }
         }
         if let email = email, !email.isEmpty {
             return email

--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -691,7 +691,7 @@ struct ContentView: View {
                     } else {
                         // Monitor or remote mode: refresh button
                         Button {
-                            Task { await viewModel.refreshQuotasDirectly() }
+                            Task { await viewModel.manualRefresh() }
                         } label: {
                             Image(systemName: "arrow.clockwise")
                         }

--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -1307,9 +1307,12 @@ actor AntigravityQuotaFetcher {
         }
         for file in files where file.hasPrefix("antigravity-") && file.hasSuffix(".json") {
             let path = (directory as NSString).appendingPathComponent(file)
-            guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
-                  let auth = try? JSONDecoder().decode(AntigravityAuthFile.self, from: data),
-                  auth.email == accountKey else { continue }
+            let key = file
+                .replacingOccurrences(of: "antigravity-", with: "")
+                .replacingOccurrences(of: ".json", with: "")
+                .replacingOccurrences(of: "_", with: ".")
+                .replacingOccurrences(of: ".gmail.com", with: "@gmail.com")
+            guard key == accountKey else { continue }
             return await fetchQuotaAndSubscriptionForAuthFile(at: path)
         }
         return (nil, nil)

--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -1148,6 +1148,9 @@ actor AntigravityQuotaFetcher {
                         quota = try await fetchQuota(accessToken: access)
                     }
                     quotaResults[account.accountKey] = quota
+                    if let subscription = subscriptionCache[credential.accessToken] {
+                        subscriptionResults[account.accountKey] = subscription
+                    }
                 } catch QuotaFetchError.httpError(let status) where status == 401 || status == 403 {
                     if let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id),
                        let refresh = latest.refreshToken,
@@ -1157,6 +1160,9 @@ actor AntigravityQuotaFetcher {
                         credential.expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn))
                         try? await MonitorCredentialVault.shared.save(credential, metadata: account)
                         quotaResults[account.accountKey] = try? await fetchQuota(accessToken: access)
+                        if let subscription = subscriptionCache[access] {
+                            subscriptionResults[account.accountKey] = subscription
+                        }
                     }
                 } catch {
                     continue
@@ -1174,7 +1180,11 @@ actor AntigravityQuotaFetcher {
                }
            )),
            let quota = try? await fetchQuota(accessToken: accessToken) {
-            quotaResults[await nativeAccountName(accessToken: accessToken)] = quota
+            let key = await nativeAccountName(accessToken: accessToken)
+            quotaResults[key] = quota
+            if let subscription = subscriptionCache[accessToken] {
+                subscriptionResults[key] = subscription
+            }
         }
 
         if let native = loadNativeKeychainToken(),
@@ -1182,6 +1192,10 @@ actor AntigravityQuotaFetcher {
             if let quota = try? await fetchQuota(accessToken: accessToken) {
                 let key = await nativeAccountName(accessToken: accessToken)
                 if quotaResults[key] == nil { quotaResults[key] = quota }
+                if subscriptionResults[key] == nil,
+                   let subscription = subscriptionCache[accessToken] {
+                    subscriptionResults[key] = subscription
+                }
             }
         }
 
@@ -1217,6 +1231,88 @@ actor AntigravityQuotaFetcher {
         }
 
         return (quotaResults, subscriptionResults)
+    }
+
+    /// Fetches quota and subscription for exactly one canonical account key.
+    func fetchData(forAccountKey accountKey: String) async -> (
+        quota: ProviderQuotaData?,
+        subscription: SubscriptionInfo?
+    ) {
+        if let account = await MonitorCredentialVault.shared.accounts().first(where: {
+            $0.provider == .antigravity && !$0.isDisabled && $0.accountKey == accountKey
+        }), var credential = await MonitorCredentialVault.shared.credential(for: account.id) {
+            if credential.expiresAt.map({ $0.timeIntervalSinceNow < 300 }) ?? false,
+               let refresh = credential.refreshToken,
+               let (access, expiresIn) = try? await refreshAccessTokenWithExpiry(refreshToken: refresh) {
+                credential.accessToken = access
+                credential.expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn))
+                try? await MonitorCredentialVault.shared.save(credential, metadata: account)
+            }
+            var quota: ProviderQuotaData?
+            do {
+                quota = try await fetchQuota(accessToken: credential.accessToken)
+            } catch QuotaFetchError.httpError(let status) where status == 401 || status == 403 {
+                quota = nil
+            } catch {
+                return (nil, subscriptionCache[credential.accessToken])
+            }
+            var didRetryCredential = false
+            if quota?.isForbidden == true,
+               let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id),
+               let refresh = latest.refreshToken,
+               let (access, expiresIn) = try? await refreshAccessTokenWithExpiry(refreshToken: refresh) {
+                didRetryCredential = true
+                credential = latest
+                credential.accessToken = access
+                credential.expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn))
+                try? await MonitorCredentialVault.shared.save(credential, metadata: account)
+                quota = try? await fetchQuota(accessToken: access)
+            }
+            if quota == nil, !didRetryCredential,
+               let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id),
+               let refresh = latest.refreshToken,
+               let (access, expiresIn) = try? await refreshAccessTokenWithExpiry(refreshToken: refresh) {
+                credential = latest
+                credential.accessToken = access
+                credential.expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn))
+                try? await MonitorCredentialVault.shared.save(credential, metadata: account)
+                quota = try? await fetchQuota(accessToken: access)
+            }
+            return (quota, subscriptionCache[credential.accessToken])
+        }
+
+        if let ideToken = try? await databaseService.getCurrentTokenInfo(),
+           let access = await usableNativeAccessToken(from: NativeToken(
+               accessToken: ideToken.accessToken,
+               refreshToken: ideToken.refreshToken,
+               expiresAt: ideToken.expiry.map {
+                   let raw = TimeInterval($0)
+                   return Date(timeIntervalSince1970: raw > 10_000_000_000 ? raw / 1000 : raw)
+               }
+           )), await nativeAccountName(accessToken: access) == accountKey {
+            let quota = try? await fetchQuota(accessToken: access)
+            return (quota, subscriptionCache[access])
+        }
+
+        if let native = loadNativeKeychainToken(),
+           let access = await usableNativeAccessToken(from: native),
+           await nativeAccountName(accessToken: access) == accountKey {
+            let quota = try? await fetchQuota(accessToken: access)
+            return (quota, subscriptionCache[access])
+        }
+
+        let directory = NSString(string: "~/.cli-proxy-api").expandingTildeInPath
+        guard let files = try? FileManager.default.contentsOfDirectory(atPath: directory) else {
+            return (nil, nil)
+        }
+        for file in files where file.hasPrefix("antigravity-") && file.hasSuffix(".json") {
+            let path = (directory as NSString).appendingPathComponent(file)
+            guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+                  let auth = try? JSONDecoder().decode(AntigravityAuthFile.self, from: data),
+                  auth.email == accountKey else { continue }
+            return await fetchQuotaAndSubscriptionForAuthFile(at: path)
+        }
+        return (nil, nil)
     }
 
     /// Antigravity/agy stores a go-keyring wrapped JSON credential. Quotio only reads that item;

--- a/Quotio/Services/DirectAuthFileService.swift
+++ b/Quotio/Services/DirectAuthFileService.swift
@@ -53,9 +53,17 @@ struct DirectAuthFile: Identifiable, Sendable, Hashable {
     }
 
     /// Stable key for menu bar selection and quota lookup
-    var menuBarAccountKey: String {
+    nonisolated var menuBarAccountKey: String {
         if provider == .codex {
             return filename.codexFilenameKey
+        }
+        if provider == .copilot {
+            if let login, !login.isEmpty {
+                return login
+            }
+            if let filenameKey = filename.copilotFilenameKey {
+                return filenameKey
+            }
         }
         if provider == .kiro {
             if let email = email, !email.isEmpty {

--- a/Quotio/Services/Monitor/MonitorRuntime.swift
+++ b/Quotio/Services/Monitor/MonitorRuntime.swift
@@ -71,8 +71,8 @@ nonisolated struct MonitorAccount: Identifiable, Codable, Hashable, Sendable {
 
     static func makeLegacy(_ file: DirectAuthFile) -> MonitorAccount {
         let accountKey: String
-        if file.provider == .codex {
-            accountKey = file.filename.codexFilenameKey
+        if file.provider == .codex || file.provider == .copilot {
+            accountKey = file.menuBarAccountKey
         } else if let email = file.email, !email.isEmpty {
             accountKey = email
         } else {

--- a/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
@@ -358,8 +358,8 @@ actor ClaudeCodeQuotaFetcher {
     func fetchQuota(accountKey: String, forceRefresh: Bool = false) async -> ProviderQuotaData? {
         if let account = await MonitorCredentialVault.shared.accounts().first(where: {
             $0.provider == .claude && !$0.isDisabled && $0.accountKey == accountKey
-        }) {
-            return await fetchOwnedQuota(account: account, forceRefresh: forceRefresh)
+        }), let quota = await fetchOwnedQuota(account: account, forceRefresh: forceRefresh) {
+            return quota
         }
 
         if nativeKeychainIdentity() == accountKey,

--- a/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
@@ -354,6 +354,58 @@ actor ClaudeCodeQuotaFetcher {
         return results
     }
 
+    /// Fetch quota for exactly one canonical Claude account.
+    func fetchQuota(accountKey: String, forceRefresh: Bool = false) async -> ProviderQuotaData? {
+        if let account = await MonitorCredentialVault.shared.accounts().first(where: {
+            $0.provider == .claude && !$0.isDisabled && $0.accountKey == accountKey
+        }) {
+            return await fetchOwnedQuota(account: account, forceRefresh: forceRefresh)
+        }
+
+        if nativeKeychainIdentity() == accountKey,
+           let quota = await fetchNativeKeychainQuotas(forceRefresh: forceRefresh)[accountKey] {
+            return quota
+        }
+
+        let fileManager = FileManager.default
+        let claudeHome = ProcessInfo.processInfo.environment["CLAUDE_CONFIG_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let nativeBase = (claudeHome?.isEmpty == false ? claudeHome! : NSString(string: "~/.claude").expandingTildeInPath)
+        let nativePath = (nativeBase as NSString).appendingPathComponent(".credentials.json")
+        if fileManager.fileExists(atPath: nativePath), authFileIdentity(at: nativePath) == accountKey {
+            return await fetchQuotaFromAuthFile(at: nativePath, forceRefresh: forceRefresh)?.data
+        }
+
+        if accountKey == "Claude Desktop" {
+            return await fetchClaudeDesktopQuota(forceRefresh: forceRefresh)?.value
+        }
+
+        let expandedPath = NSString(string: authDir).expandingTildeInPath
+        let legacyFiles = (try? fileManager.contentsOfDirectory(atPath: expandedPath))?
+            .filter { $0.hasPrefix("claude-") && $0.hasSuffix(".json") } ?? []
+        for filename in legacyFiles {
+            let path = (expandedPath as NSString).appendingPathComponent(filename)
+            guard let identity = authFileIdentity(at: path), identity == accountKey else { continue }
+            return await fetchQuotaFromAuthFile(at: path, forceRefresh: forceRefresh)?.data
+        }
+        return nil
+    }
+
+    private func authFileIdentity(at path: String) -> String? {
+        guard let data = FileManager.default.contents(atPath: path),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        let oauth = json["claudeAiOauth"] as? [String: Any]
+        guard json["access_token"] as? String != nil || oauth?["accessToken"] as? String != nil else { return nil }
+        return json["email"] as? String ?? oauth?["email"] as? String ?? "Claude Code"
+    }
+
+    private func nativeKeychainIdentity() -> String? {
+        guard let record = KeychainHelper.readExternalCredentialRecord(service: "Claude Code-credentials"),
+              let json = try? JSONSerialization.jsonObject(with: record.data) as? [String: Any],
+              let oauth = json["claudeAiOauth"] as? [String: Any],
+              oauth["accessToken"] as? String != nil else { return nil }
+        return oauth["email"] as? String ?? "Claude Code"
+    }
+
     private func fetchClaudeDesktopQuota(forceRefresh: Bool) async -> (key: String, value: ProviderQuotaData)? {
         let key = "Claude Desktop"
         if !forceRefresh, let cached = quotaCache[key], cached.isValid(ttl: cacheTTL) {
@@ -443,10 +495,17 @@ actor ClaudeCodeQuotaFetcher {
     private func fetchOwnedQuotas(forceRefresh: Bool) async -> [String: ProviderQuotaData] {
         var results: [String: ProviderQuotaData] = [:]
         for account in await MonitorCredentialVault.shared.accounts().filter({ $0.provider == .claude && !$0.isDisabled }) {
-            guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { continue }
+            if let data = await fetchOwnedQuota(account: account, forceRefresh: forceRefresh) {
+                results[account.accountKey] = data
+            }
+        }
+        return results
+    }
+
+    private func fetchOwnedQuota(account: MonitorAccount, forceRefresh: Bool) async -> ProviderQuotaData? {
+            guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { return nil }
             if !forceRefresh, let cached = quotaCache[account.accountKey], cached.isValid(ttl: cacheTTL) {
-                results[account.accountKey] = cached.data
-                continue
+                return cached.data
             }
             do {
                 if credential.expiresAt.map({ $0.timeIntervalSinceNow < 300 }) ?? false,
@@ -462,7 +521,7 @@ actor ClaudeCodeQuotaFetcher {
                     if let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id) {
                         credential = latest
                     }
-                    guard let refreshToken = credential.refreshToken else { continue }
+                    guard let refreshToken = credential.refreshToken else { return nil }
                     let refreshed = try await refreshAccessToken(refreshToken: refreshToken)
                     credential.accessToken = refreshed.accessToken
                     credential.refreshToken = refreshed.refreshToken ?? refreshToken
@@ -472,13 +531,12 @@ actor ClaudeCodeQuotaFetcher {
                 }
                 if case .success(let info) = response, let data = quotaData(from: info) {
                     quotaCache[account.accountKey] = CachedQuota(data: data, timestamp: Date())
-                    results[account.accountKey] = data
+                    return data
                 }
             } catch {
-                if let cached = quotaCache[account.accountKey] { results[account.accountKey] = cached.data }
+                return quotaCache[account.accountKey]?.data
             }
-        }
-        return results
+        return nil
     }
 
     private func quotaData(from info: ClaudeCodeQuotaInfo) -> ProviderQuotaData? {

--- a/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
@@ -368,6 +368,88 @@ actor CodexCLIQuotaFetcher {
         return results
     }
 
+    /// Fetches only the credential represented by the canonical account key.
+    func fetchQuota(forAccountKey accountKey: String) async -> ProviderQuotaData? {
+        if let account = await MonitorCredentialVault.shared.accounts().first(where: {
+            $0.provider == .codex && !$0.isDisabled && $0.accountKey == accountKey
+        }), let quota = await fetchOwnedQuota(account) {
+            return quota
+        }
+
+        if let record = KeychainHelper.readExternalCredentialRecord(service: "Codex Auth"),
+           let auth = try? JSONDecoder().decode(CodexCLIAuthFile.self, from: record.data),
+           let tokens = auth.tokens {
+            let claims = tokens.idToken.flatMap(decodeJWT)
+            let key = canonicalLocalKey(
+                email: claims?.email,
+                accountID: tokens.accountId ?? claims?.accountId,
+                fallback: "Codex"
+            )
+            if key == accountKey, let quota = await fetchNativeKeychainQuotas().values.first {
+                return quota
+            }
+        }
+
+        for source in readAuthSources() {
+            guard let tokens = source.auth.tokens else { continue }
+            let claims = tokens.idToken.flatMap(decodeJWT)
+            let key = canonicalLocalKey(
+                email: claims?.email,
+                accountID: tokens.accountId ?? claims?.accountId,
+                fallback: "Codex User"
+            )
+            guard key == accountKey else { continue }
+            return await fetchLocalAuthQuota(source: source, claims: claims)
+        }
+
+        let directory = NSString(string: "~/.cli-proxy-api").expandingTildeInPath
+        guard let filename = try? FileManager.default.contentsOfDirectory(atPath: directory).first(where: {
+            $0.hasPrefix("codex-") && $0.hasSuffix(".json") && $0.codexFilenameKey == accountKey
+        }) else { return nil }
+        let path = (directory as NSString).appendingPathComponent(filename)
+        return await fetchLegacyQuota(at: path)
+    }
+
+    private func canonicalLocalKey(email: String?, accountID: String?, fallback: String) -> String {
+        guard let accountID, !accountID.isEmpty else { return email ?? fallback }
+        let aliases = readLegacyIdentities().filter { $0.accountID == accountID }.map(\.key)
+        return Set(aliases).count == 1 ? aliases[0] : (email ?? accountID)
+    }
+
+    private func fetchLocalAuthQuota(
+        source: (path: String, auth: CodexCLIAuthFile),
+        claims: CodexJWTClaims?
+    ) async -> ProviderQuotaData? {
+        guard let tokens = source.auth.tokens, var accessToken = tokens.accessToken else { return nil }
+        var refreshToken = tokens.refreshToken
+        if isTokenExpired(accessToken: accessToken), let currentRefreshToken = refreshToken {
+            guard let refreshed = try? await refreshAccessToken(refreshToken: currentRefreshToken) else { return nil }
+            accessToken = refreshed.accessToken
+            try? self.persistRefresh(refreshed, originalRefreshToken: currentRefreshToken, path: source.path)
+            refreshToken = refreshed.refreshToken ?? currentRefreshToken
+        }
+        do {
+            return try await fetchQuota(
+                accessToken: accessToken,
+                accountId: tokens.accountId ?? claims?.accountId,
+                identity: CodexQuotaIdentity(planType: claims?.planType)
+            )
+        } catch CodexCLIQuotaError.httpError(let status) where status == 401 || status == 403 {
+            guard let latest = readAuthFile(at: source.path)?.tokens,
+                  let refresh = latest.refreshToken ?? refreshToken,
+                  let refreshed = try? await refreshAccessToken(refreshToken: refresh) else { return nil }
+            try? persistRefresh(refreshed, originalRefreshToken: refresh, path: source.path)
+            let latestClaims = latest.idToken.flatMap(decodeJWT)
+            return try? await fetchQuota(
+                accessToken: refreshed.accessToken,
+                accountId: latest.accountId ?? latestClaims?.accountId ?? claims?.accountId,
+                identity: CodexQuotaIdentity(planType: latestClaims?.planType ?? claims?.planType)
+            )
+        } catch {
+            return nil
+        }
+    }
+
     func reconcileLegacyAliases(
         in quotas: [String: ProviderQuotaData]
     ) async -> [String: ProviderQuotaData] {
@@ -510,6 +592,41 @@ actor CodexCLIQuotaFetcher {
         return results
     }
 
+    private func fetchLegacyQuota(at path: String) async -> ProviderQuotaData? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let auth = try? JSONDecoder().decode(CodexAuthFile.self, from: data) else { return nil }
+        let claims = auth.idToken.flatMap(decodeJWT)
+        var accessToken = auth.accessToken
+        var refreshToken = auth.refreshToken
+        if isTokenExpired(accessToken: accessToken), let currentRefreshToken = refreshToken {
+            guard let refreshed = try? await refreshAccessToken(refreshToken: currentRefreshToken) else { return nil }
+            accessToken = refreshed.accessToken
+            persistLegacyRefresh(refreshed, originalRefreshToken: currentRefreshToken, path: path)
+            refreshToken = refreshed.refreshToken ?? currentRefreshToken
+        }
+        do {
+            return try await fetchQuota(
+                accessToken: accessToken,
+                accountId: auth.accountId ?? claims?.accountId,
+                identity: CodexQuotaIdentity(planType: claims?.planType)
+            )
+        } catch CodexCLIQuotaError.httpError(let status) where status == 401 || status == 403 {
+            guard let latestData = try? Data(contentsOf: URL(fileURLWithPath: path)),
+                  let latest = try? JSONDecoder().decode(CodexAuthFile.self, from: latestData),
+                  let refresh = latest.refreshToken ?? refreshToken,
+                  let refreshed = try? await refreshAccessToken(refreshToken: refresh) else { return nil }
+            persistLegacyRefresh(refreshed, originalRefreshToken: refresh, path: path)
+            let latestClaims = latest.idToken.flatMap(decodeJWT)
+            return try? await fetchQuota(
+                accessToken: refreshed.accessToken,
+                accountId: latest.accountId ?? latestClaims?.accountId ?? claims?.accountId,
+                identity: CodexQuotaIdentity(planType: latestClaims?.planType ?? claims?.planType)
+            )
+        } catch {
+            return nil
+        }
+    }
+
     private func fetchNativeKeychainQuotas() async -> [String: ProviderQuotaData] {
         guard let record = KeychainHelper.readExternalCredentialRecord(service: "Codex Auth"),
               var auth = try? JSONDecoder().decode(CodexCLIAuthFile.self, from: record.data),
@@ -624,6 +741,48 @@ actor CodexCLIQuotaFetcher {
             }
         }
         return results
+    }
+
+    private func fetchOwnedQuota(_ account: MonitorAccount) async -> ProviderQuotaData? {
+        guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { return nil }
+        do {
+            if credential.expiresAt.map({ $0.timeIntervalSinceNow < 300 }) ?? isTokenExpired(accessToken: credential.accessToken),
+               let refresh = credential.refreshToken {
+                let refreshed = try await refreshAccessToken(refreshToken: refresh)
+                credential.accessToken = refreshed.accessToken
+                credential.refreshToken = refreshed.refreshToken ?? refresh
+                credential.idToken = refreshed.idToken ?? credential.idToken
+                credential.expiresAt = refreshed.expiresIn.map { Date().addingTimeInterval(TimeInterval($0)) }
+                try await MonitorCredentialVault.shared.save(credential, metadata: account)
+            }
+            let claims = credential.idToken.flatMap(decodeJWT)
+            do {
+                return try await fetchQuota(
+                    accessToken: credential.accessToken,
+                    accountId: credential.accountID ?? claims?.accountId,
+                    identity: CodexQuotaIdentity(planType: claims?.planType)
+                )
+            } catch CodexCLIQuotaError.httpError(let status) where status == 401 || status == 403 {
+                if let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id) {
+                    credential = latest
+                }
+                guard let refresh = credential.refreshToken else { return nil }
+                let refreshed = try await refreshAccessToken(refreshToken: refresh)
+                credential.accessToken = refreshed.accessToken
+                credential.refreshToken = refreshed.refreshToken ?? refresh
+                credential.idToken = refreshed.idToken ?? credential.idToken
+                credential.expiresAt = refreshed.expiresIn.map { Date().addingTimeInterval(TimeInterval($0)) }
+                try await MonitorCredentialVault.shared.save(credential, metadata: account)
+                let latestClaims = credential.idToken.flatMap(decodeJWT)
+                return try await fetchQuota(
+                    accessToken: credential.accessToken,
+                    accountId: credential.accountID ?? latestClaims?.accountId,
+                    identity: CodexQuotaIdentity(planType: latestClaims?.planType)
+                )
+            }
+        } catch {
+            return nil
+        }
     }
 
     private func persistRefresh(_ refreshed: TokenRefresh, originalRefreshToken: String, path: String) throws {

--- a/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
@@ -234,6 +234,46 @@ actor CopilotQuotaFetcher {
             return nil
         }
     }
+
+    /// Fetches quota for one canonical account key without querying sibling credentials.
+    func fetchQuota(accountKey: String) async -> ProviderQuotaData? {
+        if let account = await MonitorCredentialVault.shared.accounts().first(where: {
+            $0.provider == .copilot && $0.accountKey == accountKey && !$0.isDisabled
+        }), let credential = await MonitorCredentialVault.shared.credential(for: account.id) {
+            return await fetchQuota(accessToken: credential.accessToken)
+        }
+
+        let authDir = NSString(string: "~/.cli-proxy-api").expandingTildeInPath
+        if let files = try? FileManager.default.contentsOfDirectory(atPath: authDir) {
+            for file in files where file.hasPrefix("github-copilot-") && file.hasSuffix(".json") {
+                let path = (authDir as NSString).appendingPathComponent(file)
+                guard let authFile = loadAuthFile(from: path) else { continue }
+                let key = authFile.username ?? extractUsername(from: file)
+                if key == accountKey {
+                    return await fetchQuota(accessToken: authFile.accessToken)
+                }
+            }
+        }
+
+        // Native credentials do not always store their login. A sole native credential can
+        // safely be resolved without probing any sibling account.
+        let nativeTokens = loadNativeTokens()
+        if nativeTokens.count == 1,
+           let token = nativeTokens.first {
+            let login = await fetchGitHubLogin(accessToken: token)
+            guard accountKey == "GitHub Copilot" || login == accountKey else { return nil }
+            return await fetchQuota(accessToken: token)
+        }
+        return nil
+    }
+
+    private func fetchQuota(accessToken: String) async -> ProviderQuotaData? {
+        do {
+            return convertToQuotaData(entitlement: try await fetchEntitlement(accessToken: accessToken))
+        } catch {
+            return nil
+        }
+    }
     
     func fetchAllCopilotQuotas(
         authDir: String = "~/.cli-proxy-api",

--- a/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
@@ -255,13 +255,19 @@ actor CopilotQuotaFetcher {
             }
         }
 
-        // Native credentials do not always store their login. A sole native credential can
-        // safely be resolved without probing any sibling account.
         let nativeTokens = loadNativeTokens()
-        if nativeTokens.count == 1,
-           let token = nativeTokens.first {
+        for token in nativeTokens {
             let login = await fetchGitHubLogin(accessToken: token)
-            guard accountKey == "GitHub Copilot" || login == accountKey else { return nil }
+            if login == accountKey {
+                return await fetchQuota(accessToken: token)
+            }
+        }
+
+        // Native credentials do not always expose a login. The placeholder identity is only
+        // unambiguous when exactly one native token exists.
+        if accountKey == "GitHub Copilot",
+           nativeTokens.count == 1,
+           let token = nativeTokens.first {
             return await fetchQuota(accessToken: token)
         }
         return nil

--- a/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
@@ -285,6 +285,24 @@ actor FactoryDroidQuotaFetcher {
         return results
     }
 
+    /// Fetches quota using only the local or vaulted credential matching `accountKey`.
+    func fetchQuota(accountKey: String) async -> ProviderQuotaData? {
+        let disabledAccountIDs = await metadata.disabledAccountIDs()
+        if let localCredential = FactoryDroidCredentialReader.load() {
+            let account = Self.localAccount(for: localCredential)
+            if account.accountKey == accountKey && !disabledAccountIDs.contains(account.id) {
+                return await fetch(accessToken: localCredential.accessToken)
+            }
+        }
+
+        guard let account = await vault.accounts().first(where: {
+            $0.provider == .factoryDroid
+                && $0.accountKey == accountKey
+                && !disabledAccountIDs.contains($0.id)
+        }), let credential = await vault.credential(for: account.id) else { return nil }
+        return await fetch(accessToken: credential.accessToken)
+    }
+
     nonisolated static func localAccount(for credential: FactoryDroidCredential) -> MonitorAccount {
         .make(
             provider: .factoryDroid,

--- a/Quotio/Services/QuotaFetchers/GeminiCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/GeminiCLIQuotaFetcher.swift
@@ -262,6 +262,27 @@ actor GeminiCLIQuotaFetcher {
         return results
     }
 
+    /// Fetch quota for exactly one canonical Gemini account.
+    func fetchQuota(accountKey: String, authFiles: [AuthFile] = [], apiClient: ManagementAPIClient? = nil) async -> ProviderQuotaData? {
+        if let apiClient {
+            guard let file = authFiles.first(where: {
+                $0.providerType == .gemini && !$0.disabled && !$0.unavailable && $0.runtimeOnly != true &&
+                ($0.quotaLookupKey.isEmpty ? $0.name : $0.quotaLookupKey) == accountKey
+            }),
+            let authIndex = file.authIndex?.trimmingCharacters(in: .whitespacesAndNewlines), !authIndex.isEmpty,
+            let projectId = resolveProjectId(from: file) else { return nil }
+            return try? await fetchQuota(authIndex: authIndex, projectId: projectId, apiClient: apiClient)
+        }
+
+        if let account = await MonitorCredentialVault.shared.accounts().first(where: {
+            $0.provider == .gemini && !$0.isDisabled && $0.accountKey == accountKey
+        }) {
+            return await fetchOwnedQuota(account: account)
+        }
+        guard getAccountInfo()?.email == accountKey else { return nil }
+        return await fetchNativeQuota()
+    }
+
     /// Fetch Gemini quota directly from the native Gemini CLI credential.
     func fetchAsProviderQuota(includeMonitorCredentials: Bool = false) async -> [String: ProviderQuotaData] {
         var results = includeMonitorCredentials ? await fetchOwnedQuotas() : [:]
@@ -307,7 +328,13 @@ actor GeminiCLIQuotaFetcher {
     private func fetchOwnedQuotas() async -> [String: ProviderQuotaData] {
         var results: [String: ProviderQuotaData] = [:]
         for account in await MonitorCredentialVault.shared.accounts().filter({ $0.provider == .gemini && !$0.isDisabled }) {
-            guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { continue }
+            if let quota = await fetchOwnedQuota(account: account) { results[account.accountKey] = quota }
+        }
+        return results
+    }
+
+    private func fetchOwnedQuota(account: MonitorAccount) async -> ProviderQuotaData? {
+            guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { return nil }
             do {
                 if credential.expiresAt.map({ $0.timeIntervalSinceNow < 300 }) ?? false,
                    let refreshToken = credential.refreshToken {
@@ -319,25 +346,47 @@ actor GeminiCLIQuotaFetcher {
                     try await MonitorCredentialVault.shared.save(credential, metadata: account)
                 }
                 do {
-                    results[account.accountKey] = try await fetchDirectQuota(accessToken: credential.accessToken)
+                    return try await fetchDirectQuota(accessToken: credential.accessToken)
                 } catch DirectGeminiError.authenticationRequired {
                     if let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id) {
                         credential = latest
                     }
-                    guard let refreshToken = credential.refreshToken else { continue }
+                    guard let refreshToken = credential.refreshToken else { return nil }
                     let refreshed = try await refresh(refreshToken: refreshToken)
                     credential.accessToken = refreshed.accessToken
                     credential.refreshToken = refreshed.refreshToken ?? refreshToken
                     credential.idToken = refreshed.idToken ?? credential.idToken
                     credential.expiresAt = refreshed.expiresIn.map { Date().addingTimeInterval(TimeInterval($0)) }
                     try await MonitorCredentialVault.shared.save(credential, metadata: account)
-                    results[account.accountKey] = try await fetchDirectQuota(accessToken: credential.accessToken)
+                    return try await fetchDirectQuota(accessToken: credential.accessToken)
                 }
             } catch {
                 Log.quota("Failed to fetch Gemini quota for Quotio credential")
             }
+        return nil
+    }
+
+    private func fetchNativeQuota() async -> ProviderQuotaData? {
+        guard var auth = readAuthFile(), var accessToken = auth.accessToken else { return nil }
+        let path = NSString(string: authFilePath).expandingTildeInPath
+        if shouldRefresh(auth), let refreshToken = auth.refreshToken,
+           let refreshed = try? await refresh(refreshToken: refreshToken) {
+            accessToken = refreshed.accessToken
+            auth = applying(refreshed, to: auth)
+            try? persist(auth, expectedRefreshToken: refreshToken, path: path)
         }
-        return results
+        do {
+            return try await fetchDirectQuota(accessToken: accessToken)
+        } catch DirectGeminiError.authenticationRequired {
+            let latest = readAuthFile() ?? auth
+            guard let refreshToken = latest.refreshToken,
+                  let refreshed = try? await refresh(refreshToken: refreshToken) else { return nil }
+            let updated = applying(refreshed, to: latest)
+            try? persist(updated, expectedRefreshToken: refreshToken, path: path)
+            return try? await fetchDirectQuota(accessToken: refreshed.accessToken)
+        } catch {
+            return nil
+        }
     }
 
     private struct DirectTokenResponse: Decodable {

--- a/Quotio/Services/QuotaFetchers/GrokQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/GrokQuotaFetcher.swift
@@ -103,6 +103,14 @@ actor GrokQuotaFetcher {
         return results
     }
 
+    /// Fetches the candidate identified by its stable auth-file entry key.
+    func fetchQuota(accountKey: String) async -> ProviderQuotaData? {
+        guard let candidate = Self.loadCandidates().first(where: { $0.entryKey == accountKey }) else {
+            return nil
+        }
+        return await fetchQuota(candidate)
+    }
+
     nonisolated static func quotaResult(
         data: Data,
         statusCode: Int,

--- a/Quotio/Services/QuotaFetchers/KiroQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/KiroQuotaFetcher.swift
@@ -175,12 +175,38 @@ actor KiroQuotaFetcher {
         return results
     }
 
+    /// Fetch quota for exactly one canonical Kiro account.
+    func fetchQuota(accountKey: String) async -> ProviderQuotaData? {
+        if let account = await MonitorCredentialVault.shared.accounts().first(where: {
+            $0.provider == .kiro && !$0.isDisabled && $0.accountKey == accountKey
+        }) {
+            return await fetchOwnedQuota(account: account)
+        }
+
+        let authService = DirectAuthFileService()
+        for authFile in await kiroAuthFiles(using: authService) {
+            guard let tokenData = await authService.readAuthToken(from: authFile) else { continue }
+            let key = authFile.email
+                ?? tokenData.extras?["profileArn"]
+                ?? authFile.filename.replacingOccurrences(of: ".json", with: "")
+            guard key == accountKey else { continue }
+            return await fetchQuota(tokenData: tokenData, filePath: authFile.filePath)
+        }
+        return nil
+    }
+
     private func fetchOwnedQuotas() async -> [String: ProviderQuotaData] {
         var results: [String: ProviderQuotaData] = [:]
         for account in await MonitorCredentialVault.shared.accounts().filter({ $0.provider == .kiro && !$0.isDisabled }) {
-            guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { continue }
+            if let quota = await fetchOwnedQuota(account: account) { results[account.accountKey] = quota }
+        }
+        return results
+    }
+
+    private func fetchOwnedQuota(account: MonitorAccount) async -> ProviderQuotaData? {
+            guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { return nil }
             if credential.expiresAt.map({ $0.timeIntervalSinceNow < 300 }) ?? false {
-                guard await refreshOwnedCredential(&credential, account: account) else { continue }
+                guard await refreshOwnedCredential(&credential, account: account) else { return nil }
             }
             var tokenData = ownedTokenData(credential)
             let region = credential.extra["region"] ?? defaultRegion
@@ -202,9 +228,7 @@ actor KiroQuotaFetcher {
                     tokenData: tokenData
                 )
             }
-            if let quota = response.quotaData { results[account.accountKey] = quota }
-        }
-        return results
+            return response.quotaData
     }
 
     private func reloadAndRefreshOwnedCredential(

--- a/Quotio/Services/QuotaFetchers/OpenRouterQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/OpenRouterQuotaFetcher.swift
@@ -151,6 +151,20 @@ actor OpenRouterQuotaFetcher {
         return results
     }
 
+    /// Fetches only the vaulted credential with the matching canonical account key.
+    func fetchQuota(accountKey: String) async -> ProviderQuotaData? {
+        let disabledAccountIDs = await metadata.disabledAccountIDs()
+        guard let account = await vault.accounts().first(where: {
+            $0.provider == .openRouter
+                && $0.accountKey == accountKey
+                && !disabledAccountIDs.contains($0.id)
+        }), let credential = await vault.credential(for: account.id) else { return nil }
+
+        async let credits = fetch(creditsURL, apiKey: credential.accessToken)
+        async let key = fetch(keyURL, apiKey: credential.accessToken)
+        return OpenRouterQuotaMapper.map(credits: await credits, key: await key)
+    }
+
     private func fetch(_ url: URL, apiKey: String) async -> OpenRouterEndpointResult {
         var request = URLRequest(url: url)
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -78,6 +78,7 @@ final class StatusBarMenuBuilder {
                 } else {
                     for account in accounts {
                         let cardItem = buildAccountCardItem(
+                            accountKey: account.accountKey,
                             email: account.email,
                             data: account.data,
                             provider: provider
@@ -220,9 +221,11 @@ final class StatusBarMenuBuilder {
         return [provider]
     }
 
-    private func accountsForProvider(_ provider: AIProvider) -> [(email: String, data: ProviderQuotaData)] {
+    private func accountsForProvider(
+        _ provider: AIProvider
+    ) -> [(accountKey: String, email: String, data: ProviderQuotaData)] {
         guard let quotas = viewModel.providerQuotas[provider] else { return [] }
-        return quotas.map { ($0.value.accountDisplayName ?? $0.key, $0.value) }
+        return quotas.map { ($0.key, $0.value.accountDisplayName ?? $0.key, $0.value) }
             .sorted { $0.email < $1.email }
     }
 
@@ -263,14 +266,16 @@ final class StatusBarMenuBuilder {
     // MARK: - Account Card Item (with submenu for Antigravity)
 
     private func buildAccountCardItem(
+        accountKey: String,
         email: String,
         data: ProviderQuotaData,
         provider: AIProvider
     ) -> NSMenuItem {
-        let subscriptionInfo = viewModel.subscriptionInfos[provider]?[email]
+        let subscriptionInfo = viewModel.subscriptionInfos[provider]?[accountKey]
         let isActiveInIDE = provider == .antigravity && viewModel.isAntigravityAccountActive(email: email)
 
         let cardView = MenuAccountCardView(
+            accountKey: accountKey,
             email: email,
             data: data,
             provider: provider,
@@ -456,6 +461,7 @@ private struct MenuHeaderView: View {
 // MARK: - Provider Section Header
 
 private struct MenuProviderSectionHeader: View {
+    @Environment(QuotaViewModel.self) private var viewModel
     let provider: AIProvider
 
     var body: some View {
@@ -465,6 +471,26 @@ private struct MenuProviderSectionHeader: View {
                 .font(.system(size: 11, weight: .semibold, design: .rounded))
                 .foregroundStyle(.secondary)
             Spacer()
+
+            Button {
+                Task { await viewModel.refreshQuota(for: provider) }
+            } label: {
+                if viewModel.refreshingProviders.contains(provider) {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .frame(width: 18, height: 18)
+                } else {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 10, weight: .semibold))
+                        .frame(width: 18, height: 18)
+                }
+            }
+            .buttonStyle(.plain)
+            .disabled(
+                viewModel.isRefreshing(provider: provider)
+                    || !viewModel.supportsScopedRefresh(for: provider)
+            )
+            .help("action.refreshQuota".localized())
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 4)
@@ -750,6 +776,8 @@ private struct MenuNetworkInfoView: View {
 // MARK: Account Card View
 
 private struct MenuAccountCardView: View {
+    @Environment(QuotaViewModel.self) private var viewModel
+    let accountKey: String
     let email: String
     let data: ProviderQuotaData
     let provider: AIProvider
@@ -761,6 +789,10 @@ private struct MenuAccountCardView: View {
     @State private var isHovered = false
     @State private var isUseHovered = false
     @State private var isUsingAccount = false
+
+    private var accountID: QuotaAccountID {
+        QuotaAccountID(provider: provider, accountKey: accountKey)
+    }
     
     private var displayEmail: String {
         email.masked(if: settings.hideSensitiveInfo)
@@ -940,6 +972,27 @@ private struct MenuAccountCardView: View {
                 .lineLimit(1)
             
             Spacer()
+
+            Button {
+                Task { await viewModel.refreshQuota(for: accountID) }
+            } label: {
+                if viewModel.isRefreshing(account: accountID) {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .frame(width: 20, height: 20)
+                } else {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 20, height: 20)
+                }
+            }
+            .buttonStyle(.plain)
+            .disabled(
+                viewModel.isRefreshBlocked(for: accountID)
+                    || !viewModel.supportsScopedRefresh(for: provider)
+            )
+            .help("action.refreshQuota".localized())
             
             // Tier Badge
             if let config = tierConfig {
@@ -2504,7 +2557,7 @@ private struct MenuActionsView: View {
                 title: "action.refresh".localized(),
                 isLoading: viewModel.isLoadingQuotas
             ) {
-                Task { await viewModel.refreshQuotasUnified() }
+                Task { await viewModel.manualRefresh() }
             }
             .disabled(viewModel.isLoadingQuotas)
             

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -59,7 +59,38 @@ final class QuotaViewModel {
     var usageStats: UsageStats?
     var apiKeys: [String] = []
     var isLoading = false
-    var isLoadingQuotas = false
+    private(set) var refreshingProviders: Set<AIProvider> = []
+    private(set) var refreshingAccounts: Set<QuotaAccountID> = []
+    @ObservationIgnored private var activeRefreshProviders: Set<AIProvider> = []
+
+    var isLoadingQuotas: Bool {
+        !refreshingProviders.isEmpty || !refreshingAccounts.isEmpty
+    }
+
+    func isRefreshing(provider: AIProvider) -> Bool {
+        refreshingProviders.contains(provider)
+            || refreshingAccounts.contains(where: { $0.provider == provider })
+    }
+
+    func isRefreshing(account: QuotaAccountID) -> Bool {
+        refreshingAccounts.contains(account)
+    }
+
+    func isRefreshBlocked(for account: QuotaAccountID) -> Bool {
+        activeRefreshProviders.contains(account.provider)
+    }
+
+    func supportsScopedRefresh(for provider: AIProvider) -> Bool {
+        if modeManager.isRemoteProxyMode {
+            return provider == .gemini
+        }
+        switch provider {
+        case .qwen, .iflow, .vertex:
+            return false
+        default:
+            return true
+        }
+    }
     var errorMessage: String?
     var oauthState: OAuthState?
 
@@ -78,12 +109,19 @@ final class QuotaViewModel {
     var directAuthFiles: [DirectAuthFile] = []
     var monitorAccounts: [MonitorAccount] = []
     var monitorIssues: [AIProvider: MonitorRefreshIssue] = [:]
+    var monitorAccountIssues: [QuotaAccountID: MonitorRefreshIssue] = [:]
 
     func monitorStatus(for account: MonitorAccount) -> (status: String?, message: String?) {
-        if let issue = monitorIssues[account.provider] {
+        let updated = Self.monitorLastUpdated(for: account, providerQuotas: providerQuotas)
+        let accountID = QuotaAccountID(provider: account.provider, accountKey: account.accountKey)
+        if let issue = monitorAccountIssues[accountID],
+           updated == nil || updated! <= issue.occurredAt {
             return ("outdated", issue.message)
         }
-        let updated = Self.monitorLastUpdated(for: account, providerQuotas: providerQuotas)
+        if let issue = monitorIssues[account.provider],
+           updated == nil || updated! <= issue.occurredAt {
+            return ("outdated", issue.message)
+        }
         guard let updated else { return (nil, nil) }
         let staleAfter = refreshSettings.refreshCadence.intervalSeconds ?? 600
         if Date().timeIntervalSince(updated) > staleAfter {
@@ -202,6 +240,43 @@ final class QuotaViewModel {
     /// Post notification to trigger UI updates (works even when window is closed)
     private func notifyQuotaDataChanged() {
         NotificationCenter.default.post(name: Self.quotaDataDidChangeNotification, object: nil)
+    }
+
+    private func beginScopedRefresh(provider: AIProvider, account: QuotaAccountID? = nil) -> Bool {
+        guard supportsScopedRefresh(for: provider), activeRefreshProviders.insert(provider).inserted else {
+            return false
+        }
+        if let account {
+            refreshingAccounts.insert(account)
+        } else {
+            refreshingProviders.insert(provider)
+        }
+        notifyQuotaDataChanged()
+        return true
+    }
+
+    private func endScopedRefresh(provider: AIProvider, account: QuotaAccountID? = nil) {
+        activeRefreshProviders.remove(provider)
+        if let account {
+            refreshingAccounts.remove(account)
+        } else {
+            refreshingProviders.remove(provider)
+        }
+        notifyQuotaDataChanged()
+    }
+
+    private func beginBatchRefresh(providers: Set<AIProvider>) -> Bool {
+        guard activeRefreshProviders.isDisjoint(with: providers) else { return false }
+        activeRefreshProviders.formUnion(providers)
+        refreshingProviders.formUnion(providers)
+        notifyQuotaDataChanged()
+        return true
+    }
+
+    private func endBatchRefresh(providers: Set<AIProvider>) {
+        activeRefreshProviders.subtract(providers)
+        refreshingProviders.subtract(providers)
+        notifyQuotaDataChanged()
     }
 
     init() {
@@ -494,9 +569,13 @@ final class QuotaViewModel {
     /// Refresh quotas directly without proxy (for Quota-Only Mode)
     /// Note: Cursor and Trae are NOT auto-refreshed - user must use "Scan for IDEs" (issue #29)
     func refreshQuotasDirectly(force: Bool = false) async {
-        guard !isLoadingQuotas else { return }
-        
-        isLoadingQuotas = true
+        let providers: Set<AIProvider> = [
+            .codex, .claude, .gemini, .copilot, .kiro, .glm, .clinePass, .warp,
+            .antigravity, .factoryDroid, .devin, .grok, .openRouter,
+        ]
+        guard beginBatchRefresh(providers: providers) else { return }
+        defer { endBatchRefresh(providers: providers) }
+
         lastQuotaRefreshTime = Date()
         
         let previous = providerQuotas
@@ -593,15 +672,9 @@ final class QuotaViewModel {
             }
             return quotas
         }
-        async let antigravity = coordinator.refresh(
-            provider: .antigravity,
-            force: force,
-            previous: previous[.antigravity] ?? [:],
-            credentialAvailability: credentialAvailability[.antigravity] ?? .unknown
-        ) {
-            let (quotas, _) = await antigravityQuotaFetcher.fetchAllAntigravityData(includeMonitorCredentials: true)
-            return quotas
-        }
+        async let antigravityData = antigravityQuotaFetcher.fetchAllAntigravityData(
+            includeMonitorCredentials: true
+        )
         async let factoryDroid = coordinator.refresh(
             provider: .factoryDroid,
             force: force,
@@ -635,6 +708,16 @@ final class QuotaViewModel {
             await openRouterQuotaFetcher.fetchAllQuotas()
         }
 
+        let fetchedAntigravityData = await antigravityData
+        let antigravity = await coordinator.refresh(
+            provider: .antigravity,
+            force: force,
+            previous: previous[.antigravity] ?? [:],
+            credentialAvailability: credentialAvailability[.antigravity] ?? .unknown
+        ) {
+            fetchedAntigravityData.quotas
+        }
+
         providerQuotas[.codex] = await codexFetcher.reconcileLegacyAliases(in: await codex)
         providerQuotas[.claude] = await claude
         providerQuotas[.gemini] = await gemini
@@ -643,7 +726,10 @@ final class QuotaViewModel {
         providerQuotas[.glm] = await glm
         providerQuotas[.clinePass] = await clinePass
         providerQuotas[.warp] = await warp
-        providerQuotas[.antigravity] = await antigravity
+        providerQuotas[.antigravity] = antigravity
+        subscriptionInfos[.antigravity, default: [:]].merge(fetchedAntigravityData.subscriptions) {
+            _, fresh in fresh
+        }
         providerQuotas[.factoryDroid] = await factoryDroid
         providerQuotas[.devin] = await devin
         providerQuotas[.grok] = await grok
@@ -659,7 +745,6 @@ final class QuotaViewModel {
         pruneMenuBarItems()
         autoSelectMenuBarItems()
 
-        isLoadingQuotas = false
         notifyQuotaDataChanged()
     }
 
@@ -755,7 +840,7 @@ final class QuotaViewModel {
     }
     
     /// Refresh Gemini quota using CLIProxyAPI management data when available.
-    private func refreshGeminiCLIQuotasInternal() async {
+    private func refreshGeminiCLIQuotasInternal(allowLocalFallback: Bool = true) async {
         if modeManager.isMonitorMode {
             let quotas = await geminiCLIFetcher.fetchAsProviderQuota()
             if !quotas.isEmpty { providerQuotas[.gemini] = quotas }
@@ -791,7 +876,7 @@ final class QuotaViewModel {
         }
 
         let quotas: [String: ProviderQuotaData]
-        if managementQuotas.isEmpty {
+        if managementQuotas.isEmpty && allowLocalFallback {
             quotas = await geminiCLIFetcher.fetchAsProviderQuota()
         } else {
             quotas = managementQuotas
@@ -1454,7 +1539,7 @@ final class QuotaViewModel {
         refreshSettings.refreshCadence.intervalSeconds ?? 60
     }
     
-    func refreshData() async {
+    func refreshData(refreshQuotas: Bool = true) async {
         guard let client = apiClient else { return }
         
         do {
@@ -1488,14 +1573,14 @@ final class QuotaViewModel {
             // Prune menu bar items for accounts that no longer exist
             pruneMenuBarItems()
             
-            let shouldRefreshQuotas: Bool
+            let isQuotaRefreshDue: Bool
             if let lastRefresh = lastQuotaRefresh {
-                shouldRefreshQuotas = Date().timeIntervalSince(lastRefresh) >= quotaRefreshInterval
+                isQuotaRefreshDue = Date().timeIntervalSince(lastRefresh) >= quotaRefreshInterval
             } else {
-                shouldRefreshQuotas = true
+                isQuotaRefreshDue = true
             }
             
-            if shouldRefreshQuotas && !isLoadingQuotas {
+            if refreshQuotas && isQuotaRefreshDue && !isLoadingQuotas {
                 Task {
                     await refreshAllQuotas()
                 }
@@ -1510,8 +1595,12 @@ final class QuotaViewModel {
     func manualRefresh() async {
         if modeManager.isMonitorMode {
             await refreshQuotasDirectly(force: true)
+        } else if modeManager.isRemoteProxyMode {
+            await refreshData(refreshQuotas: false)
+            await refreshAllQuotas()
         } else if proxyManager.proxyStatus.running {
-            await refreshData()
+            await refreshData(refreshQuotas: false)
+            await refreshAllQuotas()
         } else {
             await refreshQuotasUnified()
         }
@@ -1523,14 +1612,19 @@ final class QuotaViewModel {
             await refreshQuotasDirectly()
             return
         }
-        guard !isLoadingQuotas else { return }
+        let providers: Set<AIProvider> = modeManager.isRemoteProxyMode
+            ? [.gemini]
+            : [.antigravity, .codex, .copilot, .claude, .glm, .warp, .kiro, .clinePass, .gemini]
+        guard beginBatchRefresh(providers: providers) else { return }
+        defer { endBatchRefresh(providers: providers) }
 
-        isLoadingQuotas = true
         lastQuotaRefresh = Date()
 
         // In remote mode, skip local filesystem fetchers — only show data from the remote proxy
         // (auth files, usage stats, API keys are already fetched by refreshData())
-        async let geminiCLI: () = refreshGeminiCLIQuotasInternal()
+        async let geminiCLI: () = refreshGeminiCLIQuotasInternal(
+            allowLocalFallback: !modeManager.isRemoteProxyMode
+        )
 
         if !modeManager.isRemoteProxyMode {
             // Note: Cursor and Trae removed from auto-refresh (issue #29)
@@ -1553,7 +1647,6 @@ final class QuotaViewModel {
         pruneMenuBarItems()
         autoSelectMenuBarItems()
 
-        isLoadingQuotas = false
         notifyQuotaDataChanged()
     }
 
@@ -1567,10 +1660,14 @@ final class QuotaViewModel {
             await refreshQuotasDirectly()
             return
         }
-        guard !isLoadingQuotas else { return }
         guard !modeManager.isRemoteProxyMode else { return }
 
-        isLoadingQuotas = true
+        let providers: Set<AIProvider> = [
+            .antigravity, .codex, .copilot, .claude, .glm, .warp, .kiro, .gemini, .clinePass,
+        ]
+        guard beginBatchRefresh(providers: providers) else { return }
+        defer { endBatchRefresh(providers: providers) }
+
         lastQuotaRefreshTime = Date()
         lastQuotaRefresh = Date()
 
@@ -1592,7 +1689,6 @@ final class QuotaViewModel {
         pruneMenuBarItems()
         autoSelectMenuBarItems()
 
-        isLoadingQuotas = false
         notifyQuotaDataChanged()
     }
 
@@ -1682,11 +1778,27 @@ final class QuotaViewModel {
         providerQuotas[.copilot] = quotas
     }
     
-    func refreshQuotaForProvider(_ provider: AIProvider) async {
-        if modeManager.isMonitorMode {
-            await refreshQuotasDirectly(force: true)
+    func refreshQuota(for provider: AIProvider) async {
+        guard beginScopedRefresh(provider: provider) else { return }
+        defer { endScopedRefresh(provider: provider) }
+
+        if modeManager.isRemoteProxyMode {
+            guard provider == .gemini, let apiClient else { return }
+            let quotas = await geminiCLIFetcher.fetchAsProviderQuota(authFiles: authFiles, apiClient: apiClient)
+            if !quotas.isEmpty {
+                providerQuotas[.gemini, default: [:]].merge(quotas) { _, fresh in fresh }
+                await finishScopedRefresh(provider: provider)
+            }
             return
         }
+
+        if modeManager.isMonitorMode {
+            await refreshMonitorProvider(provider)
+            await finishScopedRefresh(provider: provider)
+            return
+        }
+
+        let previous = providerQuotas[provider] ?? [:]
         switch provider {
         case .antigravity:
             await refreshAntigravityQuotasInternal()
@@ -1714,13 +1826,242 @@ final class QuotaViewModel {
             await refreshKiroQuotasInternal()
         case .clinePass:
             await refreshClinePassQuotasInternal()
+        case .factoryDroid:
+            providerQuotas[provider] = await factoryDroidFetcher.fetchAllQuotas()
+        case .devin:
+            providerQuotas[provider] = await devinFetcher.fetchAsProviderQuota()
+        case .grok:
+            providerQuotas[provider] = await grokFetcher.fetchAllQuotas()
+        case .openRouter:
+            providerQuotas[provider] = await openRouterFetcher.fetchAllQuotas()
         default:
-            break
+            return
         }
 
-        // Prune menu bar items after refresh to remove deleted accounts
-        pruneMenuBarItems()
+        let fresh = providerQuotas[provider] ?? [:]
+        guard !fresh.isEmpty else {
+            if !previous.isEmpty {
+                providerQuotas[provider] = previous
+            }
+            return
+        }
+        providerQuotas[provider] = previous.merging(fresh) { _, value in value }
+        await finishScopedRefresh(provider: provider)
+    }
 
+    func refreshQuota(for account: QuotaAccountID) async {
+        guard beginScopedRefresh(provider: account.provider, account: account) else { return }
+        defer { endScopedRefresh(provider: account.provider, account: account) }
+
+        let quota: ProviderQuotaData?
+        var subscription: SubscriptionInfo?
+
+        switch account.provider {
+        case .antigravity:
+            let result = await antigravityFetcher.fetchData(forAccountKey: account.accountKey)
+            quota = result.quota
+            subscription = result.subscription
+        case .codex:
+            quota = await codexCLIFetcher.fetchQuota(forAccountKey: account.accountKey)
+        case .copilot:
+            quota = await copilotFetcher.fetchQuota(accountKey: account.accountKey)
+        case .claude:
+            quota = await claudeCodeFetcher.fetchQuota(accountKey: account.accountKey, forceRefresh: true)
+        case .cursor:
+            quota = await cursorFetcher.fetchAsProviderQuota()[account.accountKey]
+        case .gemini:
+            let hasManagementAccount = authFiles.contains {
+                $0.providerType == .gemini && ($0.quotaLookupKey.isEmpty ? $0.name : $0.quotaLookupKey) == account.accountKey
+            }
+            if modeManager.isRemoteProxyMode {
+                guard let apiClient else { return }
+                quota = await geminiCLIFetcher.fetchQuota(
+                    accountKey: account.accountKey,
+                    authFiles: authFiles,
+                    apiClient: apiClient
+                )
+            } else {
+                quota = await geminiCLIFetcher.fetchQuota(
+                    accountKey: account.accountKey,
+                    authFiles: authFiles,
+                    apiClient: hasManagementAccount ? apiClient : nil
+                )
+            }
+        case .trae:
+            quota = await traeFetcher.fetchAsProviderQuota()[account.accountKey]
+        case .glm:
+            guard let customProvider = CustomProviderService.shared.providers.first(where: {
+                $0.type == .glmCompatibility && $0.isEnabled && $0.name == account.accountKey
+            }), let apiKey = customProvider.apiKeys.first?.apiKey else { return }
+            quota = try? await glmFetcher.fetchQuota(apiKey: apiKey, baseURL: customProvider.baseURL)
+        case .warp:
+            guard let entry = WarpService.shared.tokens.first(where: {
+                $0.isEnabled && $0.name == account.accountKey
+            }) else { return }
+            quota = try? await warpFetcher.fetchQuota(apiKey: entry.token)
+        case .kiro:
+            quota = await kiroFetcher.fetchQuota(accountKey: account.accountKey)
+        case .clinePass:
+            guard let customProvider = CustomProviderService.shared.providers.first(where: {
+                $0.type == .clinePass && $0.isEnabled && $0.name == account.accountKey
+            }), let apiKey = customProvider.apiKeys.first?.apiKey else { return }
+            quota = try? await clinePassFetcher.fetchQuota(apiKey: apiKey)
+        case .factoryDroid:
+            quota = await factoryDroidFetcher.fetchQuota(accountKey: account.accountKey)
+        case .devin:
+            quota = await devinFetcher.fetchAsProviderQuota()[account.accountKey]
+        case .grok:
+            quota = await grokFetcher.fetchQuota(accountKey: account.accountKey)
+        case .openRouter:
+            quota = await openRouterFetcher.fetchQuota(accountKey: account.accountKey)
+        case .qwen, .iflow, .vertex:
+            return
+        }
+
+        guard let quota else {
+            if modeManager.isMonitorMode {
+                monitorAccountIssues[account] = MonitorRefreshIssue(
+                    message: "monitor.refresh.failed".localized(),
+                    occurredAt: Date()
+                )
+            }
+            return
+        }
+        providerQuotas[account.provider, default: [:]][account.accountKey] = quota
+        if let subscription {
+            subscriptionInfos[account.provider, default: [:]][account.accountKey] = subscription
+        }
+        monitorAccountIssues.removeValue(forKey: account)
+        await finishScopedRefresh(provider: account.provider)
+    }
+
+    func refreshQuotaForProvider(_ provider: AIProvider) async {
+        await refreshQuota(for: provider)
+    }
+
+    private func refreshMonitorProvider(_ provider: AIProvider) async {
+        let coordinator = monitorCoordinator
+        let previous = providerQuotas[provider] ?? [:]
+        let fresh: [String: ProviderQuotaData]
+        var freshSubscriptions: [String: SubscriptionInfo] = [:]
+
+        switch provider {
+        case .codex:
+            let fetcher = codexCLIFetcher
+            let refreshed = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+                await fetcher.fetchAsProviderQuota()
+            }
+            fresh = await fetcher.reconcileLegacyAliases(in: refreshed)
+        case .claude:
+            let fetcher = claudeCodeFetcher
+            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+                await fetcher.fetchAsProviderQuota(forceRefresh: true, includeMonitorCredentials: true)
+            }
+        case .gemini:
+            let fetcher = geminiCLIFetcher
+            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+                await fetcher.fetchAsProviderQuota(includeMonitorCredentials: true)
+            }
+        case .copilot:
+            let fetcher = copilotFetcher
+            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+                await fetcher.fetchAllCopilotQuotas(includeMonitorCredentials: true)
+            }
+        case .kiro:
+            let fetcher = kiroFetcher
+            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+                await fetcher.fetchAllQuotas(includeMonitorCredentials: true)
+            }
+        case .glm:
+            let fetcher = glmFetcher
+            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+                await fetcher.fetchAllQuotas()
+            }
+        case .clinePass:
+            let fetcher = clinePassFetcher
+            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+                await fetcher.fetchAllQuotas()
+            }
+        case .warp:
+            let fetcher = warpFetcher
+            let tokens = WarpService.shared.tokens.filter(\.isEnabled)
+            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+                var results: [String: ProviderQuotaData] = [:]
+                for entry in tokens {
+                    if let quota = try? await fetcher.fetchQuota(apiKey: entry.token) {
+                        results[entry.name] = quota
+                    }
+                }
+                return results
+            }
+        case .antigravity:
+            let fetcher = antigravityFetcher
+            let fetched = await fetcher.fetchAllAntigravityData(includeMonitorCredentials: true)
+            freshSubscriptions = fetched.subscriptions
+            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+                fetched.quotas
+            }
+        case .factoryDroid:
+            let fetcher = factoryDroidFetcher
+            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+                await fetcher.fetchAllQuotas()
+            }
+        case .devin:
+            let fetcher = devinFetcher
+            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+                await fetcher.fetchAsProviderQuota()
+            }
+        case .grok:
+            let fetcher = grokFetcher
+            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+                await fetcher.fetchAllQuotas()
+            }
+        case .openRouter:
+            let fetcher = openRouterFetcher
+            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+                await fetcher.fetchAllQuotas()
+            }
+        case .cursor:
+            let fetcher = cursorFetcher
+            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+                await fetcher.fetchAsProviderQuota()
+            }
+        case .trae:
+            let fetcher = traeFetcher
+            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+                await fetcher.fetchAsProviderQuota()
+            }
+        case .qwen, .iflow, .vertex:
+            return
+        }
+
+        if fresh.isEmpty {
+            providerQuotas.removeValue(forKey: provider)
+        } else {
+            providerQuotas[provider] = fresh
+        }
+        if provider == .antigravity {
+            subscriptionInfos[provider, default: [:]].merge(freshSubscriptions) { _, fresh in fresh }
+        }
+    }
+
+    private func finishScopedRefresh(provider: AIProvider) async {
+        lastQuotaRefreshTime = Date()
+
+        if modeManager.isMonitorMode {
+            monitorAccounts = await monitorCoordinator.discoverAccounts(merging: providerQuotas)
+            removeDisabledMonitorQuotas()
+            monitorIssues = await monitorCoordinator.currentIssues()
+            await monitorCoordinator.finish(quotas: providerQuotas)
+        }
+
+        if provider == .cursor || provider == .trae {
+            savePersistedIDEQuotas()
+        }
+
+        checkQuotaNotifications()
+        pruneMenuBarItems()
+        autoSelectMenuBarItems()
         notifyQuotaDataChanged()
     }
 

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -1942,50 +1942,70 @@ final class QuotaViewModel {
     private func refreshMonitorProvider(_ provider: AIProvider) async {
         let coordinator = monitorCoordinator
         let previous = providerQuotas[provider] ?? [:]
+        let credentialProviders: Set<AIProvider> = [
+            .codex, .claude, .gemini, .copilot, .kiro, .antigravity,
+            .factoryDroid, .devin, .grok, .openRouter,
+        ]
+        let discoveredProviders = Set(await coordinator.discoverAccounts().map(\.provider))
+        let credentialAvailability: MonitorCredentialAvailability = credentialProviders.contains(provider)
+            ? (discoveredProviders.contains(provider) ? .present : .missing)
+            : .unknown
         let fresh: [String: ProviderQuotaData]
         var freshSubscriptions: [String: SubscriptionInfo] = [:]
+
+        func coordinatedRefresh(
+            _ operation: @escaping @Sendable () async -> [String: ProviderQuotaData]
+        ) async -> [String: ProviderQuotaData] {
+            await coordinator.refresh(
+                provider: provider,
+                force: true,
+                previous: previous,
+                credentialAvailability: credentialAvailability,
+                operation: operation
+            )
+        }
 
         switch provider {
         case .codex:
             let fetcher = codexCLIFetcher
-            let refreshed = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+            let refreshed = await coordinatedRefresh {
                 await fetcher.fetchAsProviderQuota()
             }
             fresh = await fetcher.reconcileLegacyAliases(in: refreshed)
         case .claude:
             let fetcher = claudeCodeFetcher
-            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+            fresh = await coordinatedRefresh {
                 await fetcher.fetchAsProviderQuota(forceRefresh: true, includeMonitorCredentials: true)
             }
         case .gemini:
             let fetcher = geminiCLIFetcher
-            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+            fresh = await coordinatedRefresh {
                 await fetcher.fetchAsProviderQuota(includeMonitorCredentials: true)
             }
         case .copilot:
             let fetcher = copilotFetcher
-            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+            fresh = await coordinatedRefresh {
                 await fetcher.fetchAllCopilotQuotas(includeMonitorCredentials: true)
             }
         case .kiro:
             let fetcher = kiroFetcher
-            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+            fresh = await coordinatedRefresh {
                 await fetcher.fetchAllQuotas(includeMonitorCredentials: true)
             }
         case .glm:
             let fetcher = glmFetcher
-            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+            fresh = await coordinatedRefresh {
                 await fetcher.fetchAllQuotas()
             }
         case .clinePass:
             let fetcher = clinePassFetcher
-            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+            fresh = await coordinatedRefresh {
                 await fetcher.fetchAllQuotas()
             }
         case .warp:
             let fetcher = warpFetcher
             let tokens = WarpService.shared.tokens.filter(\.isEnabled)
-            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+            fresh = await coordinatedRefresh {
                 var results: [String: ProviderQuotaData] = [:]
                 for entry in tokens {
                     if let quota = try? await fetcher.fetchQuota(apiKey: entry.token) {
@@ -1998,37 +2018,37 @@ final class QuotaViewModel {
             let fetcher = antigravityFetcher
             let fetched = await fetcher.fetchAllAntigravityData(includeMonitorCredentials: true)
             freshSubscriptions = fetched.subscriptions
-            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+            fresh = await coordinatedRefresh {
                 fetched.quotas
             }
         case .factoryDroid:
             let fetcher = factoryDroidFetcher
-            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+            fresh = await coordinatedRefresh {
                 await fetcher.fetchAllQuotas()
             }
         case .devin:
             let fetcher = devinFetcher
-            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+            fresh = await coordinatedRefresh {
                 await fetcher.fetchAsProviderQuota()
             }
         case .grok:
             let fetcher = grokFetcher
-            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+            fresh = await coordinatedRefresh {
                 await fetcher.fetchAllQuotas()
             }
         case .openRouter:
             let fetcher = openRouterFetcher
-            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+            fresh = await coordinatedRefresh {
                 await fetcher.fetchAllQuotas()
             }
         case .cursor:
             let fetcher = cursorFetcher
-            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+            fresh = await coordinatedRefresh {
                 await fetcher.fetchAsProviderQuota()
             }
         case .trae:
             let fetcher = traeFetcher
-            fresh = await coordinator.refresh(provider: provider, force: true, previous: previous) {
+            fresh = await coordinatedRefresh {
                 await fetcher.fetchAsProviderQuota()
             }
         case .qwen, .iflow, .vertex:
@@ -2379,7 +2399,7 @@ final class QuotaViewModel {
 
     /// Remove menu bar items that no longer have valid quota data
     private func pruneMenuBarItems() {
-        migrateCodexMenuBarSelections()
+        migrateMenuBarSelections()
 
         var validItems: [MenuBarQuotaItem] = []
         var seen = Set<String>()
@@ -2417,37 +2437,60 @@ final class QuotaViewModel {
         menuBarSettings.pruneInvalidItems(validItems: validItems)
     }
 
-    private func migrateCodexMenuBarSelections() {
-        var canonicalKeys = Set<String>()
-        var canonicalKeysByAlias: [String: Set<String>] = [:]
+    private func migrateMenuBarSelections() {
+        var canonicalKeys: [AIProvider: Set<String>] = [:]
+        var canonicalKeysByAlias: [AIProvider: [String: Set<String>]] = [:]
 
-        func addAliases(filename: String, email: String?) {
-            let canonicalKey = filename.codexFilenameKey
+        func addAliases(provider: AIProvider, canonicalKey: String, aliases: [String?]) {
             guard !canonicalKey.isEmpty else { return }
 
-            canonicalKeys.insert(canonicalKey)
+            canonicalKeys[provider, default: []].insert(canonicalKey)
 
-            let filenameWithoutExtension = filename.hasSuffix(".json")
-                ? String(filename.dropLast(".json".count))
-                : filename
-            var aliases = [filename, filenameWithoutExtension]
-            if let email, !email.isEmpty {
-                aliases.append(email)
-            }
-
-            for alias in aliases where alias != canonicalKey {
-                canonicalKeysByAlias[alias, default: []].insert(canonicalKey)
+            for alias in aliases.compactMap({ value -> String? in
+                guard let alias = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !alias.isEmpty else { return nil }
+                return alias
+            }) where alias != canonicalKey {
+                canonicalKeysByAlias[provider, default: [:]][alias, default: []].insert(canonicalKey)
             }
         }
 
         if !modeManager.isRemoteProxyMode {
             for file in directAuthFiles where file.provider == .codex {
-                addAliases(filename: file.filename, email: file.email)
+                let filenameWithoutExtension = file.filename.hasSuffix(".json")
+                    ? String(file.filename.dropLast(".json".count))
+                    : file.filename
+                addAliases(
+                    provider: .codex,
+                    canonicalKey: file.filename.codexFilenameKey,
+                    aliases: [file.filename, filenameWithoutExtension, file.email]
+                )
+            }
+            for file in directAuthFiles where file.provider == .copilot {
+                addAliases(
+                    provider: .copilot,
+                    canonicalKey: file.menuBarAccountKey,
+                    aliases: [file.email]
+                )
             }
         }
 
         for file in authFiles where file.providerType == .codex {
-            addAliases(filename: file.name, email: file.email)
+            let filenameWithoutExtension = file.name.hasSuffix(".json")
+                ? String(file.name.dropLast(".json".count))
+                : file.name
+            addAliases(
+                provider: .codex,
+                canonicalKey: file.name.codexFilenameKey,
+                aliases: [file.name, filenameWithoutExtension, file.email]
+            )
+        }
+        for file in authFiles where file.providerType == .copilot {
+            addAliases(
+                provider: .copilot,
+                canonicalKey: file.menuBarAccountKey,
+                aliases: [file.email]
+            )
         }
 
         var migratedItems: [MenuBarQuotaItem] = []
@@ -2456,13 +2499,13 @@ final class QuotaViewModel {
         for item in menuBarSettings.selectedItems {
             var migratedItem = item
 
-            if item.aiProvider == .codex,
-               !canonicalKeys.contains(item.accountKey),
-               let candidates = canonicalKeysByAlias[item.accountKey],
+            if let provider = item.aiProvider,
+               !canonicalKeys[provider, default: []].contains(item.accountKey),
+               let candidates = canonicalKeysByAlias[provider]?[item.accountKey],
                candidates.count == 1,
                let canonicalKey = candidates.first {
                 migratedItem = MenuBarQuotaItem(
-                    provider: AIProvider.codex.rawValue,
+                    provider: provider.rawValue,
                     accountKey: canonicalKey
                 )
             }

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -73,7 +73,7 @@ final class QuotaViewModel {
     }
 
     func isRefreshing(account: QuotaAccountID) -> Bool {
-        refreshingAccounts.contains(account)
+        refreshingAccounts.contains(account) || refreshingProviders.contains(account.provider)
     }
 
     func isRefreshBlocked(for account: QuotaAccountID) -> Bool {
@@ -1604,7 +1604,6 @@ final class QuotaViewModel {
         } else {
             await refreshQuotasUnified()
         }
-        lastQuotaRefreshTime = Date()
     }
     
     func refreshAllQuotas() async {
@@ -1619,6 +1618,7 @@ final class QuotaViewModel {
         defer { endBatchRefresh(providers: providers) }
 
         lastQuotaRefresh = Date()
+        lastQuotaRefreshTime = Date()
 
         // In remote mode, skip local filesystem fetchers — only show data from the remote proxy
         // (auth files, usage stats, API keys are already fetched by refreshData())
@@ -1798,7 +1798,6 @@ final class QuotaViewModel {
             return
         }
 
-        let previous = providerQuotas[provider] ?? [:]
         switch provider {
         case .antigravity:
             await refreshAntigravityQuotasInternal()
@@ -1838,14 +1837,6 @@ final class QuotaViewModel {
             return
         }
 
-        let fresh = providerQuotas[provider] ?? [:]
-        guard !fresh.isEmpty else {
-            if !previous.isEmpty {
-                providerQuotas[provider] = previous
-            }
-            return
-        }
-        providerQuotas[provider] = previous.merging(fresh) { _, value in value }
         await finishScopedRefresh(provider: provider)
     }
 

--- a/Quotio/Views/Screens/DashboardScreen.swift
+++ b/Quotio/Views/Screens/DashboardScreen.swift
@@ -394,7 +394,7 @@ struct DashboardScreen: View {
                         .foregroundStyle(.secondary)
                     
                     Button {
-                        Task { await viewModel.refreshQuotasDirectly() }
+                        Task { await viewModel.manualRefresh() }
                     } label: {
                         Label("action.refresh".localized(), systemImage: "arrow.clockwise")
                     }

--- a/Quotio/Views/Screens/QuotaScreen.swift
+++ b/Quotio/Views/Screens/QuotaScreen.swift
@@ -126,19 +126,41 @@ struct QuotaScreen: View {
                 }
                 
                 ToolbarItem(placement: .primaryAction) {
-                Button {
-                    Task {
-                        if modeManager.isMonitorMode {
-                            await viewModel.manualRefresh()
+                    Menu {
+                        if let provider = selectedProvider ?? availableProviders.first {
+                            Button {
+                                Task { await viewModel.refreshQuota(for: provider) }
+                            } label: {
+                                Label(
+                                    provider.displayName + " — " + "action.refreshQuota".localized(),
+                                    systemImage: "arrow.clockwise"
+                                )
+                            }
+                            .disabled(
+                                viewModel.isRefreshing(provider: provider)
+                                    || !viewModel.supportsScopedRefresh(for: provider)
+                            )
+
+                            Divider()
+                        }
+
+                        Button {
+                            Task { await viewModel.manualRefresh() }
+                        } label: {
+                            Label("action.refresh".localized(), systemImage: "arrow.triangle.2.circlepath")
+                        }
+                        .disabled(viewModel.isLoadingQuotas)
+                    } label: {
+                        if let provider = selectedProvider ?? availableProviders.first,
+                           viewModel.isRefreshing(provider: provider) {
+                            ProgressView()
+                                .controlSize(.small)
                         } else {
-                            await viewModel.refreshQuotasUnified()
+                            Image(systemName: "arrow.clockwise")
                         }
                     }
-                } label: {
-                    Image(systemName: "arrow.clockwise")
+                    .help("action.refreshQuota".localized())
                 }
-                .disabled(viewModel.isLoadingQuotas)
-            }
         }
         .onAppear {
             if selectedProvider == nil, let first = availableProviders.first {
@@ -172,7 +194,7 @@ struct QuotaScreen: View {
                         authFiles: viewModel.authFiles.filter { $0.providerType == provider },
                         quotaData: viewModel.providerQuotas[provider] ?? [:],
                         subscriptionInfos: viewModel.subscriptionInfos[provider] ?? [:],
-                        isLoading: viewModel.isLoadingQuotas
+                        isLoading: viewModel.refreshingProviders.contains(provider)
                     )
                     .padding(.horizontal, 24)
                     .padding(.vertical, 16)
@@ -448,9 +470,16 @@ private struct AccountQuotaCardV2: View {
     let account: AccountInfo
     let isLoading: Bool
     
-    @State private var isRefreshing = false
     @State private var showSwitchSheet = false
     @State private var showModelsDetailSheet = false
+
+    private var accountID: QuotaAccountID {
+        QuotaAccountID(provider: provider, accountKey: account.key)
+    }
+
+    private var isRefreshing: Bool {
+        viewModel.isRefreshing(account: accountID)
+    }
 
     /// Check if OAuth is in progress for this provider
     private var isReauthenticating: Bool {
@@ -660,9 +689,7 @@ private struct AccountQuotaCardV2: View {
                 
                 Button {
                     Task {
-                        isRefreshing = true
-                        await viewModel.refreshQuotaForProvider(provider)
-                        isRefreshing = false
+                        await viewModel.refreshQuota(for: accountID)
                     }
                 } label: {
                     if isRefreshing || isLoading {
@@ -674,7 +701,7 @@ private struct AccountQuotaCardV2: View {
                         HStack(spacing: 4) {
                             Image(systemName: "arrow.clockwise")
                                 .font(.caption)
-                            Text("Refresh")
+                            Text("action.refresh".localized())
                                 .font(.caption)
                                 .fontWeight(.medium)
                         }
@@ -686,7 +713,11 @@ private struct AccountQuotaCardV2: View {
                     }
                 }
                 .buttonStyle(.plain)
-                .disabled(isRefreshing || isLoading)
+                .disabled(
+                    viewModel.isRefreshBlocked(for: accountID)
+                        || !viewModel.supportsScopedRefresh(for: provider)
+                )
+                .help("action.refreshQuota".localized())
                 
                 if let data = account.quotaData, data.isForbidden {
                     if provider == .claude {

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -168,6 +168,44 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertEqual(Set(accounts.map(\.deduplicationKey)).count, 2)
     }
 
+    func testCopilotCanonicalKeyPrefersLoginOverEmail() {
+        let direct = DirectAuthFile(
+            id: "copilot",
+            provider: .copilot,
+            email: "person@example.com",
+            login: "octocat",
+            expired: nil,
+            accountType: nil,
+            filePath: "/tmp/github-copilot-octocat.json",
+            source: .cliProxyApi,
+            filename: "github-copilot-octocat.json"
+        )
+        let proxy = AuthFile(
+            id: "copilot",
+            name: "github-copilot-octocat.json",
+            provider: "github-copilot",
+            label: nil,
+            status: "ready",
+            statusMessage: nil,
+            disabled: false,
+            unavailable: false,
+            runtimeOnly: false,
+            source: nil,
+            path: nil,
+            email: "person@example.com",
+            accountType: nil,
+            account: "octocat",
+            authIndex: nil,
+            createdAt: nil,
+            updatedAt: nil,
+            lastRefresh: nil
+        )
+
+        XCTAssertEqual(direct.menuBarAccountKey, "octocat")
+        XCTAssertEqual(MonitorAccount.makeLegacy(direct).accountKey, "octocat")
+        XCTAssertEqual(proxy.quotaLookupKey, "octocat")
+    }
+
     private actor Counter {
         var value = 0
         func increment() { value += 1 }


### PR DESCRIPTION
## Summary

- add true account-scoped and provider-scoped quota/usage refresh APIs
- expose scoped refresh actions and loading indicators in the Quota screen and menu bar dropdown
- keep Refresh All while serializing conflicting work per provider
- preserve canonical account identity and last-good sibling quota data during partial or failed refreshes
- keep Monitor snapshots/issues and Antigravity subscriptions consistent
- prevent Remote mode from falling back to local credentials

## Provider support

Adds targeted account fetching for Codex, Claude, Gemini, Copilot, Kiro, Antigravity, Factory Droid, Grok, and OpenRouter, while reusing existing single-account paths for compatible providers. Single-credential providers remain provider-equivalent at account scope.

## Validation

- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build`
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug -only-testing:QuotioTests/MonitorRuntimeTests test` — 50 tests passed
- `git diff --check`

## Manual verification still recommended

- Quota screen and menu bar interactions in light and dark mode
- one multi-account provider in Monitor and local proxy modes
- Remote Gemini management refresh with a live server
