### PR TITLE
fix(menubar): deduplicate GitHub Copilot quota items

### DIFF
--- a/Quotio/Models/Models.swift
+++ b/Quotio/Models/Models.swift
@@ -386,13 +386,11 @@ nonisolated struct AuthFile: Codable, Identifiable, Hashable, Sendable {
             // so filename-based keys keep same-email Plus/Team accounts distinct.
             return name.codexFilenameKey
         }
-        if providerType == .copilot {
-            if let account, !account.isEmpty {
-                return account
-            }
-            if let filenameKey = name.copilotFilenameKey {
-                return filenameKey
-            }
+        if providerType == .copilot,
+           let key = CopilotQuotaFetcher.canonicalAccountKey(filename: name, username: account) {
+            // Same canonical rule as CopilotQuotaFetcher / DirectAuthFileService (#404):
+            // identity field first, `github-copilot-*` filename suffix otherwise.
+            return key
         }
         if let email = email, !email.isEmpty {
             return email

--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -154,8 +154,13 @@ final class AppBootstrap {
             return quotaData
         }
 
-        guard provider == .codex else { return nil }
-        return accountQuotas[selectedItem.accountKey.codexFilenameKey]
+        if provider == .codex {
+            return accountQuotas[selectedItem.accountKey.codexFilenameKey]
+        }
+        if provider == .copilot, let filenameKey = selectedItem.accountKey.copilotFilenameKey {
+            return accountQuotas[filenameKey]
+        }
+        return nil
     }
 }
 

