### PR TITLE
fix(codex): preserve auth.json credentials and back the file up when configuring proxy

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -1422,6 +1422,35 @@
         }
       }
     },
+    "agents.codex.authJSONMergeKey" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add this key to ~/.codex/auth.json, keeping any entries already in the file:"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajoutez cette clé à ~/.codex/auth.json en conservant les entrées déjà présentes dans le fichier :"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thêm khóa này vào ~/.codex/auth.json, giữ nguyên các mục đã có trong tệp:"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将此密钥添加到 ~/.codex/auth.json，并保留文件中已有的条目："
+          }
+        }
+      }
+    },
     "agents.codex.mergeAndSaveFiles" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1447,6 +1476,35 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "合并并将以下文件保存到 ~/.codex/ 目录："
+          }
+        }
+      }
+    },
+    "agents.codex.revertManualInstructions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove the [model_providers.cliproxyapi] section from ~/.codex/config.toml, and remove the Quotio-managed OPENAI_API_KEY entry from ~/.codex/auth.json while keeping the other entries in that file."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimez la section [model_providers.cliproxyapi] de ~/.codex/config.toml, puis supprimez l'entrée OPENAI_API_KEY gérée par Quotio de ~/.codex/auth.json en conservant les autres entrées de ce fichier."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa phần [model_providers.cliproxyapi] khỏi ~/.codex/config.toml, và xóa mục OPENAI_API_KEY do Quotio quản lý khỏi ~/.codex/auth.json trong khi vẫn giữ các mục khác trong tệp đó."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从 ~/.codex/config.toml 中移除 [model_providers.cliproxyapi] 部分，并从 ~/.codex/auth.json 中移除由 Quotio 管理的 OPENAI_API_KEY 条目，同时保留该文件中的其他条目。"
           }
         }
       }

