### PR TITLE
fix: purge stale/hidden quota tiles from Quota screen

### DIFF
--- a/Quotio/Services/Monitor/MonitorRuntime.swift
+++ b/Quotio/Services/Monitor/MonitorRuntime.swift
@@ -562,6 +562,20 @@ actor MonitorRefreshCoordinator {
     private var retryAfter: [AIProvider: Date] = [:]
     private(set) var issues: [AIProvider: MonitorRefreshIssue] = [:]
 
+    /// Generic account keys that represent the same underlying login as a more
+    /// specific, higher-priority credential for the same provider (e.g. a
+    /// nameless "Claude Code" native credential once "Claude Desktop" is also
+    /// discovered). `discoverAccounts` hides these from the account list to
+    /// avoid duplicate rows; `QuotaViewModel` uses the same table to keep quota
+    /// data for hidden placeholders from lingering on the Quota screen.
+    static let placeholderAccountKeys: [AIProvider: Set<String>] = [
+        .copilot: ["github copilot"],
+        .antigravity: ["antigravity"],
+        .claude: ["claude code"],
+        .codex: ["codex", "codex user"],
+        .kiro: ["kiro"],
+    ]
+
     init(
         discovery: MonitorAccountDiscovery = MonitorAccountDiscovery(),
         snapshots: MonitorSnapshotStore = MonitorSnapshotStore()
@@ -605,13 +619,7 @@ actor MonitorRefreshCoordinator {
                 accounts.append(account)
             }
         }
-        let placeholders: [AIProvider: Set<String>] = [
-            .copilot: ["github copilot"],
-            .antigravity: ["antigravity"],
-            .claude: ["claude code"],
-            .codex: ["codex", "codex user"],
-            .kiro: ["kiro"],
-        ]
+        let placeholders = Self.placeholderAccountKeys
         accounts = accounts.filter { account in
             guard placeholders[account.provider]?.contains(account.accountKey.lowercased()) == true else { return true }
             return !accounts.contains {

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -476,6 +476,10 @@ final class QuotaViewModel {
 
     func setMonitorAccountDisabled(_ disabled: Bool, accountID: String) async {
         await monitorCoordinator.setDisabled(disabled, accountID: accountID)
+        if disabled, let account = monitorAccounts.first(where: { $0.id == accountID }) {
+            providerQuotas[account.provider]?.removeValue(forKey: account.accountKey)
+            await monitorCoordinator.finish(quotas: providerQuotas)
+        }
         monitorAccounts = await monitorCoordinator.discoverAccounts(merging: providerQuotas)
         syncMenuBarSelection()
     }
@@ -803,6 +807,22 @@ final class QuotaViewModel {
     private func removeDisabledMonitorQuotas() {
         for account in monitorAccounts where account.isDisabled {
             providerQuotas[account.provider]?.removeValue(forKey: account.accountKey)
+        }
+        removeHiddenPlaceholderQuotas()
+    }
+
+    /// `MonitorRefreshCoordinator.discoverAccounts` hides generic placeholder
+    /// accounts (e.g. "Claude Code") once a more specific credential exists for
+    /// the same provider, but the underlying quota fetch still runs for them.
+    /// Without this, their tiles keep showing on the Quota screen even though
+    /// there's no corresponding account row to disable.
+    private func removeHiddenPlaceholderQuotas() {
+        for (provider, placeholderKeys) in MonitorRefreshCoordinator.placeholderAccountKeys {
+            guard providerQuotas[provider] != nil else { continue }
+            let visibleKeys = Set(monitorAccounts.filter { $0.provider == provider }.map { $0.accountKey.lowercased() })
+            providerQuotas[provider] = providerQuotas[provider]?.filter { key, _ in
+                !placeholderKeys.contains(key.lowercased()) || visibleKeys.contains(key.lowercased())
+            }
         }
     }
     


### PR DESCRIPTION
## Summary
- Disabling a monitor account (e.g. "Claude Desktop") only removed it from the Accounts
  list; `providerQuotas` kept its last-fetched entry until the next refresh cycle, so the
  Quota screen kept showing a tile for an account the user had just disabled.
- Separately, `discoverAccounts()` intentionally hides generic placeholder accounts (e.g.
  "Claude Code") once a more specific credential exists for the same provider, but the
  underlying quota fetch keeps running for them regardless — with no account row to
  disable, that tile was effectively stuck on permanently.
- `setMonitorAccountDisabled` now purges the disabled account's entry from
  `providerQuotas` immediately (mirroring the existing `deleteMonitorAccount` pattern),
  and `removeDisabledMonitorQuotas` also drops quota data for any placeholder key that
  discovery has hidden in favor of a more specific account. The placeholder table is now
  shared via `MonitorRefreshCoordinator.placeholderAccountKeys` instead of duplicated
  between the two call sites.

## Test plan
- [x] Built and ran locally via `./scripts/build_and_run.sh`
- [x] Reproduced both stale tiles (disabled account still showing; unremovable "Claude
      Code" placeholder tile) on current `master`
- [x] Confirmed both tiles disappear after the fix, in both the main window Quota screen
      and the menu bar dropdown