### PR TITLE
fix(codex): refresh matching legacy quota aliases

### DIFF
--- a/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
@@ -516,10 +516,14 @@ actor CodexCLIQuotaFetcher {
             }
             for currentIdentity in matchingCurrent {
                 guard let freshQuota = reconciled[currentIdentity.key],
+                      matchingCurrent.filter({ $0.key == currentIdentity.key }).count == 1,
                       let currentAccountID = currentIdentity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
                       !currentAccountID.isEmpty else { continue }
                 for legacyAccount in legacyAccounts where
                     legacyAccount.accountID?.trimmingCharacters(in: .whitespacesAndNewlines) == currentAccountID {
+                    guard reconciled[legacyAccount.key].map({ $0.lastUpdated <= freshQuota.lastUpdated }) ?? true else {
+                        continue
+                    }
                     reconciled[legacyAccount.key] = freshQuota
                 }
             }

--- a/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
@@ -514,6 +514,15 @@ actor CodexCLIQuotaFetcher {
             let matchingCurrent = current.filter {
                 $0.email?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == email
             }
+            for currentIdentity in matchingCurrent {
+                guard let freshQuota = reconciled[currentIdentity.key],
+                      let currentAccountID = currentIdentity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !currentAccountID.isEmpty else { continue }
+                for legacyAccount in legacyAccounts where
+                    legacyAccount.accountID?.trimmingCharacters(in: .whitespacesAndNewlines) == currentAccountID {
+                    reconciled[legacyAccount.key] = freshQuota
+                }
+            }
             let hasDistinctCurrentAccount = matchingCurrent.contains { identity in
                 guard let accountID = identity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
                       !accountID.isEmpty, !legacyAccountIDs.isEmpty else { return true }

--- a/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
@@ -516,9 +516,11 @@ actor CodexCLIQuotaFetcher {
             }
             for currentIdentity in matchingCurrent {
                 guard let freshQuota = reconciled[currentIdentity.key],
-                      matchingCurrent.filter({ $0.key == currentIdentity.key }).count == 1,
                       let currentAccountID = currentIdentity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
-                      !currentAccountID.isEmpty else { continue }
+                      !currentAccountID.isEmpty,
+                      matchingCurrent.filter({ $0.key == currentIdentity.key }).allSatisfy({
+                          $0.accountID?.trimmingCharacters(in: .whitespacesAndNewlines) == currentAccountID
+                      }) else { continue }
                 for legacyAccount in legacyAccounts where
                     legacyAccount.accountID?.trimmingCharacters(in: .whitespacesAndNewlines) == currentAccountID {
                     guard reconciled[legacyAccount.key].map({ $0.lastUpdated <= freshQuota.lastUpdated }) ?? true else {

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -167,6 +167,74 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertEqual(reconciled["same@example.com-pro"]?.lastUpdated, freshDate)
     }
 
+    func testCodexQuotaReconciliationPreservesNewerLegacyQuota() {
+        let staleDate = Date(timeIntervalSince1970: 1_000)
+        let freshDate = Date(timeIntervalSince1970: 2_000)
+        let reconciled = CodexCLIQuotaFetcher.reconcileLegacyAliases(
+            in: [
+                "same@example.com": ProviderQuotaData(models: [], lastUpdated: staleDate),
+                "same@example.com-pro": ProviderQuotaData(models: [], lastUpdated: freshDate),
+            ],
+            legacy: [
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com-pro",
+                    email: "same@example.com",
+                    accountID: "account-1"
+                ),
+            ],
+            current: [
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com",
+                    email: "same@example.com",
+                    accountID: "account-1"
+                ),
+            ]
+        )
+
+        XCTAssertEqual(reconciled["same@example.com-pro"]?.lastUpdated, freshDate)
+    }
+
+    func testCodexQuotaReconciliationDoesNotShareAmbiguousEmailQuota() {
+        let firstDate = Date(timeIntervalSince1970: 1_000)
+        let secondDate = Date(timeIntervalSince1970: 1_500)
+        let emailDate = Date(timeIntervalSince1970: 2_000)
+        let reconciled = CodexCLIQuotaFetcher.reconcileLegacyAliases(
+            in: [
+                "same@example.com": ProviderQuotaData(models: [], lastUpdated: emailDate),
+                "same@example.com-pro": ProviderQuotaData(models: [], lastUpdated: firstDate),
+                "same@example.com-team": ProviderQuotaData(models: [], lastUpdated: secondDate),
+            ],
+            legacy: [
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com-pro",
+                    email: "same@example.com",
+                    accountID: "account-1"
+                ),
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com-team",
+                    email: "same@example.com",
+                    accountID: "account-2"
+                ),
+            ],
+            current: [
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com",
+                    email: "same@example.com",
+                    accountID: "account-1"
+                ),
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com",
+                    email: "same@example.com",
+                    accountID: "account-2"
+                ),
+            ]
+        )
+
+        XCTAssertEqual(Set(reconciled.keys), ["same@example.com-pro", "same@example.com-team"])
+        XCTAssertEqual(reconciled["same@example.com-pro"]?.lastUpdated, firstDate)
+        XCTAssertEqual(reconciled["same@example.com-team"]?.lastUpdated, secondDate)
+    }
+
     func testLegacyCodexAccountsUseDistinctFilenameKeysForSameEmail() {
         let plus = DirectAuthFile(
             id: "plus",

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -235,6 +235,33 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertEqual(reconciled["same@example.com-team"]?.lastUpdated, secondDate)
     }
 
+    func testCodexQuotaReconciliationAllowsDuplicateSourcesForSameAccount() {
+        let staleDate = Date(timeIntervalSince1970: 1_000)
+        let freshDate = Date(timeIntervalSince1970: 2_000)
+        let duplicateIdentity = CodexQuotaAccountIdentity(
+            key: "same@example.com",
+            email: "same@example.com",
+            accountID: "account-1"
+        )
+        let reconciled = CodexCLIQuotaFetcher.reconcileLegacyAliases(
+            in: [
+                "same@example.com": ProviderQuotaData(models: [], lastUpdated: freshDate),
+                "same@example.com-pro": ProviderQuotaData(models: [], lastUpdated: staleDate),
+            ],
+            legacy: [
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com-pro",
+                    email: "same@example.com",
+                    accountID: "account-1"
+                ),
+            ],
+            current: [duplicateIdentity, duplicateIdentity]
+        )
+
+        XCTAssertEqual(Set(reconciled.keys), ["same@example.com-pro"])
+        XCTAssertEqual(reconciled["same@example.com-pro"]?.lastUpdated, freshDate)
+    }
+
     func testLegacyCodexAccountsUseDistinctFilenameKeysForSameEmail() {
         let plus = DirectAuthFile(
             id: "plus",

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -137,6 +137,36 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertEqual(Set(stale.keys), Set(["same@example.com-pro", "same@example.com-team"]))
     }
 
+    func testCodexQuotaReconciliationPromotesFreshQuotaToMatchingLegacyAlias() {
+        let staleDate = Date(timeIntervalSince1970: 1_000)
+        let freshDate = Date(timeIntervalSince1970: 2_000)
+        let quotas = [
+            "same@example.com": ProviderQuotaData(models: [], lastUpdated: freshDate),
+            "same@example.com-pro": ProviderQuotaData(models: [], lastUpdated: staleDate),
+        ]
+
+        let reconciled = CodexCLIQuotaFetcher.reconcileLegacyAliases(
+            in: quotas,
+            legacy: [
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com-pro",
+                    email: "same@example.com",
+                    accountID: "account-1"
+                ),
+            ],
+            current: [
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com",
+                    email: "same@example.com",
+                    accountID: "account-1"
+                ),
+            ]
+        )
+
+        XCTAssertEqual(Set(reconciled.keys), ["same@example.com-pro"])
+        XCTAssertEqual(reconciled["same@example.com-pro"]?.lastUpdated, freshDate)
+    }
+
     func testLegacyCodexAccountsUseDistinctFilenameKeysForSameEmail() {
         let plus = DirectAuthFile(
             id: "plus",


### PR DESCRIPTION
## Summary

- promote fresh Codex quota data from the current credential key to its matching legacy CLIProxyAPI alias
- match aliases by Codex account ID before removing the duplicate email key
- add regression coverage for stale legacy timestamps during provider-wide auto-refresh

## Root cause

Provider-wide refresh fetched fresh quota data under the current Codex email key, while the menu card used a legacy key such as `email-pro`. Alias reconciliation removed the duplicate email entry without copying its fresh quota to the matching legacy alias, so auto-refresh preserved the alias's stale timestamp. Account-scoped refresh already canonicalized directly to the legacy key, which is why clicking refresh on the card worked.

## Validation

- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug test -only-testing:QuotioTests/MonitorRuntimeTests/testCodexQuotaReconciliationRemovesOnlyLegacyAliases -only-testing:QuotioTests/MonitorRuntimeTests/testCodexQuotaReconciliationPromotesFreshQuotaToMatchingLegacyAlias`
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build`
- `git diff --check`
