### PR TITLE
fix: stop repeated keychain prompts for Claude Code credentials

### DIFF
--- a/Quotio/Services/Monitor/ClaudeCredentialAdoption.swift
+++ b/Quotio/Services/Monitor/ClaudeCredentialAdoption.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Copies the Claude Code CLI's keychain credential into Quotio's own keychain
+/// item so quota polling never has to read an item Quotio does not own.
+///
+/// The CLI persists refreshed tokens with `security add-generic-password -U`,
+/// which rebuilds the item from scratch and discards its ACL. Any "Always Allow"
+/// grant the user gives Quotio therefore survives only until the CLI's next
+/// token refresh, so reading that item on a poll loop produces an authorization
+/// prompt several times a day. Adopting the credential once trades all of those
+/// for a single prompt.
+///
+/// The copy is strictly read-only with respect to the CLI. Quotio never writes
+/// the CLI's item and never refreshes the adopted credential: the CLI serializes
+/// refreshes across its own processes with a lock and treats a spent refresh
+/// token as fatal (`invalid_grant` -> token marked dead -> cleared from disk),
+/// so an unsynchronized refresh from Quotio could log the user out of Claude
+/// Code. The adopted copy is used until it expires and no further; continuous
+/// monitoring comes from signing in to Quotio, which yields an independent
+/// credential Quotio may refresh freely.
+actor ClaudeCredentialAdopter {
+    static let shared = ClaudeCredentialAdopter()
+
+    nonisolated static let service = "Claude Code-credentials"
+
+    /// Marks a vault account as a copy of the CLI's credential rather than one
+    /// obtained by signing in to Quotio. Refreshing is only safe for the latter.
+    nonisolated static let credentialReference = "keychain:claude-code-copy"
+
+    /// Wait before touching the CLI's item again after an adoption that did not
+    /// yield a usable credential — a denied prompt must not become a prompt per
+    /// poll.
+    private let failureBackoff: TimeInterval = 6 * 3600
+
+    private let vault: MonitorCredentialStore
+    private var nextAttempt: Date?
+
+    init(vault: MonitorCredentialStore = MonitorCredentialVault.shared) {
+        self.vault = vault
+    }
+
+    /// True when the account is a copy of the CLI's credential, whose refresh
+    /// token is shared with Claude Code and must not be spent.
+    nonisolated static func isCopyOfCLICredential(_ account: MonitorAccount) -> Bool {
+        account.credentialReference == credentialReference
+    }
+
+    /// The Quotio-owned Claude credential, performing the one-time copy from the
+    /// CLI's keychain item if it has not happened yet.
+    @discardableResult
+    func adoptIfNeeded() async -> MonitorAccount? {
+        if let owned = await ownedAccount() { return owned }
+        return await adopt()
+    }
+
+    /// Existing Quotio-owned Claude credential, if any. Never reads the CLI item.
+    /// An account from signing in to Quotio takes precedence over an adopted copy,
+    /// since only it can be kept alive by refreshing.
+    func ownedAccount() async -> MonitorAccount? {
+        let owned = await vault.accounts().filter { $0.provider == .claude && $0.source == .quotioKeychain }
+        return owned.first { !Self.isCopyOfCLICredential($0) } ?? owned.first
+    }
+
+    private func adopt() async -> MonitorAccount? {
+        if let nextAttempt, Date() < nextAttempt { return nil }
+
+        guard let record = KeychainHelper.readExternalCredentialRecord(service: Self.service),
+              let parsed = Self.parse(record.data) else {
+            nextAttempt = Date().addingTimeInterval(failureBackoff)
+            return nil
+        }
+
+        // Not deletable: the credential belongs to the CLI login, and deleting the
+        // copy would only make the next discovery pass adopt it again — prompting
+        // once more in the process. Disabling the account is the way to opt out.
+        let account = MonitorAccount.make(
+            provider: .claude,
+            accountKey: parsed.email,
+            source: .quotioKeychain,
+            credentialReference: Self.credentialReference
+        )
+
+        do {
+            try await vault.save(parsed.credential, metadata: account)
+        } catch {
+            nextAttempt = Date().addingTimeInterval(failureBackoff)
+            Log.keychain("Claude credential adoption failed: \(error.localizedDescription)")
+            return nil
+        }
+
+        nextAttempt = Date().addingTimeInterval(failureBackoff)
+        Log.keychain("Adopted Claude Code credential for \(parsed.email) into Quotio's keychain")
+        return account
+    }
+
+    /// Decode the CLI's credential blob into the vault's representation.
+    nonisolated static func parse(_ data: Data) -> (credential: MonitorOAuthCredential, email: String)? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let oauth = json["claudeAiOauth"] as? [String: Any],
+              let accessToken = (oauth["accessToken"] as? String)?.nilIfBlank else { return nil }
+
+        var extra: [String: String] = [:]
+        if let subscription = (oauth["subscriptionType"] as? String)?.nilIfBlank {
+            extra["subscriptionType"] = subscription
+        }
+
+        // The refresh token is deliberately dropped: it belongs to Claude Code's
+        // refresh lineage and spending it would invalidate the CLI's own copy.
+        let credential = MonitorOAuthCredential(
+            accessToken: accessToken,
+            refreshToken: nil,
+            idToken: nil,
+            accountID: nil,
+            expiresAt: expiryDate(oauth["expiresAt"]),
+            extra: extra
+        )
+        return (credential, (oauth["email"] as? String)?.nilIfBlank ?? "Claude Code")
+    }
+
+    /// Claude Code stores expiry as epoch milliseconds.
+    private nonisolated static func expiryDate(_ value: Any?) -> Date? {
+        guard let milliseconds = (value as? NSNumber)?.doubleValue, milliseconds > 0 else { return nil }
+        return Date(timeIntervalSince1970: milliseconds / 1000)
+    }
+}
+
+private extension String {
+    nonisolated var nilIfBlank: String? {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Quotio/Services/Monitor/MonitorRuntime.swift
+++ b/Quotio/Services/Monitor/MonitorRuntime.swift
@@ -301,6 +301,11 @@ actor MonitorAccountDiscovery {
     }
 
     func discover() async -> [MonitorAccount] {
+        // Copies the Claude Code CLI credential into Quotio's own keychain item
+        // on first run, so the account below comes from `vault.accounts()` from
+        // then on instead of an authorization-prompting read of the CLI's item.
+        await ClaudeCredentialAdopter.shared.adoptIfNeeded()
+
         let legacyFiles = await directAuthService.scanAllAuthFiles()
         let codexAliases = Self.codexAliases(from: legacyFiles)
         var candidates = await canonicalizeCodexAccounts(await vault.accounts(), aliases: codexAliases)
@@ -542,12 +547,10 @@ actor MonitorAccountDiscovery {
             let account = MonitorAccount.make(provider: .codex, accountKey: email, source: .nativeCredential, credentialReference: "keychain:Codex Auth")
             accounts.append(Self.canonicalizeCodexAccount(account, accountID: accountID, aliases: codexAliases))
         }
-        if let data = KeychainHelper.readExternalCredential(service: "Claude Code-credentials"),
-           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-           let oauth = json["claudeAiOauth"] as? [String: Any],
-           (oauth["accessToken"] as? String)?.isEmpty == false {
-            accounts.append(.make(provider: .claude, accountKey: (oauth["email"] as? String) ?? "Claude Code", source: .nativeCredential, credentialReference: "keychain:Claude Code-credentials"))
-        }
+        // Claude Code's credential is deliberately absent here: `ClaudeCredentialAdopter`
+        // copies it into Quotio's own keychain item once, and the resulting account
+        // arrives through `vault.accounts()`. Probing the CLI's item on every
+        // discovery pass is what produced the repeated authorization prompts.
         if KeychainHelper.readExternalCredential(service: "gh:github.com") != nil {
             accounts.append(.make(provider: .copilot, accountKey: "GitHub Copilot", source: .nativeCredential, credentialReference: "keychain:gh:github.com"))
         }

--- a/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
@@ -331,11 +331,11 @@ actor ClaudeCodeQuotaFetcher {
         var results = includeMonitorCredentials
             ? await fetchOwnedQuotas(forceRefresh: forceRefresh)
             : [:]
-        for (key, quota) in await fetchNativeKeychainQuotas(forceRefresh: forceRefresh) where results[key] == nil {
+        for (key, quota) in await fetchAdoptedNativeQuotas(forceRefresh: forceRefresh) where results[key] == nil {
             results[key] = quota
         }
         for filePath in nativePaths {
-            guard let quota = await fetchQuotaFromAuthFile(at: filePath, forceRefresh: forceRefresh),
+            guard let quota = await fetchQuotaFromAuthFile(at: filePath, forceRefresh: forceRefresh, allowRefresh: false),
                   results[quota.email] == nil else { continue }
             results[quota.email] = quota.data
         }
@@ -362,8 +362,9 @@ actor ClaudeCodeQuotaFetcher {
             return quota
         }
 
-        if nativeKeychainIdentity() == accountKey,
-           let quota = await fetchNativeKeychainQuotas(forceRefresh: forceRefresh)[accountKey] {
+        if let adopted = await ClaudeCredentialAdopter.shared.adoptIfNeeded(),
+           adopted.accountKey == accountKey,
+           let quota = await fetchOwnedQuota(account: adopted, forceRefresh: forceRefresh) {
             return quota
         }
 
@@ -372,7 +373,7 @@ actor ClaudeCodeQuotaFetcher {
         let nativeBase = (claudeHome?.isEmpty == false ? claudeHome! : NSString(string: "~/.claude").expandingTildeInPath)
         let nativePath = (nativeBase as NSString).appendingPathComponent(".credentials.json")
         if fileManager.fileExists(atPath: nativePath), authFileIdentity(at: nativePath) == accountKey {
-            return await fetchQuotaFromAuthFile(at: nativePath, forceRefresh: forceRefresh)?.data
+            return await fetchQuotaFromAuthFile(at: nativePath, forceRefresh: forceRefresh, allowRefresh: false)?.data
         }
 
         if accountKey == "Claude Desktop" {
@@ -398,14 +399,6 @@ actor ClaudeCodeQuotaFetcher {
         return json["email"] as? String ?? oauth?["email"] as? String ?? "Claude Code"
     }
 
-    private func nativeKeychainIdentity() -> String? {
-        guard let record = KeychainHelper.readExternalCredentialRecord(service: "Claude Code-credentials"),
-              let json = try? JSONSerialization.jsonObject(with: record.data) as? [String: Any],
-              let oauth = json["claudeAiOauth"] as? [String: Any],
-              oauth["accessToken"] as? String != nil else { return nil }
-        return oauth["email"] as? String ?? "Claude Code"
-    }
-
     private func fetchClaudeDesktopQuota(forceRefresh: Bool) async -> (key: String, value: ProviderQuotaData)? {
         let key = "Claude Desktop"
         if !forceRefresh, let cached = quotaCache[key], cached.isValid(ttl: cacheTTL) {
@@ -418,78 +411,15 @@ actor ClaudeCodeQuotaFetcher {
         return (key, quota)
     }
 
-    private func fetchNativeKeychainQuotas(forceRefresh: Bool) async -> [String: ProviderQuotaData] {
-        guard let record = KeychainHelper.readExternalCredentialRecord(service: "Claude Code-credentials"),
-              let json = try? JSONSerialization.jsonObject(with: record.data) as? [String: Any],
-              let oauth = json["claudeAiOauth"] as? [String: Any],
-              var accessToken = oauth["accessToken"] as? String else { return [:] }
-        let email = oauth["email"] as? String ?? "Claude Code"
-        if !forceRefresh, let cached = quotaCache[email], cached.isValid(ttl: cacheTTL) {
-            return [email: cached.data]
-        }
-        let refreshToken = oauth["refreshToken"] as? String
-        do {
-            if isTokenExpired(json: normalizedExpiryJSON(json)), let refreshToken {
-                let refreshed = try await refreshAccessToken(refreshToken: refreshToken)
-                accessToken = refreshed.accessToken
-                persistClaudeKeychainRefresh(
-                    record: record,
-                    json: json,
-                    accessToken: refreshed.accessToken,
-                    expectedRefreshToken: refreshToken,
-                    newRefreshToken: refreshed.refreshToken ?? refreshToken,
-                    expiresIn: refreshed.expiresIn
-                )
-            }
-            var response = await fetchUsageFromAPI(accessToken: accessToken, email: email)
-            if case .authenticationError = response,
-               let latest = KeychainHelper.readExternalCredentialRecord(service: "Claude Code-credentials", account: record.account),
-               let latestJSON = try? JSONSerialization.jsonObject(with: latest.data) as? [String: Any],
-               let latestOAuth = latestJSON["claudeAiOauth"] as? [String: Any],
-               let latestRefreshToken = latestOAuth["refreshToken"] as? String {
-                let refreshed = try await refreshAccessToken(refreshToken: latestRefreshToken)
-                accessToken = refreshed.accessToken
-                persistClaudeKeychainRefresh(
-                    record: latest,
-                    json: latestJSON,
-                    accessToken: refreshed.accessToken,
-                    expectedRefreshToken: latestRefreshToken,
-                    newRefreshToken: refreshed.refreshToken ?? latestRefreshToken,
-                    expiresIn: refreshed.expiresIn
-                )
-                response = await fetchUsageFromAPI(accessToken: accessToken, email: email)
-            }
-            guard case .success(let info) = response, let quota = quotaData(from: info) else { return [:] }
-            quotaCache[email] = CachedQuota(data: quota, timestamp: Date())
-            return [email: quota]
-        } catch {
-            return quotaCache[email].map { [email: $0.data] } ?? [:]
-        }
-    }
-
-    private func persistClaudeKeychainRefresh(
-        record: (data: Data, account: String),
-        json: [String: Any],
-        accessToken: String,
-        expectedRefreshToken: String,
-        newRefreshToken: String,
-        expiresIn: Int?
-    ) {
-        guard let oauth = json["claudeAiOauth"] as? [String: Any],
-              oauth["refreshToken"] as? String == expectedRefreshToken else { return }
-        let updated = updatedAuthJSON(
-            json,
-            accessToken: accessToken,
-            refreshToken: newRefreshToken,
-            expiresIn: expiresIn
-        )
-        guard let data = try? JSONSerialization.data(withJSONObject: updated, options: [.prettyPrinted, .sortedKeys]) else { return }
-        _ = KeychainHelper.compareAndSwapExternalCredential(
-            service: "Claude Code-credentials",
-            account: record.account,
-            expectedData: record.data,
-            newData: data
-        )
+    /// Quota for the Claude Code CLI credential, served from the copy Quotio owns.
+    ///
+    /// The copy is made on first use and refreshed in Quotio's own keychain item
+    /// from then on, so no poll ever reads — or writes — the CLI's item.
+    private func fetchAdoptedNativeQuotas(forceRefresh: Bool) async -> [String: ProviderQuotaData] {
+        guard let account = await ClaudeCredentialAdopter.shared.adoptIfNeeded(),
+              !account.isDisabled,
+              let quota = await fetchOwnedQuota(account: account, forceRefresh: forceRefresh) else { return [:] }
+        return [account.accountKey: quota]
     }
 
     private func fetchOwnedQuotas(forceRefresh: Bool) async -> [String: ProviderQuotaData] {
@@ -502,11 +432,18 @@ actor ClaudeCodeQuotaFetcher {
         return results
     }
 
+    /// Fetch quota for a credential Quotio holds in its own keychain item.
+    ///
+    /// A credential adopted from the Claude Code CLI carries no refresh token —
+    /// `ClaudeCredentialAdopter` drops it, because spending it would invalidate
+    /// the CLI's own copy — so both refresh branches below are inert for one and
+    /// it simply expires. Signing in to Quotio produces a credential with an
+    /// independent refresh lineage that can be kept alive indefinitely.
     private func fetchOwnedQuota(account: MonitorAccount, forceRefresh: Bool) async -> ProviderQuotaData? {
-            guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { return nil }
             if !forceRefresh, let cached = quotaCache[account.accountKey], cached.isValid(ttl: cacheTTL) {
                 return cached.data
             }
+            guard var credential = await MonitorCredentialVault.shared.credential(for: account.id) else { return nil }
             do {
                 if credential.expiresAt.map({ $0.timeIntervalSinceNow < 300 }) ?? false,
                    let refreshToken = credential.refreshToken {
@@ -521,7 +458,9 @@ actor ClaudeCodeQuotaFetcher {
                     if let latest = await MonitorCredentialVault.shared.reloadLatest(accountID: account.id) {
                         credential = latest
                     }
-                    guard let refreshToken = credential.refreshToken else { return nil }
+                    guard let refreshToken = credential.refreshToken else {
+                        return expiredCopyQuota(account: account)
+                    }
                     let refreshed = try await refreshAccessToken(refreshToken: refreshToken)
                     credential.accessToken = refreshed.accessToken
                     credential.refreshToken = refreshed.refreshToken ?? refreshToken
@@ -533,10 +472,22 @@ actor ClaudeCodeQuotaFetcher {
                     quotaCache[account.accountKey] = CachedQuota(data: data, timestamp: Date())
                     return data
                 }
+                if case .authenticationError = response {
+                    return expiredCopyQuota(account: account)
+                }
             } catch {
                 return quotaCache[account.accountKey]?.data
             }
         return nil
+    }
+
+    /// An adopted copy that has outlived its access token cannot be renewed
+    /// without spending Claude Code's refresh token, so surface it as needing
+    /// authentication. That drives the user to sign in to Quotio, which yields a
+    /// credential Quotio can refresh on its own.
+    private func expiredCopyQuota(account: MonitorAccount) -> ProviderQuotaData? {
+        guard ClaudeCredentialAdopter.isCopyOfCLICredential(account) else { return nil }
+        return ProviderQuotaData(models: [], lastUpdated: Date(), isForbidden: true, planType: nil)
     }
 
     private func quotaData(from info: ClaudeCodeQuotaInfo) -> ProviderQuotaData? {
@@ -569,7 +520,16 @@ actor ClaudeCodeQuotaFetcher {
     /// - Parameters:
     ///   - path: Path to the auth file
     ///   - forceRefresh: If true, bypass cache
-    private func fetchQuotaFromAuthFile(at path: String, forceRefresh: Bool = false) async -> (email: String, data: ProviderQuotaData)? {
+    ///   - allowRefresh: Whether an expired token may be renewed and written back.
+    ///     False for files owned by the Claude Code CLI: its refresh tokens are
+    ///     single-use, and the CLI treats a spent one as fatal, so renewing on its
+    ///     behalf can log the user out of Claude Code. Only files Quotio and the
+    ///     proxy own are refreshed.
+    private func fetchQuotaFromAuthFile(
+        at path: String,
+        forceRefresh: Bool = false,
+        allowRefresh: Bool = true
+    ) async -> (email: String, data: ProviderQuotaData)? {
         let fileManager = FileManager.default
 
         guard let data = fileManager.contents(atPath: path),
@@ -589,7 +549,9 @@ actor ClaudeCodeQuotaFetcher {
         }
 
         // Refresh expired token before fetching usage
-        let refreshToken = (json["refresh_token"] as? String) ?? (nestedOAuth?["refreshToken"] as? String)
+        let refreshToken = allowRefresh
+            ? (json["refresh_token"] as? String) ?? (nestedOAuth?["refreshToken"] as? String)
+            : nil
         if isTokenExpired(json: normalizedExpiryJSON(json)), let refreshToken {
             do {
                 let refreshed = try await refreshAccessToken(refreshToken: refreshToken)
@@ -604,7 +566,7 @@ actor ClaudeCodeQuotaFetcher {
 
         // Fetch usage from API using the token
         var result = await fetchUsageFromAPI(accessToken: accessToken, email: email)
-        if case .authenticationError = result {
+        if case .authenticationError = result, allowRefresh {
             do {
                 guard let latestData = fileManager.contents(atPath: path),
                       let latestJSON = try? JSONSerialization.jsonObject(with: latestData) as? [String: Any] else {

--- a/QuotioTests/ClaudeCredentialAdoptionTests.swift
+++ b/QuotioTests/ClaudeCredentialAdoptionTests.swift
@@ -1,0 +1,195 @@
+import XCTest
+@testable import Quotio
+
+private actor FakeCredentialStore: MonitorCredentialStore {
+    private var storedAccounts: [MonitorAccount] = []
+    private var credentials: [String: MonitorOAuthCredential] = [:]
+    private(set) var saveCount = 0
+
+    init(seeding account: MonitorAccount? = nil, credential: MonitorOAuthCredential? = nil) {
+        if let account {
+            storedAccounts = [account]
+            credentials[account.id] = credential
+        }
+    }
+
+    func accounts() async -> [MonitorAccount] { storedAccounts }
+    func credential(for accountID: String) async -> MonitorOAuthCredential? { credentials[accountID] }
+    func reloadLatest(accountID: String) async -> MonitorOAuthCredential? { credentials[accountID] }
+
+    func save(_ credential: MonitorOAuthCredential, metadata: MonitorAccount) async throws {
+        saveCount += 1
+        credentials[metadata.id] = credential
+        storedAccounts.removeAll { $0.id == metadata.id }
+        storedAccounts.append(metadata)
+    }
+
+    func delete(accountID: String) async {
+        credentials.removeValue(forKey: accountID)
+        storedAccounts.removeAll { $0.id == accountID }
+    }
+}
+
+final class ClaudeCredentialAdoptionTests: XCTestCase {
+    private func credentialBlob(_ oauth: [String: Any]) -> Data {
+        try! JSONSerialization.data(withJSONObject: ["claudeAiOauth": oauth])
+    }
+
+    func testParseReadsTokenEmailAndMillisecondExpiry() throws {
+        let expiry = Date().addingTimeInterval(3600)
+        let data = credentialBlob([
+            "accessToken": "access-abc",
+            "refreshToken": "refresh-xyz",
+            "email": "me@example.com",
+            "subscriptionType": "max",
+            "expiresAt": expiry.timeIntervalSince1970 * 1000,
+        ])
+
+        let parsed = try XCTUnwrap(ClaudeCredentialAdopter.parse(data))
+
+        XCTAssertEqual(parsed.email, "me@example.com")
+        XCTAssertEqual(parsed.credential.accessToken, "access-abc")
+        XCTAssertEqual(parsed.credential.extra["subscriptionType"], "max")
+        let expiresAt = try XCTUnwrap(parsed.credential.expiresAt)
+        XCTAssertEqual(expiresAt.timeIntervalSince1970, expiry.timeIntervalSince1970, accuracy: 1)
+    }
+
+    /// Claude Code's refresh tokens are single-use and the CLI treats a spent one
+    /// as fatal, so Quotio must not even be able to spend it: the copy keeps the
+    /// access token and drops the refresh token on the floor.
+    func testParseDiscardsRefreshTokenSoItCanNeverBeSpent() throws {
+        let data = credentialBlob([
+            "accessToken": "access-abc",
+            "refreshToken": "refresh-xyz",
+            "email": "me@example.com",
+        ])
+
+        let parsed = try XCTUnwrap(ClaudeCredentialAdopter.parse(data))
+
+        XCTAssertNil(parsed.credential.refreshToken)
+        XCTAssertEqual(parsed.credential.accessToken, "access-abc")
+    }
+
+    func testAdoptedCopyIsDistinguishableFromAQuotioLogin() {
+        let adopted = MonitorAccount.make(
+            provider: .claude,
+            accountKey: "me@example.com",
+            source: .quotioKeychain,
+            credentialReference: ClaudeCredentialAdopter.credentialReference
+        )
+        let signedIn = MonitorAccount.make(
+            provider: .claude,
+            accountKey: "me@example.com",
+            source: .quotioKeychain,
+            credentialReference: "keychain",
+            canDelete: true
+        )
+
+        XCTAssertTrue(ClaudeCredentialAdopter.isCopyOfCLICredential(adopted))
+        XCTAssertFalse(ClaudeCredentialAdopter.isCopyOfCLICredential(signedIn))
+    }
+
+    func testParseFallsBackToPlaceholderKeyWhenCredentialCarriesNoEmail() throws {
+        let data = credentialBlob(["accessToken": "access-abc"])
+
+        let parsed = try XCTUnwrap(ClaudeCredentialAdopter.parse(data))
+
+        XCTAssertEqual(parsed.email, "Claude Code")
+        XCTAssertNil(parsed.credential.refreshToken)
+        XCTAssertNil(parsed.credential.expiresAt)
+    }
+
+    func testParseRejectsCredentialWithoutAccessToken() {
+        XCTAssertNil(ClaudeCredentialAdopter.parse(credentialBlob(["refreshToken": "refresh-xyz"])))
+        XCTAssertNil(ClaudeCredentialAdopter.parse(credentialBlob(["accessToken": "   "])))
+        XCTAssertNil(ClaudeCredentialAdopter.parse(Data("not json".utf8)))
+    }
+
+    /// The whole point of adoption: once Quotio owns a copy, nothing goes back to
+    /// the CLI's keychain item. `adopt` is the only path that reads that item and
+    /// it always writes on success, so a save-free call proves it was skipped.
+    func testAdoptionIsSkippedOnceQuotioOwnsTheCredential() async {
+        let owned = MonitorAccount.make(
+            provider: .claude,
+            accountKey: "me@example.com",
+            source: .quotioKeychain,
+            credentialReference: ClaudeCredentialAdopter.credentialReference
+        )
+        let store = FakeCredentialStore(
+            seeding: owned,
+            credential: MonitorOAuthCredential(
+                accessToken: "access-abc",
+                refreshToken: nil,
+                idToken: nil,
+                accountID: nil,
+                expiresAt: Date().addingTimeInterval(3600),
+                extra: [:]
+            )
+        )
+        let adopter = ClaudeCredentialAdopter(vault: store)
+
+        let resolved = await adopter.adoptIfNeeded()
+
+        XCTAssertEqual(resolved?.id, owned.id)
+        let saveCount = await store.saveCount
+        XCTAssertEqual(saveCount, 0)
+    }
+
+    /// Once the user signs in to Quotio, that credential must win: it is the only
+    /// one with an independent refresh lineage, so it can be kept alive.
+    func testSignedInCredentialIsPreferredOverAnAdoptedCopy() async {
+        let copy = MonitorAccount.make(
+            provider: .claude,
+            accountKey: "copy@example.com",
+            source: .quotioKeychain,
+            credentialReference: ClaudeCredentialAdopter.credentialReference
+        )
+        let signedIn = MonitorAccount.make(
+            provider: .claude,
+            accountKey: "signed-in@example.com",
+            source: .quotioKeychain,
+            credentialReference: "keychain",
+            canDelete: true
+        )
+        let store = FakeCredentialStore(seeding: copy, credential: nil)
+        try? await store.save(
+            MonitorOAuthCredential(
+                accessToken: "access-def",
+                refreshToken: "refresh-uvw",
+                idToken: nil,
+                accountID: nil,
+                expiresAt: Date().addingTimeInterval(3600),
+                extra: [:]
+            ),
+            metadata: signedIn
+        )
+        let adopter = ClaudeCredentialAdopter(vault: store)
+
+        let resolved = await adopter.ownedAccount()
+
+        XCTAssertEqual(resolved?.id, signedIn.id)
+    }
+
+    /// A credential discovered from the CLI must outrank the file- and
+    /// keychain-derived candidates for the same login, so the adopted copy is the
+    /// one the app actually polls.
+    func testAdoptedAccountOutranksNativeCandidatesForSameLogin() {
+        let adopted = MonitorAccount.make(
+            provider: .claude,
+            accountKey: "me@example.com",
+            source: .quotioKeychain,
+            credentialReference: "keychain"
+        )
+        let native = MonitorAccount.make(
+            provider: .claude,
+            accountKey: "me@example.com",
+            source: .nativeCredential,
+            credentialReference: "~/.claude/.credentials.json"
+        )
+
+        let selected = MonitorAccountDiscovery.selectPreferred([native, adopted])
+
+        XCTAssertEqual(selected.count, 1)
+        XCTAssertEqual(selected.first?.source, .quotioKeychain)
+    }
+}


### PR DESCRIPTION
## Problem

Quotio reads the Claude Code CLI's `Claude Code-credentials` keychain item on **every quota poll**. That item belongs to the CLI, not to Quotio, so macOS gates it behind an authorization prompt — and clicking "Always Allow" does not make the prompt stop. It reappears several times a day, indefinitely.

The cause is how the CLI persists refreshed tokens. From the `claude` binary's keychain module:

```
security find-generic-password -a "…" -w -s "…"
add-generic-password -U -a "…" -s "…" -X "…"
delete-generic-password              ← fallback path in the same module
```

`security add-generic-password -U` does not update in place. It rebuilds the item with a fresh default ACL containing only the creating process, discarding every trusted-application entry — including the one "Always Allow" added for Quotio. The grant therefore survives only until the CLI's next token refresh.

Compounding it, the keychain read happened *before* the quota cache was consulted, so a wiped ACL produced a prompt per poll rather than one.

## Fix

Copy the credential into Quotio's own keychain item once, then serve quota from that copy. Nothing reads the CLI's item again, so the prompt appears at most once per install.

`MonitorAccountDiscovery.discover()` performs the one-time adoption; the account then arrives via `vault.accounts()` instead of the per-pass probe that was in `discoverNativeKeychains`.

## Staying read-only toward Claude Code

Quotio is a usage monitor and shouldn't interfere with the CLI it observes. Being read-only locally is not sufficient on its own, because refreshing is itself a write — to Anthropic's authorization server, spending a refresh token the CLI also holds.

The CLI treats that token as a serialized, single-use resource:

```
tengu_oauth_token_refresh_lock_acquiring / _acquired / _retry / _retry_limit_reached
ELOCKED, oauth_refresh_lock_timeout, _lock_compromised_pre_post
tengu_oauth_token_refresh_race_resolved / _race_recovered
tengu_oauth_refresh_compromised_cas_adopted_sibling
tengu_oauth_refresh_token_marked_dead_invalid_grant
tengu_oauth_refresh_token_cleared_on_disk, known_dead_refresh_token
```

A cross-process lock, sibling-race detection, and a dead-token path on `invalid_grant`. An unsynchronized refresh from Quotio could push the CLI into that dead-token state and log the user out of Claude Code.

So the adopted credential **carries no refresh token at all** — it is dropped at parse time, making it structurally impossible for Quotio to spend rather than merely disallowed. Both refresh branches in `fetchOwnedQuota` are gated on `credential.refreshToken` and are inert for a copy.

`~/.claude/.credentials.json` had the same problem through a different door — it was being refreshed and rewritten in place — so it is now read without refresh or write-back. Auth files under `~/.cli-proxy-api/`, which Quotio and the proxy own, still refresh as before.

After the change: one read of the CLI's keychain item in the codebase (the one-time adoption), zero writes, and all four `refreshAccessToken` call sites unreachable for CLI-owned credentials.

## Trade-off

An adopted copy cannot be renewed once its access token expires, so it surfaces as needing authentication. Signing in to Quotio yields a credential with an independent refresh lineage that can be kept alive indefinitely and never touches Claude Code — that flow already existed (`beginClaudeLogin`/`completeClaudeLogin`) and is unchanged. `ownedAccount()` prefers a signed-in credential over an adopted copy when both exist.

## Testing

New `ClaudeCredentialAdoptionTests` covers the refresh-token drop, credential parsing (including millisecond expiry and the email fallback), adoption being skipped once a copy exists, copy-vs-login distinction, login precedence, and adopted accounts outranking native candidates for the same login.

Full suite: 73 passing.

One note for maintainers: `MonitorRuntimeTests.testCoordinatorCoalescesConcurrentRefreshForProvider` is a pre-existing load-sensitive flake, unrelated to this change — I verified it failing on unmodified `master` under CPU load (1 of 2 runs). `refresh(provider:)` only touches the `inFlight` map and never reaches adoption. Might be worth tightening separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)