### PR TITLE
fix(opencode): wire MiniMax multimodal input capability

### DIFF
--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -1300,6 +1300,11 @@ actor AgentConfigurationService {
             modelConfig["limit"] = ["context": 128000, "output": 16384]
             modelConfig["attachment"] = true
             modelConfig["modalities"] = ["input": ["text", "image"], "output": ["text"]]
+        } else if modelName.lowercased().contains("minimax") {
+            // MiniMax multimodal models: 1M context with text, image, and video input
+            modelConfig["limit"] = ["context": 1000000, "output": 16384]
+            modelConfig["attachment"] = true
+            modelConfig["modalities"] = ["input": ["text", "image", "video"], "output": ["text"]]
         } else {
             // Default: text-only models
             modelConfig["limit"] = ["context": 128000, "output": 16384]


### PR DESCRIPTION
Reason: MiniMax models fell through to the default text-only 128k OpenCode config instead of their 1M context with text/image/video input.

## Changes

- Added a MiniMax branch to `buildOpenCodeModelConfig()` in `Quotio/Services/AgentConfigurationService.swift`.
- MiniMax models now generate an OpenCode model config with:
  - `limit.context` = 1,000,000 (1M token context window)
  - `attachment` = `true`
  - `modalities.input` = `["text", "image", "video"]`
  - `modalities.output` = `["text"]`

This follows the existing input-capability pipeline established for Claude, Gemini, GPT, and Qwen VL models (PR #273), so OpenCode's provider resolution surfaces the full multimodal input capability for MiniMax models instead of falling back to the text-only default.

## Notes

- Detection is case-insensitive (`modelName.lowercased().contains("minimax")`) so it covers mixed-case model ids such as `MiniMax-M3` as well as lowercase variants.
- Context window and input modalities are taken from the target MiniMax model configuration; no other model families are touched.
- No build or test commands were run because this repository is a macOS Xcode project (`Quotio.xcodeproj`) and no Swift/Xcode toolchain is available on this Linux worker.