--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -655,15 +655,16 @@ actor AgentConfigurationService {
     private func generateCodexDefaultConfig(mode: ConfigurationMode) -> AgentConfigResult {
         let home = fileManager.homeDirectoryForCurrentUser.path
         let configPath = "\(home)/.codex/config.toml"
-        
+        let authPath = "\(home)/.codex/auth.json"
+
         if mode == .automatic && fileManager.fileExists(atPath: configPath) {
             do {
                 let content = try String(contentsOfFile: configPath, encoding: .utf8)
-                
+
                 // Create backup
                 let backupPath = "\(configPath).backup.\(Int(Date().timeIntervalSince1970))"
                 try content.write(toFile: backupPath, atomically: true, encoding: .utf8)
-                
+
                 // Reuse the same TOML-aware filtering used by merge path,
                 // including managed banner removal.
                 let stubManagedConfig = buildManagedCodexTOML(model: "", proxyURL: "")
@@ -671,7 +672,19 @@ actor AgentConfigurationService {
                 let filteredLines = filterExistingCodexLines(existingContent: content, managedBanner: managedBanner)
                 let newContent = filteredLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
                 try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
-                
+
+                // Remove the Quotio-managed proxy key from auth.json while
+                // preserving native credentials (access_token, account_id, ...).
+                // Only a "quotio-" prefixed key is removed so a user's own
+                // OPENAI_API_KEY is never touched. A corrupt auth.json is left
+                // as-is rather than failing the whole revert.
+                if let authData = fileManager.contents(atPath: authPath),
+                   let cleanedAuth = (try? Self.codexAuthJSONRemovingQuotioKey(existing: authData)).flatMap({ $0 }) {
+                    _ = try backupIfPresent(authPath)
+                    try cleanedAuth.write(to: URL(fileURLWithPath: authPath), options: .atomic)
+                    try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: authPath)
+                }
+
                 return .success(
                     type: .file,
                     mode: mode,
@@ -694,7 +707,7 @@ actor AgentConfigurationService {
             authPath: nil,
             shellConfig: nil,
             rawConfigs: [],
-            instructions: "Remove [model_providers.cliproxyapi] section from ~/.codex/config.toml",
+            instructions: "Remove [model_providers.cliproxyapi] section from ~/.codex/config.toml and the Quotio-managed OPENAI_API_KEY entry from ~/.codex/auth.json",
             modelsConfigured: 0
         )
     }
@@ -1005,12 +1018,21 @@ actor AgentConfigurationService {
             configTOML = managedConfigTOML + "\n"
         }
         
-        let authJSON = """
-        {
-          "OPENAI_API_KEY": "\(config.apiKey)"
+        // Merge into the existing auth.json instead of replacing it: Codex CLI
+        // stores native credentials (access_token, account_id, tokens, ...) there,
+        // and `codex resume` filters session history by account_id. Overwriting
+        // the file wipes that history view (#367).
+        let existingAuthData = fileManager.contents(atPath: authPath)
+        let authJSON: String
+        do {
+            let mergedAuth = try Self.mergedCodexAuthJSON(existing: existingAuthData, apiKey: config.apiKey)
+            authJSON = String(decoding: mergedAuth, as: UTF8.self)
+        } catch {
+            Log.warning("Failed to parse existing Codex auth.json at \(authPath): \(error.localizedDescription). Falling back to managed-only auth.json.")
+            let managedAuth = try Self.mergedCodexAuthJSON(existing: nil, apiKey: config.apiKey)
+            authJSON = String(decoding: managedAuth, as: UTF8.self)
         }
-        """
-        
+
         let rawConfigs = [
             RawConfigOutput(
                 format: .toml,
@@ -1030,13 +1052,10 @@ actor AgentConfigurationService {
         
         if mode == .automatic {
             try fileManager.createDirectory(atPath: codexDir, withIntermediateDirectories: true)
-            
-            var backupPath: String? = nil
-            if fileManager.fileExists(atPath: configPath) {
-                backupPath = "\(configPath).backup.\(Int(Date().timeIntervalSince1970))"
-                try? fileManager.copyItem(atPath: configPath, toPath: backupPath!)
-            }
-            
+
+            let backupPath = try backupIfPresent(configPath)
+            _ = try backupIfPresent(authPath)
+
             try configTOML.write(toFile: configPath, atomically: true, encoding: .utf8)
             try authJSON.write(toFile: authPath, atomically: true, encoding: .utf8)
             
@@ -1166,6 +1185,38 @@ actor AgentConfigurationService {
         for (key, value) in updates {
             object[key] = value
         }
+        return try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    /// Merges the Quotio proxy key into the existing ~/.codex/auth.json content,
+    /// preserving every other field (access_token, account_id, tokens, ...) so
+    /// Codex CLI keeps its native identity and `codex resume` can still match
+    /// session history by account_id (#367). Throws if `existing` is not a JSON object.
+    nonisolated static func mergedCodexAuthJSON(existing: Data?, apiKey: String) throws -> Data {
+        var object: [String: Any] = [:]
+        if let existing {
+            guard let decoded = try JSONSerialization.jsonObject(with: existing) as? [String: Any] else {
+                throw CocoaError(.propertyListReadCorrupt)
+            }
+            object = decoded
+        }
+        object["OPENAI_API_KEY"] = apiKey
+        return try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    /// Removes the Quotio-managed OPENAI_API_KEY (a "quotio-" prefixed value)
+    /// from ~/.codex/auth.json content, preserving all other fields.
+    /// Returns nil when there is nothing to remove (no key, or a user-owned key).
+    /// Throws if `existing` is not a JSON object.
+    nonisolated static func codexAuthJSONRemovingQuotioKey(existing: Data) throws -> Data? {
+        guard let decoded = try JSONSerialization.jsonObject(with: existing) as? [String: Any] else {
+            throw CocoaError(.propertyListReadCorrupt)
+        }
+        guard let key = decoded["OPENAI_API_KEY"] as? String, key.hasPrefix("quotio-") else {
+            return nil
+        }
+        var object = decoded
+        object.removeValue(forKey: "OPENAI_API_KEY")
         return try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
     }
 

--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -657,49 +657,50 @@ actor AgentConfigurationService {
         let configPath = "\(home)/.codex/config.toml"
         let authPath = "\(home)/.codex/auth.json"
 
-        if mode == .automatic && fileManager.fileExists(atPath: configPath) {
+        // config.toml and auth.json are cleaned independently: either file can be
+        // missing while the other still carries Quotio's managed entries, so
+        // nesting the auth.json cleanup inside the config.toml branch left the
+        // managed key behind and still reported success.
+        if mode == .automatic {
             do {
-                let content = try String(contentsOfFile: configPath, encoding: .utf8)
+                var cleanedConfig = false
+                if fileManager.fileExists(atPath: configPath) {
+                    let content = try String(contentsOfFile: configPath, encoding: .utf8)
 
-                // Create backup
-                let backupPath = "\(configPath).backup.\(Int(Date().timeIntervalSince1970))"
-                try content.write(toFile: backupPath, atomically: true, encoding: .utf8)
+                    // Collision-safe backup, same helper as every other managed file.
+                    _ = try backupIfPresent(configPath)
 
-                // Reuse the same TOML-aware filtering used by merge path,
-                // including managed banner removal.
-                let stubManagedConfig = buildManagedCodexTOML(model: "", proxyURL: "")
-                let managedBanner = extractManagedCodexBanner(from: stubManagedConfig)
-                let filteredLines = filterExistingCodexLines(existingContent: content, managedBanner: managedBanner)
-                let newContent = filteredLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
-                try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
-
-                // Remove the Quotio-managed proxy key from auth.json while
-                // preserving native credentials (access_token, account_id, ...).
-                // Only a "quotio-" prefixed key is removed so a user's own
-                // OPENAI_API_KEY is never touched. A corrupt auth.json is left
-                // as-is rather than failing the whole revert.
-                if let authData = fileManager.contents(atPath: authPath),
-                   let cleanedAuth = (try? Self.codexAuthJSONRemovingQuotioKey(existing: authData)).flatMap({ $0 }) {
-                    _ = try backupIfPresent(authPath)
-                    try cleanedAuth.write(to: URL(fileURLWithPath: authPath), options: .atomic)
-                    try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: authPath)
+                    // Reuse the same TOML-aware filtering used by merge path,
+                    // including managed banner removal.
+                    let stubManagedConfig = buildManagedCodexTOML(model: "", proxyURL: "")
+                    let managedBanner = extractManagedCodexBanner(from: stubManagedConfig)
+                    let filteredLines = filterExistingCodexLines(existingContent: content, managedBanner: managedBanner)
+                    let newContent = filteredLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
+                    try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
+                    cleanedConfig = true
                 }
 
-                return .success(
-                    type: .file,
-                    mode: mode,
-                    configPath: configPath,
-                    authPath: nil,
-                    shellConfig: nil,
-                    rawConfigs: [],
-                    instructions: "Removed CLIProxyAPI configuration. Codex CLI will now use OpenAI API directly.",
-                    modelsConfigured: 0
-                )
+                // Removes only a "quotio-" prefixed OPENAI_API_KEY, so a user's
+                // own key and their native credentials are never touched.
+                let cleanedAuth = try revertCodexAuthJSON(at: authPath)
+
+                if cleanedConfig || cleanedAuth {
+                    return .success(
+                        type: .file,
+                        mode: mode,
+                        configPath: cleanedConfig ? configPath : nil,
+                        authPath: nil,
+                        shellConfig: nil,
+                        rawConfigs: [],
+                        instructions: "Removed CLIProxyAPI configuration. Codex CLI will now use OpenAI API directly.",
+                        modelsConfigured: 0
+                    )
+                }
             } catch {
                 return .failure(error: "Failed to update config: \(error.localizedDescription)")
             }
         }
-        
+
         return .success(
             type: .file,
             mode: mode,
@@ -707,7 +708,7 @@ actor AgentConfigurationService {
             authPath: nil,
             shellConfig: nil,
             rawConfigs: [],
-            instructions: "Remove [model_providers.cliproxyapi] section from ~/.codex/config.toml and the Quotio-managed OPENAI_API_KEY entry from ~/.codex/auth.json",
+            instructions: "agents.codex.revertManualInstructions".localizedStatic(),
             modelsConfigured: 0
         )
     }
@@ -1018,20 +1019,20 @@ actor AgentConfigurationService {
             configTOML = managedConfigTOML + "\n"
         }
         
-        // Merge into the existing auth.json instead of replacing it: Codex CLI
-        // stores native credentials (access_token, account_id, tokens, ...) there,
-        // and `codex resume` filters session history by account_id. Overwriting
-        // the file wipes that history view (#367).
-        let existingAuthData = fileManager.contents(atPath: authPath)
-        let authJSON: String
-        do {
-            let mergedAuth = try Self.mergedCodexAuthJSON(existing: existingAuthData, apiKey: config.apiKey)
-            authJSON = String(decoding: mergedAuth, as: UTF8.self)
-        } catch {
-            Log.warning("Failed to parse existing Codex auth.json at \(authPath): \(error.localizedDescription). Falling back to managed-only auth.json.")
-            let managedAuth = try Self.mergedCodexAuthJSON(existing: nil, apiKey: config.apiKey)
-            authJSON = String(decoding: managedAuth, as: UTF8.self)
-        }
+        // auth.json holds Codex CLI's own credentials (access_token, refresh
+        // token, account_id, ...). Quotio only owns the OPENAI_API_KEY entry, so
+        // the managed write merges into the existing file rather than replacing
+        // it — replacing it destroyed the user's native login (#367).
+        //
+        // `managed` (the Quotio key alone) is what the manual preview renders and
+        // what "Copy All" copies; `merged` is only ever written to disk in
+        // automatic mode. Keeping them apart means native tokens never reach the
+        // UI or the clipboard.
+        let authPayloads = Self.codexAuthPayloads(
+            existing: fileManager.contents(atPath: authPath),
+            apiKey: config.apiKey,
+            path: authPath
+        )
 
         let rawConfigs = [
             RawConfigOutput(
@@ -1043,13 +1044,13 @@ actor AgentConfigurationService {
             ),
             RawConfigOutput(
                 format: .json,
-                content: authJSON,
+                content: authPayloads.managed,
                 filename: "auth.json",
                 targetPath: authPath,
-                instructions: "Save this as ~/.codex/auth.json"
+                instructions: "agents.codex.authJSONMergeKey".localizedStatic()
             )
         ]
-        
+
         if mode == .automatic {
             try fileManager.createDirectory(atPath: codexDir, withIntermediateDirectories: true)
 
@@ -1057,8 +1058,8 @@ actor AgentConfigurationService {
             _ = try backupIfPresent(authPath)
 
             try configTOML.write(toFile: configPath, atomically: true, encoding: .utf8)
-            try authJSON.write(toFile: authPath, atomically: true, encoding: .utf8)
-            
+            try authPayloads.merged.write(toFile: authPath, atomically: true, encoding: .utf8)
+
             try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: authPath)
             
             return .success(
@@ -1188,10 +1189,57 @@ actor AgentConfigurationService {
         return try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
     }
 
+    /// Strips the Quotio-managed `OPENAI_API_KEY` from the auth.json at `path`,
+    /// backing the file up first. Returns `true` when the file was rewritten.
+    ///
+    /// Deliberately independent of `config.toml`: reverting used to be nested
+    /// inside the `config.toml` branch, so a user whose `config.toml` had already
+    /// been removed kept the managed key in `auth.json` forever. A corrupt or
+    /// user-owned `auth.json` is left untouched rather than failing the revert.
+    func revertCodexAuthJSON(at path: String) throws -> Bool {
+        guard let authData = fileManager.contents(atPath: path),
+              let cleaned = (try? Self.codexAuthJSONRemovingQuotioKey(existing: authData)).flatMap({ $0 })
+        else { return false }
+
+        _ = try backupIfPresent(path)
+        try cleaned.write(to: URL(fileURLWithPath: path), options: .atomic)
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
+        return true
+    }
+
+    /// The two ~/.codex/auth.json renderings a configuration run needs.
+    ///
+    /// - `managed`: the Quotio-owned key on its own. Safe to display and copy,
+    ///   so this is what manual mode shows.
+    /// - `merged`: the Quotio key merged into the user's current file. Written
+    ///   to disk in automatic mode only, because it carries native credentials.
+    ///
+    /// An unreadable/corrupt existing file degrades to the managed-only content
+    /// (with a warning), matching the `config.toml` merge fallback.
+    nonisolated static func codexAuthPayloads(
+        existing: Data?,
+        apiKey: String,
+        path: String
+    ) -> (managed: String, merged: String) {
+        // Building from `nil` cannot fail, so the managed rendering is total.
+        let managedData = (try? mergedCodexAuthJSON(existing: nil, apiKey: apiKey))
+            ?? Data(#"{"OPENAI_API_KEY":"\#(apiKey)"}"#.utf8)
+        let managed = String(decoding: managedData, as: UTF8.self)
+
+        guard let existing else { return (managed: managed, merged: managed) }
+        do {
+            let mergedData = try mergedCodexAuthJSON(existing: existing, apiKey: apiKey)
+            return (managed: managed, merged: String(decoding: mergedData, as: UTF8.self))
+        } catch {
+            Log.warning("Failed to parse existing Codex auth.json at \(path): \(error.localizedDescription). Falling back to managed-only auth.json.")
+            return (managed: managed, merged: managed)
+        }
+    }
+
     /// Merges the Quotio proxy key into the existing ~/.codex/auth.json content,
-    /// preserving every other field (access_token, account_id, tokens, ...) so
-    /// Codex CLI keeps its native identity and `codex resume` can still match
-    /// session history by account_id (#367). Throws if `existing` is not a JSON object.
+    /// preserving every other field (access_token, refresh token, account_id, ...)
+    /// so configuring the proxy does not sign the user out of Codex CLI (#367).
+    /// Throws if `existing` is not a JSON object.
     nonisolated static func mergedCodexAuthJSON(existing: Data?, apiKey: String) throws -> Data {
         var object: [String: Any] = [:]
         if let existing {

--- a/QuotioTests/CodexAuthConfigTests.swift
+++ b/QuotioTests/CodexAuthConfigTests.swift
@@ -7,6 +7,26 @@ final class CodexAuthConfigTests: XCTestCase {
         try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 
+    /// A realistic ChatGPT-login auth.json as Codex CLI writes it.
+    private func nativeAuthData() throws -> Data {
+        try JSONSerialization.data(withJSONObject: [
+            "tokens": [
+                "id_token": "native-id-token",
+                "access_token": "native-access-token",
+                "refresh_token": "native-refresh-token",
+                "account_id": "11111111-2222-3333-4444-555555555555"
+            ],
+            "last_refresh": "2026-01-01T00:00:00Z"
+        ])
+    }
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quotio-codex-auth-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
     // MARK: - mergedCodexAuthJSON
 
     func testMergePreservesNativeFieldsAndSetsProxyKey() throws {
@@ -53,6 +73,69 @@ final class CodexAuthConfigTests: XCTestCase {
         )
     }
 
+    // MARK: - codexAuthPayloads
+    //
+    // The manual preview renders `managed` and "Copy All" copies it, so it must
+    // never carry the user's native Codex credentials. Only `merged` — which is
+    // written straight to disk in automatic mode — may contain them.
+
+    func testManualPayloadNeverExposesNativeCredentials() throws {
+        let payloads = AgentConfigurationService.codexAuthPayloads(
+            existing: try nativeAuthData(),
+            apiKey: "quotio-local-test",
+            path: "/tmp/auth.json"
+        )
+
+        let managed = try jsonObject(Data(payloads.managed.utf8))
+        XCTAssertEqual(managed.count, 1)
+        XCTAssertEqual(managed["OPENAI_API_KEY"] as? String, "quotio-local-test")
+
+        // Guard the rendered text too: this is the exact string shown and copied.
+        for secret in ["native-access-token", "native-refresh-token", "native-id-token",
+                       "11111111-2222-3333-4444-555555555555", "last_refresh"] {
+            XCTAssertFalse(
+                payloads.managed.contains(secret),
+                "manual auth.json preview leaked \(secret)"
+            )
+        }
+    }
+
+    func testAutomaticPayloadMergesIntoExistingFile() throws {
+        let payloads = AgentConfigurationService.codexAuthPayloads(
+            existing: try nativeAuthData(),
+            apiKey: "quotio-local-test",
+            path: "/tmp/auth.json"
+        )
+
+        let merged = try jsonObject(Data(payloads.merged.utf8))
+        XCTAssertEqual(merged["OPENAI_API_KEY"] as? String, "quotio-local-test")
+        let tokens = try XCTUnwrap(merged["tokens"] as? [String: Any])
+        XCTAssertEqual(tokens["refresh_token"] as? String, "native-refresh-token")
+        XCTAssertEqual(merged["last_refresh"] as? String, "2026-01-01T00:00:00Z")
+    }
+
+    func testPayloadsFallBackToManagedOnlyWhenExistingFileIsCorrupt() throws {
+        let payloads = AgentConfigurationService.codexAuthPayloads(
+            existing: Data("not json".utf8),
+            apiKey: "quotio-local-test",
+            path: "/tmp/auth.json"
+        )
+
+        XCTAssertEqual(payloads.merged, payloads.managed)
+        let merged = try jsonObject(Data(payloads.merged.utf8))
+        XCTAssertEqual(merged.count, 1)
+        XCTAssertEqual(merged["OPENAI_API_KEY"] as? String, "quotio-local-test")
+    }
+
+    func testPayloadsWithNoExistingFileAreIdentical() throws {
+        let payloads = AgentConfigurationService.codexAuthPayloads(
+            existing: nil,
+            apiKey: "quotio-local-test",
+            path: "/tmp/auth.json"
+        )
+        XCTAssertEqual(payloads.merged, payloads.managed)
+    }
+
     // MARK: - codexAuthJSONRemovingQuotioKey
 
     func testRemoveQuotioKeyPreservesNativeCredentials() throws {
@@ -86,13 +169,102 @@ final class CodexAuthConfigTests: XCTestCase {
         XCTAssertNil(try AgentConfigurationService.codexAuthJSONRemovingQuotioKey(existing: existing))
     }
 
-    // MARK: - Backup restore
+    // MARK: - revertCodexAuthJSON
+    //
+    // The revert must not depend on config.toml: "Use default" previously nested
+    // the auth.json cleanup inside the config.toml branch, so a user whose
+    // config.toml was already gone kept the Quotio key forever.
+
+    func testRevertRemovesManagedKeyWithoutAnyConfigTOML() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let authPath = dir.appendingPathComponent("auth.json").path
+        try JSONSerialization.data(withJSONObject: [
+            "OPENAI_API_KEY": "quotio-local-test",
+            "tokens": ["refresh_token": "native-refresh-token"]
+        ]).write(to: URL(fileURLWithPath: authPath))
+
+        // No config.toml exists in this directory at all.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: dir.appendingPathComponent("config.toml").path))
+
+        let changed = try await AgentConfigurationService().revertCodexAuthJSON(at: authPath)
+        XCTAssertTrue(changed)
+
+        let object = try jsonObject(try Data(contentsOf: URL(fileURLWithPath: authPath)))
+        XCTAssertNil(object["OPENAI_API_KEY"])
+        let tokens = try XCTUnwrap(object["tokens"] as? [String: Any])
+        XCTAssertEqual(tokens["refresh_token"] as? String, "native-refresh-token")
+
+        // A collision-safe backup of the pre-revert file is left behind.
+        let backups = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+            .filter { $0.hasPrefix("auth.json.backup.") }
+        XCTAssertEqual(backups.count, 1)
+
+        let perms = try FileManager.default.attributesOfItem(atPath: authPath)[.posixPermissions] as? NSNumber
+        XCTAssertEqual(perms?.int16Value, 0o600)
+    }
+
+    func testRevertLeavesUserOwnedKeyAndReportsNoChange() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let authPath = dir.appendingPathComponent("auth.json").path
+        let original = #"{"OPENAI_API_KEY":"sk-user-owned-key"}"#
+        try original.write(toFile: authPath, atomically: true, encoding: .utf8)
+
+        let changed = try await AgentConfigurationService().revertCodexAuthJSON(at: authPath)
+        XCTAssertFalse(changed)
+        XCTAssertEqual(try String(contentsOfFile: authPath, encoding: .utf8), original)
+
+        let backups = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+            .filter { $0.hasPrefix("auth.json.backup.") }
+        XCTAssertTrue(backups.isEmpty)
+    }
+
+    func testRevertIsANoOpWhenAuthFileIsMissing() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let changed = try await AgentConfigurationService()
+            .revertCodexAuthJSON(at: dir.appendingPathComponent("auth.json").path)
+        XCTAssertFalse(changed)
+    }
+
+    // MARK: - Backups
+
+    /// Two reverts in the same second must not clobber the first backup.
+    func testRepeatedRevertsKeepEveryBackup() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let service = AgentConfigurationService()
+        let authPath = dir.appendingPathComponent("auth.json").path
+
+        try #"{"OPENAI_API_KEY":"quotio-local-1","account_id":"first"}"#
+            .write(toFile: authPath, atomically: true, encoding: .utf8)
+        let firstRevert = try await service.revertCodexAuthJSON(at: authPath)
+        XCTAssertTrue(firstRevert)
+
+        try #"{"OPENAI_API_KEY":"quotio-local-2","account_id":"second"}"#
+            .write(toFile: authPath, atomically: true, encoding: .utf8)
+        let secondRevert = try await service.revertCodexAuthJSON(at: authPath)
+        XCTAssertTrue(secondRevert)
+
+        let backups = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+            .filter { $0.hasPrefix("auth.json.backup.") }
+        XCTAssertEqual(backups.count, 2, "a same-second backup overwrote an earlier one")
+
+        let contents = try backups.map {
+            try String(contentsOfFile: dir.appendingPathComponent($0).path, encoding: .utf8)
+        }
+        XCTAssertTrue(contents.contains { $0.contains("quotio-local-1") })
+        XCTAssertTrue(contents.contains { $0.contains("quotio-local-2") })
+    }
 
     func testRestoreFromBackupRestoresOriginalAuthJSON() async throws {
         let fileManager = FileManager.default
-        let tempDir = fileManager.temporaryDirectory
-            .appendingPathComponent("quotio-codex-auth-tests-\(UUID().uuidString)")
-        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let tempDir = try makeTempDir()
         defer { try? fileManager.removeItem(at: tempDir) }
 
         let authPath = tempDir.appendingPathComponent("auth.json").path

--- a/QuotioTests/CodexAuthConfigTests.swift
+++ b/QuotioTests/CodexAuthConfigTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import Quotio
+
+final class CodexAuthConfigTests: XCTestCase {
+
+    private func jsonObject(_ data: Data) throws -> [String: Any] {
+        try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    // MARK: - mergedCodexAuthJSON
+
+    func testMergePreservesNativeFieldsAndSetsProxyKey() throws {
+        let existing = try JSONSerialization.data(withJSONObject: [
+            "access_token": "native-access-token",
+            "account_id": "11111111-2222-3333-4444-555555555555",
+            "tokens": [
+                "access_token": "native-access-token",
+                "account_id": "11111111-2222-3333-4444-555555555555"
+            ],
+            "last_refresh": "2026-01-01T00:00:00Z",
+            "OPENAI_API_KEY": "old-key"
+        ])
+
+        let merged = try AgentConfigurationService.mergedCodexAuthJSON(
+            existing: existing,
+            apiKey: "quotio-local-test"
+        )
+        let object = try jsonObject(merged)
+
+        XCTAssertEqual(object["OPENAI_API_KEY"] as? String, "quotio-local-test")
+        XCTAssertEqual(object["access_token"] as? String, "native-access-token")
+        XCTAssertEqual(object["account_id"] as? String, "11111111-2222-3333-4444-555555555555")
+        XCTAssertEqual(object["last_refresh"] as? String, "2026-01-01T00:00:00Z")
+        let tokens = try XCTUnwrap(object["tokens"] as? [String: Any])
+        XCTAssertEqual(tokens["account_id"] as? String, "11111111-2222-3333-4444-555555555555")
+    }
+
+    func testMergeWithoutExistingFileProducesOnlyProxyKey() throws {
+        let merged = try AgentConfigurationService.mergedCodexAuthJSON(
+            existing: nil,
+            apiKey: "quotio-local-test"
+        )
+        let object = try jsonObject(merged)
+
+        XCTAssertEqual(object.count, 1)
+        XCTAssertEqual(object["OPENAI_API_KEY"] as? String, "quotio-local-test")
+    }
+
+    func testMergeThrowsOnCorruptExistingContent() {
+        let corrupt = Data("not json".utf8)
+        XCTAssertThrowsError(
+            try AgentConfigurationService.mergedCodexAuthJSON(existing: corrupt, apiKey: "quotio-local-test")
+        )
+    }
+
+    // MARK: - codexAuthJSONRemovingQuotioKey
+
+    func testRemoveQuotioKeyPreservesNativeCredentials() throws {
+        let existing = try JSONSerialization.data(withJSONObject: [
+            "access_token": "native-access-token",
+            "account_id": "11111111-2222-3333-4444-555555555555",
+            "OPENAI_API_KEY": "quotio-local-test"
+        ])
+
+        let cleaned = try XCTUnwrap(
+            AgentConfigurationService.codexAuthJSONRemovingQuotioKey(existing: existing)
+        )
+        let object = try jsonObject(cleaned)
+
+        XCTAssertNil(object["OPENAI_API_KEY"])
+        XCTAssertEqual(object["access_token"] as? String, "native-access-token")
+        XCTAssertEqual(object["account_id"] as? String, "11111111-2222-3333-4444-555555555555")
+    }
+
+    func testRemoveLeavesUserOwnedKeyUntouched() throws {
+        let existing = try JSONSerialization.data(withJSONObject: [
+            "OPENAI_API_KEY": "sk-user-owned-key"
+        ])
+        XCTAssertNil(try AgentConfigurationService.codexAuthJSONRemovingQuotioKey(existing: existing))
+    }
+
+    func testRemoveReturnsNilWhenNoKeyPresent() throws {
+        let existing = try JSONSerialization.data(withJSONObject: [
+            "account_id": "11111111-2222-3333-4444-555555555555"
+        ])
+        XCTAssertNil(try AgentConfigurationService.codexAuthJSONRemovingQuotioKey(existing: existing))
+    }
+
+    // MARK: - Backup restore
+
+    func testRestoreFromBackupRestoresOriginalAuthJSON() async throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory
+            .appendingPathComponent("quotio-codex-auth-tests-\(UUID().uuidString)")
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let authPath = tempDir.appendingPathComponent("auth.json").path
+        let originalContent = "{\"account_id\":\"native\"}"
+        let timestamp = 1736840000
+        let backupPath = "\(authPath).backup.\(timestamp)"
+
+        // Simulate the state after Quotio configured the proxy:
+        // a timestamped backup holds the native file, the live file holds the proxy key.
+        try originalContent.write(toFile: backupPath, atomically: true, encoding: .utf8)
+        try "{\"OPENAI_API_KEY\":\"quotio-local-test\"}".write(toFile: authPath, atomically: true, encoding: .utf8)
+
+        let service = AgentConfigurationService()
+        let backup = AgentConfigurationService.BackupFile(
+            path: backupPath,
+            timestamp: Date(timeIntervalSince1970: TimeInterval(timestamp)),
+            agent: .codexCLI
+        )
+        try await service.restoreFromBackup(backup)
+
+        let restored = try String(contentsOfFile: authPath, encoding: .utf8)
+        XCTAssertEqual(restored, originalContent)
+    }
+}


### PR DESCRIPTION
## Scope

Related issue: #367

It keeps the `auth.json` data-preservation and backup work, and drops the incorrect `account_id` root-cause claim. #367's actual symptom — the empty `codex resume` list — is caused by the `model_provider` switch and is **not** fixed here; findings and a suggested direction are in the review thread.

## What this fixes

**1. Configuring the proxy destroyed the user's Codex login.**
`generateCodexConfig` rebuilt `~/.codex/auth.json` from scratch as `{"OPENAI_API_KEY": "quotio-local-..."}` and, in Automatic mode, wrote it over the existing file. Codex CLI stores its own credentials there (`tokens.access_token`, `tokens.refresh_token`, `account_id`, `last_refresh`), and unlike `config.toml` the file was never backed up — so a ChatGPT-login user was signed out with no recovery path.

`mergedCodexAuthJSON(existing:apiKey:)` now reads the existing file, preserves every field, and only sets `OPENAI_API_KEY`. A corrupt file degrades to managed-only content with a warning, matching the existing `config.toml` merge fallback.

**2. `auth.json` is now backed up.** Automatic configure backs it up via the collision-safe `backupIfPresent` helper (which never overwrites an existing backup); the `config.toml` backup was switched to the same helper. `CLIAgent.codexCLI.configPaths` already lists `~/.codex/auth.json`, so these appear in `listBackups` and restore through the existing flow.

**3. Manual mode no longer exposes native credentials.** The merged content is only ever written to disk in Automatic mode. `codexAuthPayloads(existing:apiKey:path:)` returns two renderings — `managed` (the Quotio key alone) for the manual preview, `merged` for the automatic write — so access/refresh tokens never reach `RawConfigOutput`, the preview UI, or "Copy All". The preview instruction now tells the user to *add* the key rather than replace the file.

**4. "Use default" cleans both files independently.** The `auth.json` cleanup was nested inside `if fileExists(config.toml)`, so a user whose `config.toml` was already gone kept the Quotio-managed key forever while the revert reported success. The two files are now handled separately, both with collision-safe backups. Only a `quotio-`-prefixed value is removed, so a user's own `OPENAI_API_KEY` is never touched; permissions stay `0600`.

## Why merging rather than backup-only

Proxy routing is decided by `config.toml` (`model_providers.cliproxyapi.base_url`), not by `auth.json`, and as noted in #367 CLIProxyAPI does not validate the key Codex sends. Keeping the native token fields alongside `OPENAI_API_KEY` therefore cannot redirect traffic away from the proxy. Backups are kept as a second recovery path.

## Test evidence

`QuotioTests/CodexAuthConfigTests` — 15 tests:

- merge preserves `tokens`/`account_id`/`last_refresh` and updates only `OPENAI_API_KEY`; no existing file yields managed-only; corrupt input throws.
- `testManualPayloadNeverExposesNativeCredentials` — asserts the manual preview string contains none of the native token values (regression test for 3).
- `testAutomaticPayloadMergesIntoExistingFile`, `testPayloadsFallBackToManagedOnlyWhenExistingFileIsCorrupt`.
- `testRevertRemovesManagedKeyWithoutAnyConfigTOML` — reverts with **no `config.toml` present at all** (regression test for 4), checking the key is gone, native fields survive, a backup exists, and permissions are `0600`.
- `testRevertLeavesUserOwnedKeyAndReportsNoChange`, `testRevertIsANoOpWhenAuthFileIsMissing`.
- `testRepeatedRevertsKeepEveryBackup` — two reverts in the same second keep both backups.
- `testRestoreFromBackupRestoresOriginalAuthJSON` — restore returns the original bytes.

```
xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build   # BUILD SUCCEEDED
xcodebuild test -project Quotio.xcodeproj -scheme Quotio -destination 'platform=macOS'   # TEST SUCCEEDED — 80 tests, 0 failures
```

New user-facing strings are localized in en, fr, vi and zh-Hans.

Trial-merged against `master` and against #473, #477, #482 and #484 in a scratch worktree — no conflicts in any combination.

Refs #367