--- a/Quotio/Services/DirectAuthFileService.swift
+++ b/Quotio/Services/DirectAuthFileService.swift
@@ -21,7 +21,11 @@ struct DirectAuthFile: Identifiable, Sendable, Hashable {
     let filePath: String
     let source: AuthFileSource
     let filename: String
-    
+    /// Identity fields this file also matches, but which are not the canonical
+    /// key. Older Quotio versions keyed Copilot files by the JSON `login` field;
+    /// those keys must still migrate onto the canonical key (#404).
+    nonisolated var legacyIdentityKeys: [String] = []
+
     /// Source location of the auth file
     enum AuthFileSource: String, Sendable {
         case cliProxyApi = "~/.cli-proxy-api"
@@ -57,13 +61,9 @@ struct DirectAuthFile: Identifiable, Sendable, Hashable {
         if provider == .codex {
             return filename.codexFilenameKey
         }
-        if provider == .copilot {
-            if let login, !login.isEmpty {
-                return login
-            }
-            if let filenameKey = filename.copilotFilenameKey {
-                return filenameKey
-            }
+        if provider == .copilot,
+           let key = CopilotQuotaFetcher.canonicalAccountKey(filename: filename, username: login) {
+            return key
         }
         if provider == .kiro {
             if let email = email, !email.isEmpty {
@@ -172,9 +172,25 @@ actor DirectAuthFileService {
         
         // Extract metadata
         var email = json["email"] as? String
-        // Copilot auth files written by CLIProxyAPI store the GitHub handle as
-        // "username"; older files may use "login".
-        let login = json["login"] as? String ?? json["username"] as? String
+        var login = json["login"] as? String
+        var legacyIdentityKeys: [String] = []
+        if provider == .copilot {
+            // Copilot auth files written by CLIProxyAPI store the GitHub handle as
+            // "username"; older files use "login". The precedence must match
+            // CopilotQuotaFetcher, otherwise the direct-auth item and the quota
+            // result key the same file differently and #404 comes back.
+            let rawLogin = json["login"] as? String
+            login = CopilotQuotaFetcher.canonicalIdentityField(
+                username: json["username"] as? String,
+                login: rawLogin
+            )
+            // Releases before this fix keyed the file by `login`; keep that value
+            // as a migration alias when `username` now wins.
+            if let rawLogin = rawLogin?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !rawLogin.isEmpty, rawLogin != login {
+                legacyIdentityKeys.append(rawLogin)
+            }
+        }
         let accountType = json["account_type"] as? String
         
         // For Kiro: if email is empty, try to use provider (e.g., "Google") as identifier
@@ -201,7 +217,8 @@ actor DirectAuthFileService {
             accountType: accountType,
             filePath: filePath,
             source: .cliProxyApi,
-            filename: filename
+            filename: filename,
+            legacyIdentityKeys: legacyIdentityKeys
         )
     }
     

--- a/Quotio/Services/DirectAuthFileService.swift
+++ b/Quotio/Services/DirectAuthFileService.swift
@@ -172,7 +172,9 @@ actor DirectAuthFileService {
         
         // Extract metadata
         var email = json["email"] as? String
-        let login = json["login"] as? String
+        // Copilot auth files written by CLIProxyAPI store the GitHub handle as
+        // "username"; older files may use "login".
+        let login = json["login"] as? String ?? json["username"] as? String
         let accountType = json["account_type"] as? String
         
         // For Kiro: if email is empty, try to use provider (e.g., "Google") as identifier

--- a/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
@@ -148,6 +148,8 @@ nonisolated struct CopilotAuthFile: Codable, Sendable {
     let tokenType: String?
     let scope: String?
     let username: String?
+    /// Older CLIProxyAPI releases stored the GitHub handle under `login`.
+    let login: String?
     let type: String?
 
     enum CodingKeys: String, CodingKey {
@@ -155,6 +157,7 @@ nonisolated struct CopilotAuthFile: Codable, Sendable {
         case tokenType = "token_type"
         case scope
         case username
+        case login
         case type
     }
 }
@@ -257,7 +260,7 @@ actor CopilotQuotaFetcher {
             for file in files where file.hasPrefix("github-copilot-") && file.hasSuffix(".json") {
                 let path = (authDir as NSString).appendingPathComponent(file)
                 guard let authFile = loadAuthFile(from: path) else { continue }
-                let key = authFile.username ?? extractUsername(from: file)
+                let key = quotaKey(filename: file, authFile: authFile)
                 if key == accountKey {
                     return await fetchQuota(accessToken: authFile.accessToken)
                 }
@@ -333,8 +336,7 @@ actor CopilotQuotaFetcher {
             let filePath = (expandedPath as NSString).appendingPathComponent(file)
             if let authFile = loadAuthFile(from: filePath),
                let quota = await fetchQuota(authFilePath: filePath) {
-                let key = authFile.username ?? extractUsername(from: file)
-                results[key] = quota
+                results[quotaKey(filename: file, authFile: authFile)] = quota
             }
         }
         
@@ -553,16 +555,48 @@ actor CopilotQuotaFetcher {
         return reconciled
     }
 
+    // MARK: - Canonical Account Identity
+
+    /// The canonical identity field of a Copilot account.
+    ///
+    /// This is the single source of truth for Copilot field precedence. CLIProxyAPI
+    /// writes the GitHub handle as `username`; older auth files and the management
+    /// API expose it as `login` / `account`. `username` wins because that is the
+    /// field `fetchAllCopilotQuotas` keys its results by — any call site that picks
+    /// a different field ends up keying the same auth file twice (#404).
+    nonisolated static func canonicalIdentityField(username: String?, login: String?) -> String? {
+        for candidate in [username, login] {
+            guard let value = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !value.isEmpty else { continue }
+            return value
+        }
+        return nil
+    }
+
+    /// The canonical quota key for one Copilot auth file: the identity field when
+    /// present, the `github-copilot-*` filename suffix otherwise. Returns `nil`
+    /// when neither is available so callers keep their own final fallback.
+    nonisolated static func canonicalAccountKey(
+        filename: String,
+        username: String?,
+        login: String? = nil
+    ) -> String? {
+        canonicalIdentityField(username: username, login: login) ?? filename.copilotFilenameKey
+    }
+
     /// Canonical key and legacy aliases for one Copilot auth file. The canonical
-    /// key matches the one `fetchAllCopilotQuotas` produces: JSON `username`
-    /// first, extracted filename suffix otherwise.
-    nonisolated static func accountIdentity(filename: String, username: String?) -> CopilotQuotaAccountIdentity {
+    /// key matches the one `fetchAllCopilotQuotas` produces.
+    nonisolated static func accountIdentity(
+        filename: String,
+        username: String?,
+        login: String? = nil
+    ) -> CopilotQuotaAccountIdentity {
         let filenameWithoutExtension = filename.hasSuffix(".json")
             ? String(filename.dropLast(".json".count))
             : filename
         let filenameKey = extractUsername(from: filename)
-        let trimmedUsername = username?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let canonicalKey = trimmedUsername.flatMap { $0.isEmpty ? nil : $0 } ?? filenameKey
+        let canonicalKey = canonicalAccountKey(filename: filename, username: username, login: login)
+            ?? filenameKey
         return CopilotQuotaAccountIdentity(
             canonicalKey: canonicalKey,
             aliases: [filename, filenameWithoutExtension, filenameKey]
@@ -577,8 +611,22 @@ actor CopilotQuotaFetcher {
         return files.compactMap { file in
             guard file.hasPrefix("github-copilot-"), file.hasSuffix(".json") else { return nil }
             let path = (expandedPath as NSString).appendingPathComponent(file)
-            return Self.accountIdentity(filename: file, username: loadAuthFile(from: path)?.username)
+            let authFile = loadAuthFile(from: path)
+            return Self.accountIdentity(
+                filename: file,
+                username: authFile?.username,
+                login: authFile?.login
+            )
         }
+    }
+
+    /// The quota key this fetcher stores results under for `filename`.
+    private func quotaKey(filename: String, authFile: CopilotAuthFile) -> String {
+        Self.canonicalAccountKey(
+            filename: filename,
+            username: authFile.username,
+            login: authFile.login
+        ) ?? extractUsername(from: filename)
     }
 
     // MARK: - Copilot Available Models

--- a/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
@@ -159,6 +159,15 @@ nonisolated struct CopilotAuthFile: Codable, Sendable {
     }
 }
 
+// MARK: - Copilot Account Identity
+
+/// Identity of one Copilot auth file: the canonical quota key plus the legacy
+/// keys older Quotio versions generated for the same file.
+nonisolated struct CopilotQuotaAccountIdentity: Sendable {
+    let canonicalKey: String
+    let aliases: [String]
+}
+
 // MARK: - Copilot API Token Response
 
 nonisolated struct CopilotAPITokenResponse: Codable, Sendable {
@@ -492,6 +501,10 @@ actor CopilotQuotaFetcher {
     }
     
     private func extractUsername(from filename: String) -> String {
+        Self.extractUsername(from: filename)
+    }
+
+    private nonisolated static func extractUsername(from filename: String) -> String {
         var name = filename
         if name.hasPrefix("github-copilot-") {
             name = String(name.dropFirst("github-copilot-".count))
@@ -500,6 +513,72 @@ actor CopilotQuotaFetcher {
             name = String(name.dropLast(".json".count))
         }
         return name
+    }
+
+    // MARK: - Legacy Alias Reconciliation
+
+    /// Collapses legacy quota keys left behind by older Quotio versions (full
+    /// filename or filename-derived suffix) onto the canonical account key, so a
+    /// single auth file yields exactly one quota entry.
+    func reconcileLegacyAliases(
+        in quotas: [String: ProviderQuotaData],
+        authDir: String = "~/.cli-proxy-api"
+    ) -> [String: ProviderQuotaData] {
+        Self.reconcileLegacyAliases(in: quotas, accounts: readAccountIdentities(authDir: authDir))
+    }
+
+    nonisolated static func reconcileLegacyAliases(
+        in quotas: [String: ProviderQuotaData],
+        accounts: [CopilotQuotaAccountIdentity]
+    ) -> [String: ProviderQuotaData] {
+        var reconciled = quotas
+        let canonicalKeys = Set(accounts.map(\.canonicalKey))
+        var canonicalKeysByAlias: [String: Set<String>] = [:]
+        for account in accounts {
+            for alias in account.aliases where alias != account.canonicalKey {
+                canonicalKeysByAlias[alias, default: []].insert(account.canonicalKey)
+            }
+        }
+
+        for (alias, candidates) in canonicalKeysByAlias {
+            guard let aliasQuota = reconciled[alias],
+                  !canonicalKeys.contains(alias),
+                  candidates.count == 1,
+                  let canonicalKey = candidates.first else { continue }
+            reconciled.removeValue(forKey: alias)
+            if reconciled[canonicalKey].map({ $0.lastUpdated <= aliasQuota.lastUpdated }) ?? true {
+                reconciled[canonicalKey] = aliasQuota
+            }
+        }
+        return reconciled
+    }
+
+    /// Canonical key and legacy aliases for one Copilot auth file. The canonical
+    /// key matches the one `fetchAllCopilotQuotas` produces: JSON `username`
+    /// first, extracted filename suffix otherwise.
+    nonisolated static func accountIdentity(filename: String, username: String?) -> CopilotQuotaAccountIdentity {
+        let filenameWithoutExtension = filename.hasSuffix(".json")
+            ? String(filename.dropLast(".json".count))
+            : filename
+        let filenameKey = extractUsername(from: filename)
+        let trimmedUsername = username?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let canonicalKey = trimmedUsername.flatMap { $0.isEmpty ? nil : $0 } ?? filenameKey
+        return CopilotQuotaAccountIdentity(
+            canonicalKey: canonicalKey,
+            aliases: [filename, filenameWithoutExtension, filenameKey]
+        )
+    }
+
+    private func readAccountIdentities(authDir: String) -> [CopilotQuotaAccountIdentity] {
+        let expandedPath = NSString(string: authDir).expandingTildeInPath
+        guard let files = try? FileManager.default.contentsOfDirectory(atPath: expandedPath) else {
+            return []
+        }
+        return files.compactMap { file in
+            guard file.hasPrefix("github-copilot-"), file.hasSuffix(".json") else { return nil }
+            let path = (expandedPath as NSString).appendingPathComponent(file)
+            return Self.accountIdentity(filename: file, username: loadAuthFile(from: path)?.username)
+        }
     }
 
     // MARK: - Copilot Available Models

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -1880,6 +1880,31 @@ final class QuotaViewModel {
         await refreshQuota(for: provider)
     }
 
+    /// Runs a provider-scoped Copilot refresh and reconciles the result.
+    ///
+    /// `MonitorRefreshCoordinator.refresh` merges `previous` into the fetcher
+    /// output, so reconciling only the fetcher output is not enough: a Copilot-only
+    /// refresh would re-store the stale filename key that the merge carried over.
+    /// The reconciliation therefore runs on the *merged* dictionary, matching what
+    /// `refreshQuotasDirectly` does for the full refresh (#404).
+    nonisolated static func refreshCopilotThroughCoordinator(
+        coordinator: MonitorRefreshCoordinator,
+        fetcher: CopilotQuotaFetcher,
+        previous: [String: ProviderQuotaData],
+        credentialAvailability: MonitorCredentialAvailability,
+        authDir: String = "~/.cli-proxy-api",
+        operation: @escaping @Sendable () async -> [String: ProviderQuotaData]
+    ) async -> [String: ProviderQuotaData] {
+        let merged = await coordinator.refresh(
+            provider: .copilot,
+            force: true,
+            previous: previous,
+            credentialAvailability: credentialAvailability,
+            operation: operation
+        )
+        return await fetcher.reconcileLegacyAliases(in: merged, authDir: authDir)
+    }
+
     private func refreshMonitorProvider(_ provider: AIProvider) async {
         let coordinator = monitorCoordinator
         let previous = providerQuotas[provider] ?? [:]
@@ -1920,7 +1945,12 @@ final class QuotaViewModel {
             }
         case .copilot:
             let fetcher = copilotFetcher
-            fresh = await coordinatedRefresh {
+            fresh = await Self.refreshCopilotThroughCoordinator(
+                coordinator: coordinator,
+                fetcher: fetcher,
+                previous: previous,
+                credentialAvailability: credentialAvailability
+            ) {
                 await fetcher.fetchAllCopilotQuotas(includeMonitorCredentials: true)
             }
         case .kiro:
@@ -2447,7 +2477,7 @@ final class QuotaViewModel {
                         filenameWithoutExtension,
                         file.filename.copilotFilenameKey,
                         file.email,
-                    ]
+                    ] + file.legacyIdentityKeys.map { $0 as String? }
                 )
             }
         }

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -739,7 +739,7 @@ final class QuotaViewModel {
 
         providerQuotas[.codex] = await codexFetcher.reconcileLegacyAliases(in: await codex)
         providerQuotas[.claude] = await claude
-        providerQuotas[.copilot] = await copilot
+        providerQuotas[.copilot] = await copilotQuotaFetcher.reconcileLegacyAliases(in: await copilot)
         providerQuotas[.kiro] = await kiro
         providerQuotas[.glm] = await glm
         providerQuotas[.clinePass] = await clinePass
@@ -2436,10 +2436,18 @@ final class QuotaViewModel {
                 )
             }
             for file in directAuthFiles where file.provider == .copilot {
+                let filenameWithoutExtension = file.filename.hasSuffix(".json")
+                    ? String(file.filename.dropLast(".json".count))
+                    : file.filename
                 addAliases(
                     provider: .copilot,
                     canonicalKey: file.menuBarAccountKey,
-                    aliases: [file.email]
+                    aliases: [
+                        file.filename,
+                        filenameWithoutExtension,
+                        file.filename.copilotFilenameKey,
+                        file.email,
+                    ]
                 )
             }
         }
@@ -2455,10 +2463,18 @@ final class QuotaViewModel {
             )
         }
         for file in authFiles where file.providerType == .copilot {
+            let filenameWithoutExtension = file.name.hasSuffix(".json")
+                ? String(file.name.dropLast(".json".count))
+                : file.name
             addAliases(
                 provider: .copilot,
                 canonicalKey: file.menuBarAccountKey,
-                aliases: [file.email]
+                aliases: [
+                    file.name,
+                    filenameWithoutExtension,
+                    file.name.copilotFilenameKey,
+                    file.email,
+                ]
             )
         }
 

--- a/QuotioTests/CopilotQuotaFetcherTests.swift
+++ b/QuotioTests/CopilotQuotaFetcherTests.swift
@@ -179,4 +179,121 @@ final class CopilotQuotaFetcherTests: XCTestCase {
 
         XCTAssertEqual(file.menuBarAccountKey, "marcosvrs")
     }
+
+    // MARK: - Canonical Field Precedence (shared rule)
+
+    // The parser and the fetcher must resolve the same file to the same field.
+    // CopilotQuotaFetcher keys quota results by JSON `username`, so `username`
+    // wins over `login` everywhere.
+    func testCanonicalIdentityFieldPrefersUsernameOverLogin() {
+        XCTAssertEqual(
+            CopilotQuotaFetcher.canonicalIdentityField(username: "marcosvrs", login: "marcos-legacy"),
+            "marcosvrs"
+        )
+        XCTAssertEqual(
+            CopilotQuotaFetcher.canonicalIdentityField(username: "   ", login: "marcos-legacy"),
+            "marcos-legacy"
+        )
+        XCTAssertNil(CopilotQuotaFetcher.canonicalIdentityField(username: nil, login: nil))
+    }
+
+    func testParsedAuthFileAndFetcherAgreeWhenLoginAndUsernameDiffer() async throws {
+        let directory = try Self.makeTemporaryAuthDirectory()
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+        try Self.writeCopilotAuthFile(
+            named: "github-copilot-work.json",
+            in: directory,
+            fields: ["username": "marcosvrs", "login": "marcos-legacy"]
+        )
+
+        let service = DirectAuthFileService(
+            authDirectory: URL(fileURLWithPath: directory, isDirectory: true)
+        )
+        let scanned = await service.scanAllAuthFiles()
+        let parsed = try XCTUnwrap(scanned.first)
+        let identity = CopilotQuotaFetcher.accountIdentity(
+            filename: "github-copilot-work.json",
+            username: "marcosvrs",
+            login: "marcos-legacy"
+        )
+
+        // One file, one key on both sides.
+        XCTAssertEqual(parsed.menuBarAccountKey, "marcosvrs")
+        XCTAssertEqual(identity.canonicalKey, "marcosvrs")
+        XCTAssertEqual(parsed.menuBarAccountKey, identity.canonicalKey)
+        // The field that used to win stays available for selection migration.
+        XCTAssertEqual(parsed.legacyIdentityKeys, ["marcos-legacy"])
+    }
+
+    // MARK: - Provider-Scoped Monitor Refresh
+
+    // Refreshing ONLY Copilot goes through MonitorRefreshCoordinator.refresh,
+    // which merges `previous` into the fetcher output. Reconciling the fetcher
+    // output alone is not enough — the merged dictionary is what gets stored, so
+    // the stale filename key would survive and #404 would come back for anyone
+    // who uses the per-provider refresh button.
+    func testScopedMonitorRefreshCollapsesStaleKeyFromCoordinatorMerge() async throws {
+        let directory = try Self.makeTemporaryAuthDirectory()
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+        try Self.writeCopilotAuthFile(
+            named: "github-copilot-marcosvrs.json",
+            in: directory,
+            fields: ["username": "marcosvrs"]
+        )
+
+        let staleDate = Date(timeIntervalSince1970: 1_000)
+        let freshDate = Date(timeIntervalSince1970: 2_000)
+        // Snapshot written by an older release, keyed by the full filename.
+        let previous = [
+            "github-copilot-marcosvrs.json": ProviderQuotaData(models: [], lastUpdated: staleDate),
+        ]
+        let fetched = ["marcosvrs": ProviderQuotaData(models: [], lastUpdated: freshDate)]
+
+        // Counterfactual: the coordinator merge on its own keeps BOTH keys.
+        let merged = await MonitorRefreshCoordinator().refresh(
+            provider: .copilot,
+            force: true,
+            previous: previous,
+            credentialAvailability: .present
+        ) {
+            fetched
+        }
+        XCTAssertEqual(Set(merged.keys), ["github-copilot-marcosvrs.json", "marcosvrs"])
+
+        // The production scoped-refresh path reconciles that merged result.
+        let scoped = await QuotaViewModel.refreshCopilotThroughCoordinator(
+            coordinator: MonitorRefreshCoordinator(),
+            fetcher: CopilotQuotaFetcher(),
+            previous: previous,
+            credentialAvailability: .present,
+            authDir: directory
+        ) {
+            fetched
+        }
+
+        XCTAssertEqual(Set(scoped.keys), ["marcosvrs"])
+        XCTAssertEqual(scoped["marcosvrs"]?.lastUpdated, freshDate)
+    }
+
+    // MARK: - Helpers
+
+    private static func makeTemporaryAuthDirectory() throws -> String {
+        let directory = NSTemporaryDirectory() + "quotio-copilot-tests-" + UUID().uuidString
+        try FileManager.default.createDirectory(
+            atPath: directory,
+            withIntermediateDirectories: true
+        )
+        return directory
+    }
+
+    private static func writeCopilotAuthFile(
+        named filename: String,
+        in directory: String,
+        fields: [String: String]
+    ) throws {
+        var json: [String: String] = ["type": "copilot", "access_token": "ghu_test"]
+        json.merge(fields) { _, new in new }
+        let data = try JSONSerialization.data(withJSONObject: json)
+        try data.write(to: URL(fileURLWithPath: (directory as NSString).appendingPathComponent(filename)))
+    }
 }

--- a/QuotioTests/CopilotQuotaFetcherTests.swift
+++ b/QuotioTests/CopilotQuotaFetcherTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+@testable import Quotio
+
+final class CopilotQuotaFetcherTests: XCTestCase {
+    // Issue #404: a single auth file (github-copilot-marcosvrs.json with
+    // username "marcosvrs") must resolve to exactly one quota entry, with every
+    // legacy key collapsing onto the canonical account key.
+    func testSingleAuthFileCollapsesLegacyKeysIntoOneEntry() {
+        let staleDate = Date(timeIntervalSince1970: 1_000)
+        let freshDate = Date(timeIntervalSince1970: 2_000)
+        let identity = CopilotQuotaFetcher.accountIdentity(
+            filename: "github-copilot-marcosvrs.json",
+            username: "marcosvrs"
+        )
+
+        let reconciled = CopilotQuotaFetcher.reconcileLegacyAliases(
+            in: [
+                "github-copilot-marcosvrs.json": ProviderQuotaData(models: [], lastUpdated: staleDate),
+                "github-copilot-marcosvrs": ProviderQuotaData(models: [], lastUpdated: staleDate),
+                "marcosvrs": ProviderQuotaData(models: [], lastUpdated: freshDate),
+            ],
+            accounts: [identity]
+        )
+
+        XCTAssertEqual(Set(reconciled.keys), ["marcosvrs"])
+        XCTAssertEqual(reconciled["marcosvrs"]?.lastUpdated, freshDate)
+    }
+
+    func testAccountIdentityPrefersUsernameOverFilenameSuffix() {
+        let identity = CopilotQuotaFetcher.accountIdentity(
+            filename: "github-copilot-work.json",
+            username: "marcosvrs"
+        )
+
+        XCTAssertEqual(identity.canonicalKey, "marcosvrs")
+        XCTAssertEqual(
+            Set(identity.aliases),
+            ["github-copilot-work.json", "github-copilot-work", "work"]
+        )
+    }
+
+    func testAccountIdentityFallsBackToFilenameSuffixWithoutUsername() {
+        let identity = CopilotQuotaFetcher.accountIdentity(
+            filename: "github-copilot-marcosvrs.json",
+            username: nil
+        )
+
+        XCTAssertEqual(identity.canonicalKey, "marcosvrs")
+    }
+
+    func testLegacyFilenameKeyMigratesWhenUsernameDiffersFromSuffix() {
+        let staleDate = Date(timeIntervalSince1970: 1_000)
+        let reconciled = CopilotQuotaFetcher.reconcileLegacyAliases(
+            in: [
+                "github-copilot-work.json": ProviderQuotaData(models: [], lastUpdated: staleDate),
+            ],
+            accounts: [
+                CopilotQuotaFetcher.accountIdentity(
+                    filename: "github-copilot-work.json",
+                    username: "marcosvrs"
+                ),
+            ]
+        )
+
+        XCTAssertEqual(Set(reconciled.keys), ["marcosvrs"])
+        XCTAssertEqual(reconciled["marcosvrs"]?.lastUpdated, staleDate)
+    }
+
+    func testReconciliationPreservesNewerCanonicalQuota() {
+        let staleDate = Date(timeIntervalSince1970: 1_000)
+        let freshDate = Date(timeIntervalSince1970: 2_000)
+        let reconciled = CopilotQuotaFetcher.reconcileLegacyAliases(
+            in: [
+                "marcosvrs": ProviderQuotaData(models: [], lastUpdated: freshDate),
+                "github-copilot-marcosvrs.json": ProviderQuotaData(models: [], lastUpdated: staleDate),
+            ],
+            accounts: [
+                CopilotQuotaFetcher.accountIdentity(
+                    filename: "github-copilot-marcosvrs.json",
+                    username: "marcosvrs"
+                ),
+            ]
+        )
+
+        XCTAssertEqual(Set(reconciled.keys), ["marcosvrs"])
+        XCTAssertEqual(reconciled["marcosvrs"]?.lastUpdated, freshDate)
+    }
+
+    func testReconciliationPromotesNewerLegacyQuota() {
+        let staleDate = Date(timeIntervalSince1970: 1_000)
+        let freshDate = Date(timeIntervalSince1970: 2_000)
+        let reconciled = CopilotQuotaFetcher.reconcileLegacyAliases(
+            in: [
+                "marcosvrs": ProviderQuotaData(models: [], lastUpdated: staleDate),
+                "github-copilot-marcosvrs.json": ProviderQuotaData(models: [], lastUpdated: freshDate),
+            ],
+            accounts: [
+                CopilotQuotaFetcher.accountIdentity(
+                    filename: "github-copilot-marcosvrs.json",
+                    username: "marcosvrs"
+                ),
+            ]
+        )
+
+        XCTAssertEqual(Set(reconciled.keys), ["marcosvrs"])
+        XCTAssertEqual(reconciled["marcosvrs"]?.lastUpdated, freshDate)
+    }
+
+    func testAliasMatchingAnotherAccountCanonicalKeyIsPreserved() {
+        let date = Date(timeIntervalSince1970: 1_000)
+        let quotas = [
+            "marcosvrs": ProviderQuotaData(models: [], lastUpdated: date),
+            "someone-else": ProviderQuotaData(models: [], lastUpdated: date),
+        ]
+
+        let reconciled = CopilotQuotaFetcher.reconcileLegacyAliases(
+            in: quotas,
+            accounts: [
+                // File whose suffix collides with another account's username.
+                CopilotQuotaFetcher.accountIdentity(
+                    filename: "github-copilot-marcosvrs.json",
+                    username: "someone-else"
+                ),
+                CopilotQuotaFetcher.accountIdentity(
+                    filename: "github-copilot-other.json",
+                    username: "marcosvrs"
+                ),
+            ]
+        )
+
+        XCTAssertEqual(Set(reconciled.keys), ["marcosvrs", "someone-else"])
+    }
+
+    func testAmbiguousAliasIsNotCollapsed() {
+        let date = Date(timeIntervalSince1970: 1_000)
+        let reconciled = CopilotQuotaFetcher.reconcileLegacyAliases(
+            in: [
+                "shared-alias": ProviderQuotaData(models: [], lastUpdated: date),
+            ],
+            accounts: [
+                CopilotQuotaAccountIdentity(canonicalKey: "first", aliases: ["shared-alias"]),
+                CopilotQuotaAccountIdentity(canonicalKey: "second", aliases: ["shared-alias"]),
+            ]
+        )
+
+        XCTAssertEqual(Set(reconciled.keys), ["shared-alias"])
+    }
+
+    func testDirectAuthFileMenuBarKeyIsCanonicalForUsernameField() {
+        // ~/.cli-proxy-api/github-copilot-marcosvrs.json stores the GitHub
+        // handle in "username"; DirectAuthFileService maps it to `login`.
+        let file = DirectAuthFile(
+            id: "/tmp/github-copilot-marcosvrs.json",
+            provider: .copilot,
+            email: nil,
+            login: "marcosvrs",
+            expired: nil,
+            accountType: nil,
+            filePath: "/tmp/github-copilot-marcosvrs.json",
+            source: .cliProxyApi,
+            filename: "github-copilot-marcosvrs.json"
+        )
+
+        XCTAssertEqual(file.menuBarAccountKey, "marcosvrs")
+    }
+
+    func testDirectAuthFileMenuBarKeyFallsBackToFilenameSuffix() {
+        let file = DirectAuthFile(
+            id: "/tmp/github-copilot-marcosvrs.json",
+            provider: .copilot,
+            email: nil,
+            login: nil,
+            expired: nil,
+            accountType: nil,
+            filePath: "/tmp/github-copilot-marcosvrs.json",
+            source: .cliProxyApi,
+            filename: "github-copilot-marcosvrs.json"
+        )
+
+        XCTAssertEqual(file.menuBarAccountKey, "marcosvrs")
+    }
+}


### PR DESCRIPTION
## Root cause

A single Copilot auth file (`~/.cli-proxy-api/github-copilot-marcosvrs.json`) could surface **two** menu bar entries keyed differently for the same account:

1. **Legacy keys survive forever.** Older Quotio versions keyed Copilot quota items by the full auth filename (`github-copilot-marcosvrs.json`). Those keys persist in the Monitor snapshot (`snapshots-v1.json`) and in `menuBarSelectedQuotaItems`, and `MonitorRefreshCoordinator.refresh` merges `previous` into every fresh result — so the stale filename key is never dropped even though the fetcher now produces the canonical `marcosvrs` key. Both keys then count as valid quota entries: prune keeps both, auto-select re-adds both, and the account list shows a duplicate quota-derived account. The mismatched count also permanently trips the "partial refresh" path (`fresh.count < previous.count`).
2. **Two discovery paths can still disagree on the key.** `DirectAuthFileService` read the GitHub handle from the JSON `login` field, but CLIProxyAPI Copilot auth files store it as `username` (the field `CopilotQuotaFetcher` uses). When the handle differs from the filename suffix, the scan and the fetcher generate different keys for the same file.

`migrateMenuBarSelections` already migrated Codex filename aliases (#435), but for Copilot it only registered `email` as an alias, so filename-keyed selections were never migrated.

## Fix

Mirrors the approach the repo already merged for Codex (#435 "deduplicate Codex quota items" and #444 "refresh matching legacy quota aliases"):

- **`CopilotQuotaFetcher.reconcileLegacyAliases(in:)`** (new, modeled on `CodexCLIQuotaFetcher.reconcileLegacyAliases`): collapses legacy quota keys (full filename, filename without `.json`, filename suffix) onto the canonical account key (`username` from JSON, filename suffix otherwise), keeping the freshest quota. Collapsing only happens when the alias maps unambiguously to exactly one canonical key and is not itself another account's canonical key. Applied in `refreshQuotasDirectly` right where the Codex reconciliation already runs, so the persisted snapshot self-heals on the next refresh.
- **`migrateMenuBarSelections`**: registers the filename-based aliases (full filename, filename without `.json`, filename suffix) for Copilot in both the direct-auth-file and proxy-auth-file loops — same alias set Codex uses — so existing `menuBarSelectedQuotaItems` plist entries under either legacy key migrate to the canonical key and deduplicate.
- **`DirectAuthFileService`**: reads the GitHub handle from `login` **or** `username`, aligning `menuBarAccountKey` with the key `CopilotQuotaFetcher` generates.
- **`AppBootstrap.resolveQuotaData`**: adds the Copilot filename-key fallback next to the existing `codexFilenameKey` fallback, so a not-yet-migrated legacy selection still resolves to the canonical quota entry.

## Tests

New `QuotioTests/CopilotQuotaFetcherTests.swift` (10 tests) reproducing the issue scenario:

- one auth file with a `username` field and quota entries under all three legacy keys reconciles to exactly one canonical entry with the freshest data;
- legacy filename key migrates even when `username` differs from the filename suffix;
- newer canonical data is preserved / newer legacy data is promoted;
- an alias colliding with another account's canonical key, or an ambiguous alias, is left untouched;
- `DirectAuthFile.menuBarAccountKey` resolves to the GitHub handle (or filename suffix) for `github-copilot-*.json` files.

Verification:

- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build` — **BUILD SUCCEEDED**
- `xcodebuild test -project Quotio.xcodeproj -scheme Quotio -destination 'platform=macOS'` — **TEST SUCCEEDED** (all suites, including the 10 new tests)

Fixes #404
