### PR TITLE
feat(logs): display provider in request log view

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -9659,6 +9659,34 @@
         }
       }
     },
+    "logs.provider.tooltip" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Served by %1$@ · request protocol: %2$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Servi par %1$@ · protocole de requête : %2$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Được phục vụ bởi %1$@ · giao thức yêu cầu: %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "由 %1$@ 提供服务 · 请求协议：%2$@"
+          }
+        }
+      }
+    },
     "logs.provider.unknown" : {
       "localizations" : {
         "en" : {

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -9659,6 +9659,34 @@
         }
       }
     },
+    "logs.provider.unknown" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unknown"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inconnu"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không rõ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知"
+          }
+        }
+      }
+    },
     "logs.requestsWillAppear" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Models/RequestLog.swift
+++ b/Quotio/Models/RequestLog.swift
@@ -163,26 +163,198 @@ nonisolated struct RequestLog: Identifiable, Codable, Hashable, Sendable {
     }
 }
 
+// MARK: - Request Protocol
+
+/// The wire protocol (API shape) a request was made in, derived from its endpoint path.
+///
+/// This is deliberately *not* the provider. `/v1/chat/completions` is the OpenAI-compatible
+/// protocol, and Qwen, GLM, DeepSeek, Grok and every `openai-compatibility` custom provider
+/// speak it too, so the path alone says nothing about which account served the request.
+nonisolated enum RequestProtocol: String, Codable, Hashable, Sendable {
+    case anthropic
+    case openai
+    case gemini
+
+    var displayName: String {
+        switch self {
+        case .anthropic: return "Anthropic"
+        case .openai: return "OpenAI"
+        case .gemini: return "Gemini"
+        }
+    }
+
+    /// The provider label recorded when the protocol is the only available signal.
+    /// These match the values historic logs already contain, so persisted rows keep rendering.
+    var providerLabel: String {
+        switch self {
+        case .anthropic: return "claude"
+        case .openai: return "openai"
+        case .gemini: return "gemini"
+        }
+    }
+
+    /// Detect the protocol from a request path.
+    static func detect(fromPath path: String) -> RequestProtocol? {
+        let lower = path.lowercased()
+
+        // Gemini first: its markers are the most specific, and a Gemini path embeds the model
+        // id (`/v1beta/models/claude-…:generateContent`), which would otherwise trip the
+        // Anthropic check below.
+        if lower.contains("/gemini/") || lower.contains("/google/")
+            || lower.contains("/v1beta/") || lower.contains(":generatecontent") {
+            return .gemini
+        }
+        if lower.contains("/anthropic/") || lower.contains("/claude") || lower.contains("/messages") {
+            return .anthropic
+        }
+        if lower.contains("/openai/") || lower.contains("/chat/completions")
+            || lower.contains("/responses") {
+            return .openai
+        }
+        return nil
+    }
+}
+
 // MARK: - Provider Derivation
 
 nonisolated extension RequestLog {
-    /// The provider that ultimately served the request.
-    /// Prefers the fallback-resolved provider, then the provider detected at request time,
-    /// then infers one from the model name so historical entries also display a provider.
-    var effectiveProvider: String? {
-        resolvedProvider ?? provider ?? Self.inferProvider(fromModel: resolvedModel ?? model)
+    /// Provider labels that only identify the request *protocol*, not who served it.
+    ///
+    /// `ProxyBridge` derives these from the endpoint path, so a stored `openai` may really be
+    /// Qwen, GLM, DeepSeek, Grok or any `openai-compatibility` provider sharing
+    /// `/v1/chat/completions`. Every other label (`kiro`, `github-copilot`, `antigravity`, …)
+    /// names a real provider and outranks model-name inference.
+    static let protocolOnlyProviderLabels: Set<String> = ["claude", "openai", "gemini"]
+
+    /// The protocol this request was made in, derived from its endpoint.
+    var requestProtocol: RequestProtocol? {
+        RequestProtocol.detect(fromPath: endpoint)
     }
 
-    /// Infer a provider identifier from a model name (e.g. "claude-sonnet-4-5" → "claude").
-    /// Returns nil when the model family is unknown.
-    static func inferProvider(fromModel model: String?) -> String? {
-        guard let model, !model.isEmpty else { return nil }
-        let lower = model.lowercased()
-
-        // Kiro first: resolved models like "kiro-claude-opus-4-5" must map to kiro, not claude
-        if lower.contains("kiro") || lower.contains("codewhisperer") {
-            return "kiro"
+    /// The provider that ultimately served the request.
+    ///
+    /// Precedence, applied identically here and in `ProxyBridge.extractMetadata` via
+    /// `deriveProvider(path:model:)`:
+    /// 1. `resolvedProvider` — the fallback chain records the `AIProvider` it actually dialled.
+    /// 2. A stored label that names a real provider or hosting aggregator. Copilot, Kiro and
+    ///    Antigravity serve other vendors' model families, so a model name cannot override them.
+    /// 3. The model family, the only signal that separates Qwen/GLM/DeepSeek/Grok from plain
+    ///    OpenAI on a shared `/v1/chat/completions` endpoint.
+    /// 4. The stored protocol label, so unclassifiable models still read as they did before.
+    var effectiveProvider: String? {
+        if let resolvedProvider, !resolvedProvider.isEmpty {
+            return Self.canonicalProviderID(resolvedProvider)
         }
+
+        let stored = provider.map(Self.canonicalProviderID).flatMap { $0.isEmpty ? nil : $0 }
+
+        if let stored, !Self.protocolOnlyProviderLabels.contains(stored) {
+            return stored
+        }
+        if let inferred = Self.inferProvider(fromModel: resolvedModel ?? model) {
+            return inferred
+        }
+        return stored
+    }
+
+    /// The provider recorded at capture time for a request, from its path and body model.
+    /// Single source of truth shared with `ProxyBridge.extractMetadata`.
+    static func deriveProvider(path: String, model: String?) -> String? {
+        // A provider-scoped path segment names the host outright; a model name cannot
+        // contradict it because aggregators serve other vendors' model families.
+        if let hosted = hostingProvider(fromPath: path) {
+            return hosted
+        }
+        if let inferred = inferProvider(fromModel: model) {
+            return inferred
+        }
+        // Nothing better than the protocol the endpoint speaks.
+        return RequestProtocol.detect(fromPath: path)?.providerLabel
+    }
+
+    /// Providers that can be identified from the path itself rather than from the API shape.
+    private static func hostingProvider(fromPath path: String) -> String? {
+        let lower = path.lowercased()
+        if lower.contains("/copilot/") {
+            return AIProvider.copilot.rawValue
+        }
+        if lower.contains("codewhisperer") || lower.contains("/kiro") {
+            return AIProvider.kiro.rawValue
+        }
+        return nil
+    }
+
+    /// Collapse the two vocabularies this field has historically carried — path labels such as
+    /// `copilot` and `AIProvider` raw values such as `github-copilot` — onto one identifier so
+    /// badge, filter, search and stats group the same requests together.
+    static func canonicalProviderID(_ raw: String) -> String {
+        let lower = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch lower {
+        case "copilot", "github-copilot": return AIProvider.copilot.rawValue
+        case "anthropic": return "claude"
+        case "google": return "gemini"
+        case "cline-pass", "clinepass": return AIProvider.clinePass.rawValue
+        case "factory-droid", "factorydroid": return AIProvider.factoryDroid.rawValue
+        default: return lower
+        }
+    }
+
+    /// Compact display label for a provider identifier.
+    static func displayName(forProvider provider: String) -> String {
+        let id = canonicalProviderID(provider)
+        switch id {
+        case "claude": return "Claude"
+        case "openai": return "OpenAI"
+        case "gemini": return "Gemini"
+        case "github-copilot": return "Copilot"
+        case "kiro": return "Kiro"
+        case "antigravity": return "Antigravity"
+        case "qwen": return "Qwen"
+        case "glm": return "GLM"
+        case "grok": return "Grok"
+        case "deepseek": return "DeepSeek"
+        case "kimi": return "Kimi"
+        case "minimax": return "MiniMax"
+        case "mimo": return "MiMo"
+        case "clinepass": return "ClinePass"
+        case "factory-droid": return "Factory"
+        default: return AIProvider(rawValue: id)?.displayName ?? id.capitalized
+        }
+    }
+
+    /// Infer the serving provider from a model id (e.g. "qwen3-coder-plus" → "qwen").
+    /// Returns nil when the model family is unknown — a guess would be worse than "Unknown".
+    static func inferProvider(fromModel model: String?) -> String? {
+        guard let model else { return nil }
+        let lower = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !lower.isEmpty else { return nil }
+
+        // 1. Hosting aggregators first — they serve other vendors' families under their own
+        //    prefix, so the family suffix must not win. Prefixes verified against the model
+        //    ids this app actually emits: CustomProviderSheet.clinePassModels ("cline-pass/…"),
+        //    FallbackModels docs and FallbackSheets.providerFromModel ("kiro-claude-…",
+        //    "gemini-claude-…" = Antigravity-hosted Claude).
+        if lower.hasPrefix("cline-pass/") || lower.hasPrefix("clinepass/") {
+            return AIProvider.clinePass.rawValue
+        }
+        if lower.contains("codewhisperer") {
+            return AIProvider.kiro.rawValue
+        }
+        if lower.hasPrefix("gemini-claude") {
+            return AIProvider.antigravity.rawValue
+        }
+
+        // 2. Explicit provider prefix, the same rule FallbackSheets.providerFromModel uses
+        //    for icons (e.g. "kiro-claude-opus-4-6-agentic" → kiro, "claude-sonnet-4-5" → claude).
+        for provider in AIProvider.allCases {
+            let key = provider.rawValue
+            if lower.hasPrefix(key + "-") || lower.hasPrefix(key + "_") || lower.hasPrefix(key + "/") {
+                return key
+            }
+        }
+
+        // 3. Model families. Anthropic and Gemini names, then the OpenAI-compatible families
+        //    that share `/v1/chat/completions` and are indistinguishable by endpoint.
         if ["claude", "opus", "sonnet", "haiku"].contains(where: lower.contains) {
             return "claude"
         }
@@ -193,17 +365,10 @@ nonisolated extension RequestLog {
             || lower.hasPrefix("o4") || lower.contains("codex") {
             return "openai"
         }
-        if lower.hasPrefix("qwen") {
-            return "qwen"
-        }
-        if lower.hasPrefix("glm") {
-            return "glm"
-        }
-        if lower.hasPrefix("grok") {
-            return "grok"
-        }
-        if lower.hasPrefix("deepseek") {
-            return "deepseek"
+        // Families seen in AvailableModel / CustomProviderSheet model lists.
+        for family in ["qwen", "glm", "grok", "deepseek", "kimi", "minimax", "mimo"]
+        where lower.hasPrefix(family) {
+            return family
         }
         return nil
     }
@@ -353,7 +518,7 @@ nonisolated struct RequestHistoryStore: Codable, Sendable {
             
             // Aggregate by model
             if let model = entry.model {
-                var data = modelData[model] ?? (entry.provider, 0, 0, 0, 0)
+                var data = modelData[model] ?? (entry.effectiveProvider, 0, 0, 0, 0)
                 data.count += 1
                 data.input += entry.inputTokens ?? 0
                 data.output += entry.outputTokens ?? 0

--- a/Quotio/Models/RequestLog.swift
+++ b/Quotio/Models/RequestLog.swift
@@ -163,6 +163,52 @@ nonisolated struct RequestLog: Identifiable, Codable, Hashable, Sendable {
     }
 }
 
+// MARK: - Provider Derivation
+
+nonisolated extension RequestLog {
+    /// The provider that ultimately served the request.
+    /// Prefers the fallback-resolved provider, then the provider detected at request time,
+    /// then infers one from the model name so historical entries also display a provider.
+    var effectiveProvider: String? {
+        resolvedProvider ?? provider ?? Self.inferProvider(fromModel: resolvedModel ?? model)
+    }
+
+    /// Infer a provider identifier from a model name (e.g. "claude-sonnet-4-5" → "claude").
+    /// Returns nil when the model family is unknown.
+    static func inferProvider(fromModel model: String?) -> String? {
+        guard let model, !model.isEmpty else { return nil }
+        let lower = model.lowercased()
+
+        // Kiro first: resolved models like "kiro-claude-opus-4-5" must map to kiro, not claude
+        if lower.contains("kiro") || lower.contains("codewhisperer") {
+            return "kiro"
+        }
+        if ["claude", "opus", "sonnet", "haiku"].contains(where: lower.contains) {
+            return "claude"
+        }
+        if lower.hasPrefix("gemini") || lower.hasPrefix("models/gemini") {
+            return "gemini"
+        }
+        if lower.hasPrefix("gpt") || lower.hasPrefix("o1") || lower.hasPrefix("o3")
+            || lower.hasPrefix("o4") || lower.contains("codex") {
+            return "openai"
+        }
+        if lower.hasPrefix("qwen") {
+            return "qwen"
+        }
+        if lower.hasPrefix("glm") {
+            return "glm"
+        }
+        if lower.hasPrefix("grok") {
+            return "grok"
+        }
+        if lower.hasPrefix("deepseek") {
+            return "deepseek"
+        }
+        return nil
+    }
+}
+
 // MARK: - Aggregate Statistics
 
 /// Aggregated statistics for request history
@@ -296,7 +342,7 @@ nonisolated struct RequestHistoryStore: Codable, Sendable {
             }
             
             // Aggregate by provider
-            if let provider = entry.provider {
+            if let provider = entry.effectiveProvider {
                 var data = providerData[provider] ?? (0, 0, 0, 0)
                 data.count += 1
                 data.input += entry.inputTokens ?? 0

--- a/Quotio/Services/Proxy/ProxyBridge.swift
+++ b/Quotio/Services/Proxy/ProxyBridge.swift
@@ -611,33 +611,19 @@ final class ProxyBridge {
     // MARK: - Metadata Extraction
     
     private nonisolated func extractMetadata(method: String, path: String, body: String) -> (provider: String?, model: String?, method: String, path: String) {
-        // Detect provider from path
-        var provider: String?
-        if path.contains("/anthropic/") || path.contains("/claude") {
-            provider = "claude"
-        } else if path.contains("/gemini/") || path.contains("/google/") {
-            provider = "gemini"
-        } else if path.contains("/openai/") || path.contains("/chat/completions") {
-            provider = "openai"
-        } else if path.contains("/copilot/") {
-            provider = "copilot"
-        } else if path.contains("codewhisperer") || path.contains("kiro") {
-            provider = "kiro"
-        }
-        
         // Extract model from JSON body
         var model: String?
         if let bodyData = body.data(using: .utf8),
            let json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any],
            let modelValue = json["model"] as? String {
             model = modelValue
-            
-            // Infer provider from model name if not already detected
-            if provider == nil {
-                provider = RequestLog.inferProvider(fromModel: modelValue)
-            }
         }
-        
+
+        // The path only reveals the API protocol for the shared endpoints
+        // (`/v1/chat/completions`, `/v1/messages`, …), so the body model decides the provider
+        // there. See `RequestLog.deriveProvider(path:model:)` for the full precedence.
+        let provider = RequestLog.deriveProvider(path: path, model: model)
+
         return (provider, model, method, path)
     }
     

--- a/Quotio/Services/Proxy/ProxyBridge.swift
+++ b/Quotio/Services/Proxy/ProxyBridge.swift
@@ -634,15 +634,7 @@ final class ProxyBridge {
             
             // Infer provider from model name if not already detected
             if provider == nil {
-                if FallbackFormatConverter.isClaudeModel(modelValue) {
-                    provider = "claude"
-                } else if modelValue.hasPrefix("gemini") || modelValue.hasPrefix("models/gemini") {
-                    provider = "gemini"
-                } else if modelValue.hasPrefix("gpt") || modelValue.hasPrefix("o1") || modelValue.hasPrefix("o3") {
-                    provider = "openai"
-                } else if modelValue.contains("kiro") || modelValue.contains("codewhisperer") {
-                    provider = "kiro"
-                }
+                provider = RequestLog.inferProvider(fromModel: modelValue)
             }
         }
         

--- a/Quotio/Services/RequestTracker.swift
+++ b/Quotio/Services/RequestTracker.swift
@@ -137,7 +137,8 @@ final class RequestTracker {
     
     /// Get requests filtered by provider
     func requests(for provider: String) -> [RequestLog] {
-        requestHistory.filter { $0.provider == provider }
+        let target = RequestLog.canonicalProviderID(provider)
+        return requestHistory.filter { $0.effectiveProvider == target }
     }
     
     /// Get requests from last N minutes

--- a/Quotio/Views/Screens/LogsScreen.swift
+++ b/Quotio/Views/Screens/LogsScreen.swift
@@ -153,7 +153,7 @@ struct LogsScreen: View {
                 Text("logs.filter.allProviders".localized()).tag(nil as String?)
                 Divider()
                 ForEach(Array(stats.byProvider.keys.sorted()), id: \.self) { provider in
-                    Text(provider.capitalized).tag(provider as String?)
+                    Text(RequestLog.displayName(forProvider: provider)).tag(provider as String?)
                 }
             }
             .pickerStyle(.menu)
@@ -317,7 +317,7 @@ struct RequestRow: View {
 
                 // Provider Badge
                 providerBadge
-                    .frame(width: 90, alignment: .leading)
+                    .frame(width: 104, alignment: .leading)
 
                 // Model with Fallback Route
                 VStack(alignment: .leading, spacing: 2) {
@@ -448,7 +448,7 @@ struct RequestRow: View {
     @ViewBuilder
     private var providerBadge: some View {
         if let provider = request.effectiveProvider {
-            Text(provider.capitalized)
+            Text(RequestLog.displayName(forProvider: provider))
                 .font(.system(.caption2, weight: .semibold))
                 .foregroundStyle(providerColor(provider))
                 .padding(.horizontal, 6)
@@ -456,6 +456,7 @@ struct RequestRow: View {
                 .background(providerColor(provider).opacity(0.15))
                 .clipShape(RoundedRectangle(cornerRadius: 4))
                 .lineLimit(1)
+                .help(providerTooltip(for: provider))
         } else {
             Text("logs.provider.unknown".localized())
                 .font(.caption2)
@@ -463,17 +464,24 @@ struct RequestRow: View {
         }
     }
 
+    /// Spells out that the badge is the serving provider while the endpoint only fixes the
+    /// protocol — the two differ whenever a non-OpenAI model uses `/v1/chat/completions`.
+    private func providerTooltip(for provider: String) -> String {
+        let name = RequestLog.displayName(forProvider: provider)
+        guard let requestProtocol = request.requestProtocol else { return name }
+        return String(format: "logs.provider.tooltip".localized(), name, requestProtocol.displayName)
+    }
+
     private func providerColor(_ provider: String) -> Color {
-        switch provider.lowercased() {
-        case "claude": return .orange
-        case "gemini": return .blue
+        let id = RequestLog.canonicalProviderID(provider)
+        if let known = AIProvider(rawValue: id) {
+            return known.color
+        }
+        switch id {
         case "openai": return .green
-        case "copilot": return .green
-        case "kiro": return .purple
-        case "qwen": return .purple
-        case "glm": return .blue
-        case "grok": return .primary
+        case "gemini": return .blue
         case "deepseek": return .indigo
+        case "kimi", "minimax", "mimo": return .teal
         default: return .gray
         }
     }

--- a/Quotio/Views/Screens/LogsScreen.swift
+++ b/Quotio/Views/Screens/LogsScreen.swift
@@ -167,12 +167,12 @@ struct LogsScreen: View {
         var requests = viewModel.requestTracker.requestHistory
         
         if let provider = requestFilterProvider {
-            requests = requests.filter { $0.provider == provider }
+            requests = requests.filter { $0.effectiveProvider == provider }
         }
-        
+
         if !searchText.isEmpty {
             requests = requests.filter {
-                ($0.provider?.localizedCaseInsensitiveContains(searchText) ?? false) ||
+                ($0.effectiveProvider?.localizedCaseInsensitiveContains(searchText) ?? false) ||
                 ($0.model?.localizedCaseInsensitiveContains(searchText) ?? false) ||
                 ($0.endpoint.localizedCaseInsensitiveContains(searchText))
             }
@@ -315,40 +315,32 @@ struct RequestRow: View {
                 // Status Badge
                 statusBadge
 
-                // Provider & Model with Fallback Route
+                // Provider Badge
+                providerBadge
+                    .frame(width: 90, alignment: .leading)
+
+                // Model with Fallback Route
                 VStack(alignment: .leading, spacing: 2) {
                     if request.hasFallbackRoute {
                         // Show fallback route: virtual model → resolved model
+                        Text(request.model ?? "unknown")
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .foregroundStyle(.orange)
                         HStack(spacing: 4) {
-                            Text(request.model ?? "unknown")
-                                .font(.caption)
-                                .fontWeight(.medium)
-                                .foregroundStyle(.orange)
                             Image(systemName: "arrow.right")
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
-                            Text(request.resolvedProvider?.capitalized ?? "")
-                                .font(.caption)
-                                .fontWeight(.medium)
-                                .foregroundStyle(.blue)
-                        }
-                        Text(request.resolvedModel ?? "")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    } else {
-                        // Normal display
-                        if let provider = request.provider {
-                            Text(provider.capitalized)
-                                .font(.caption)
-                                .fontWeight(.medium)
-                        }
-                        if let model = request.model {
-                            Text(model)
+                            Text(request.resolvedModel ?? "")
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
                         }
+                    } else if let model = request.model {
+                        Text(model)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
                     }
                 }
                 .frame(width: 180, alignment: .leading)
@@ -451,6 +443,39 @@ struct RequestRow: View {
             }
         }
         .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var providerBadge: some View {
+        if let provider = request.effectiveProvider {
+            Text(provider.capitalized)
+                .font(.system(.caption2, weight: .semibold))
+                .foregroundStyle(providerColor(provider))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(providerColor(provider).opacity(0.15))
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .lineLimit(1)
+        } else {
+            Text("logs.provider.unknown".localized())
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    private func providerColor(_ provider: String) -> Color {
+        switch provider.lowercased() {
+        case "claude": return .orange
+        case "gemini": return .blue
+        case "openai": return .green
+        case "copilot": return .green
+        case "kiro": return .purple
+        case "qwen": return .purple
+        case "glm": return .blue
+        case "grok": return .primary
+        case "deepseek": return .indigo
+        default: return .gray
+        }
     }
 
     private var statusBadge: some View {

--- a/QuotioTests/RequestLogProviderTests.swift
+++ b/QuotioTests/RequestLogProviderTests.swift
@@ -4,6 +4,92 @@ import XCTest
 @MainActor
 final class RequestLogProviderTests: XCTestCase {
 
+    // MARK: - Protocol Detection
+
+    func testProtocolDetectionSeparatesProtocolFromProvider() {
+        XCTAssertEqual(RequestProtocol.detect(fromPath: "/v1/chat/completions"), .openai)
+        XCTAssertEqual(RequestProtocol.detect(fromPath: "/v1/responses"), .openai)
+        XCTAssertEqual(RequestProtocol.detect(fromPath: "/v1/messages"), .anthropic)
+        XCTAssertEqual(RequestProtocol.detect(fromPath: "/anthropic/v1/messages"), .anthropic)
+        XCTAssertEqual(
+            RequestProtocol.detect(fromPath: "/v1beta/models/gemini-2.5-pro:generateContent"),
+            .gemini
+        )
+        // A Gemini path embeds the model id; it must not be read as the Anthropic protocol.
+        XCTAssertEqual(
+            RequestProtocol.detect(fromPath: "/v1beta/models/claude-sonnet-4-5:generateContent"),
+            .gemini
+        )
+        XCTAssertNil(RequestProtocol.detect(fromPath: "/v1/models"))
+    }
+
+    // MARK: - Endpoint + Model Combinations (capture time)
+
+    /// The reviewer's scenario: OpenAI-compatible endpoints are shared, so the model decides.
+    func testOpenAICompatibleEndpointUsesModelFamilyNotProtocol() {
+        XCTAssertEqual(deriveProvider(path: "/v1/chat/completions", model: "qwen3-coder-plus"), "qwen")
+        XCTAssertEqual(deriveProvider(path: "/v1/chat/completions", model: "glm-4.6"), "glm")
+        XCTAssertEqual(deriveProvider(path: "/v1/chat/completions", model: "grok-4"), "grok")
+        XCTAssertEqual(deriveProvider(path: "/v1/chat/completions", model: "deepseek-chat"), "deepseek")
+        XCTAssertEqual(deriveProvider(path: "/v1/chat/completions", model: "kimi-k3"), "kimi")
+    }
+
+    func testGenuineOpenAIRequestsStillReadAsOpenAI() {
+        XCTAssertEqual(deriveProvider(path: "/v1/chat/completions", model: "gpt-5.2"), "openai")
+        XCTAssertEqual(deriveProvider(path: "/v1/responses", model: "gpt-5.1-codex"), "openai")
+        XCTAssertEqual(deriveProvider(path: "/v1/chat/completions", model: "o3-mini"), "openai")
+    }
+
+    func testAnthropicAndGeminiEndpoints() {
+        XCTAssertEqual(deriveProvider(path: "/v1/messages", model: "claude-sonnet-4-5"), "claude")
+        XCTAssertEqual(
+            deriveProvider(path: "/v1beta/models/gemini-2.5-pro:generateContent", model: nil),
+            "gemini"
+        )
+    }
+
+    /// Aggregators serve other vendors' model families, so a provider-scoped path outranks
+    /// the model name (the reviewer's Copilot / Antigravity caveat).
+    func testHostingAggregatorInPathOutranksModelFamily() {
+        XCTAssertEqual(
+            deriveProvider(path: "/copilot/v1/chat/completions", model: "claude-3.5-sonnet"),
+            AIProvider.copilot.rawValue
+        )
+        XCTAssertEqual(
+            deriveProvider(path: "/kiro/v1/messages", model: "claude-sonnet-4-5"),
+            AIProvider.kiro.rawValue
+        )
+    }
+
+    /// Antigravity hosts Claude under a `gemini-claude-` prefix
+    /// (Quotio/Models/AgentModels.swift, Quotio/Views/Components/FallbackSheets.swift).
+    func testAntigravityHostedClaudeModelIsNotReportedAsClaude() {
+        XCTAssertEqual(
+            deriveProvider(path: "/v1/chat/completions", model: "gemini-claude-opus-4-6-thinking"),
+            AIProvider.antigravity.rawValue
+        )
+    }
+
+    /// ClinePass model ids are namespaced (Quotio/Views/Components/CustomProviderSheet.swift).
+    func testClinePassHostedModelsResolveToTheAggregator() {
+        XCTAssertEqual(
+            deriveProvider(path: "/v1/chat/completions", model: "cline-pass/qwen3.7-max"),
+            AIProvider.clinePass.rawValue
+        )
+        XCTAssertEqual(
+            deriveProvider(path: "/v1/chat/completions", model: "cline-pass/deepseek-v4-pro"),
+            AIProvider.clinePass.rawValue
+        )
+    }
+
+    /// When the model family is unknown the protocol label is the best available answer,
+    /// which keeps behaviour identical to the previous release for those rows.
+    func testUnknownModelFallsBackToProtocolLabel() {
+        XCTAssertEqual(deriveProvider(path: "/v1/chat/completions", model: "totally-unknown"), "openai")
+        XCTAssertEqual(deriveProvider(path: "/v1/messages", model: nil), "claude")
+        XCTAssertNil(deriveProvider(path: "/v1/models", model: nil))
+    }
+
     // MARK: - Model Name Inference
 
     func testInferProviderFromClaudeModels() {
@@ -69,30 +155,102 @@ final class RequestLogProviderTests: XCTestCase {
         XCTAssertNil(log.effectiveProvider)
     }
 
-    // MARK: - Stats Aggregation
+    // MARK: - Already-Persisted Rows
+
+    /// Rows written before this change stored the protocol label. They must re-rank on read.
+    func testPersistedProtocolLabelIsOverriddenByModelFamily() {
+        let legacy = makeLog(provider: "openai", model: "qwen3-coder-plus", endpoint: "/v1/chat/completions")
+        XCTAssertEqual(legacy.effectiveProvider, "qwen")
+        XCTAssertEqual(RequestLog.displayName(forProvider: legacy.effectiveProvider ?? ""), "Qwen")
+    }
+
+    func testPersistedProtocolLabelSurvivesForGenuineOpenAIRows() {
+        let legacy = makeLog(provider: "openai", model: "gpt-5.2", endpoint: "/v1/chat/completions")
+        XCTAssertEqual(legacy.effectiveProvider, "openai")
+    }
+
+    func testPersistedAggregatorLabelIsNotOverriddenByModelFamily() {
+        // Old path detection stored the bare "copilot" label; it still outranks the model name
+        // and canonicalises onto the same id as the AIProvider raw value.
+        let legacy = makeLog(provider: "copilot", model: "claude-3.5-sonnet", endpoint: "/copilot/v1/chat/completions")
+        XCTAssertEqual(legacy.effectiveProvider, AIProvider.copilot.rawValue)
+        XCTAssertEqual(RequestLog.displayName(forProvider: legacy.effectiveProvider ?? ""), "Copilot")
+    }
+
+    func testPersistedRowDecodedFromDiskReRanksProvider() throws {
+        let stored = makeLog(provider: "openai", model: "glm-4.6", endpoint: "/v1/chat/completions")
+        let data = try JSONEncoder().encode(stored)
+        let decoded = try JSONDecoder().decode(RequestLog.self, from: data)
+
+        XCTAssertEqual(decoded.provider, "openai", "raw stored value is untouched")
+        XCTAssertEqual(decoded.effectiveProvider, "glm", "display value re-ranks on read")
+    }
+
+    // MARK: - Badge, Filter, Search, Stats
+
+    /// End-to-end for the reviewer's exact case: `/v1/chat/completions` + `qwen3-coder-plus`.
+    func testQwenOverOpenAIEndpointReachesBadgeFilterSearchAndStats() {
+        let metadata = deriveProvider(path: "/v1/chat/completions", model: "qwen3-coder-plus")
+        let log = makeLog(provider: metadata, model: "qwen3-coder-plus", endpoint: "/v1/chat/completions")
+
+        // Badge
+        XCTAssertEqual(log.effectiveProvider, "qwen")
+        XCTAssertEqual(RequestLog.displayName(forProvider: log.effectiveProvider ?? ""), "Qwen")
+
+        // Filter (mirrors LogsScreen.filteredRequests)
+        XCTAssertTrue([log].filter { $0.effectiveProvider == "qwen" }.count == 1)
+        XCTAssertTrue([log].filter { $0.effectiveProvider == "openai" }.isEmpty)
+
+        // Search (mirrors LogsScreen.filteredRequests)
+        XCTAssertTrue(matchesSearch(log, "qwen"))
+        XCTAssertFalse(matchesSearch(log, "openai"))
+
+        // Stats
+        var store = RequestHistoryStore.empty
+        store.addEntry(log)
+        let stats = store.calculateStats()
+        XCTAssertEqual(stats.byProvider["qwen"]?.requestCount, 1)
+        XCTAssertNil(stats.byProvider["openai"])
+    }
 
     func testStatsAggregateByEffectiveProvider() {
         var store = RequestHistoryStore.empty
         // provider is nil but derivable from model name
         store.addEntry(makeLog(provider: nil, model: "glm-4.6"))
         store.addEntry(makeLog(provider: "claude", model: "claude-sonnet-4-5"))
+        // legacy protocol-labelled row for a non-OpenAI family
+        store.addEntry(makeLog(provider: "openai", model: "deepseek-chat", endpoint: "/v1/chat/completions"))
 
         let stats = store.calculateStats()
         XCTAssertEqual(stats.byProvider["glm"]?.requestCount, 1)
         XCTAssertEqual(stats.byProvider["claude"]?.requestCount, 1)
+        XCTAssertEqual(stats.byProvider["deepseek"]?.requestCount, 1)
+        XCTAssertNil(stats.byProvider["openai"])
     }
 
     // MARK: - Helpers
+
+    private func deriveProvider(path: String, model: String?) -> String? {
+        RequestLog.deriveProvider(path: path, model: model)
+    }
+
+    /// Mirrors the search predicate in `LogsScreen.filteredRequests`.
+    private func matchesSearch(_ log: RequestLog, _ text: String) -> Bool {
+        (log.effectiveProvider?.localizedCaseInsensitiveContains(text) ?? false) ||
+        (log.model?.localizedCaseInsensitiveContains(text) ?? false) ||
+        log.endpoint.localizedCaseInsensitiveContains(text)
+    }
 
     private func makeLog(
         provider: String?,
         model: String?,
         resolvedModel: String? = nil,
-        resolvedProvider: String? = nil
+        resolvedProvider: String? = nil,
+        endpoint: String = "/v1/messages"
     ) -> RequestLog {
         RequestLog(
             method: "POST",
-            endpoint: "/v1/messages",
+            endpoint: endpoint,
             provider: provider,
             model: model,
             resolvedModel: resolvedModel,

--- a/QuotioTests/RequestLogProviderTests.swift
+++ b/QuotioTests/RequestLogProviderTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import Quotio
+
+@MainActor
+final class RequestLogProviderTests: XCTestCase {
+
+    // MARK: - Model Name Inference
+
+    func testInferProviderFromClaudeModels() {
+        XCTAssertEqual(RequestLog.inferProvider(fromModel: "claude-sonnet-4-5"), "claude")
+        XCTAssertEqual(RequestLog.inferProvider(fromModel: "claude-opus-4-5"), "claude")
+        XCTAssertEqual(RequestLog.inferProvider(fromModel: "Claude-Haiku-4-5"), "claude")
+    }
+
+    func testInferProviderFromKiroModelsBeforeClaude() {
+        // Kiro-resolved models embed a Claude model name and must still map to kiro
+        XCTAssertEqual(RequestLog.inferProvider(fromModel: "kiro-claude-opus-4-5-agentic"), "kiro")
+        XCTAssertEqual(RequestLog.inferProvider(fromModel: "codewhisperer-model"), "kiro")
+    }
+
+    func testInferProviderFromGeminiModels() {
+        XCTAssertEqual(RequestLog.inferProvider(fromModel: "gemini-2.5-pro"), "gemini")
+        XCTAssertEqual(RequestLog.inferProvider(fromModel: "models/gemini-2.0-flash"), "gemini")
+    }
+
+    func testInferProviderFromOpenAIModels() {
+        XCTAssertEqual(RequestLog.inferProvider(fromModel: "gpt-5.2"), "openai")
+        XCTAssertEqual(RequestLog.inferProvider(fromModel: "o3-mini"), "openai")
+        XCTAssertEqual(RequestLog.inferProvider(fromModel: "gpt-5.1-codex"), "openai")
+    }
+
+    func testInferProviderFromOtherModelFamilies() {
+        XCTAssertEqual(RequestLog.inferProvider(fromModel: "qwen3-coder-plus"), "qwen")
+        XCTAssertEqual(RequestLog.inferProvider(fromModel: "glm-4.6"), "glm")
+        XCTAssertEqual(RequestLog.inferProvider(fromModel: "grok-4"), "grok")
+        XCTAssertEqual(RequestLog.inferProvider(fromModel: "deepseek-chat"), "deepseek")
+    }
+
+    func testInferProviderReturnsNilForUnknownOrEmptyModel() {
+        XCTAssertNil(RequestLog.inferProvider(fromModel: "totally-unknown-model"))
+        XCTAssertNil(RequestLog.inferProvider(fromModel: ""))
+        XCTAssertNil(RequestLog.inferProvider(fromModel: nil))
+    }
+
+    // MARK: - Effective Provider
+
+    func testEffectiveProviderPrefersResolvedProvider() {
+        let log = makeLog(provider: "claude", model: "quotio-auto", resolvedModel: "kiro-claude-opus-4-5", resolvedProvider: "kiro")
+        XCTAssertEqual(log.effectiveProvider, "kiro")
+    }
+
+    func testEffectiveProviderFallsBackToDetectedProvider() {
+        let log = makeLog(provider: "gemini", model: "gemini-2.5-pro")
+        XCTAssertEqual(log.effectiveProvider, "gemini")
+    }
+
+    func testEffectiveProviderInfersFromModelWhenProviderMissing() {
+        let log = makeLog(provider: nil, model: "qwen3-coder-plus")
+        XCTAssertEqual(log.effectiveProvider, "qwen")
+    }
+
+    func testEffectiveProviderInfersFromResolvedModelFirst() {
+        let log = makeLog(provider: nil, model: "unknown-virtual", resolvedModel: "gemini-2.5-pro")
+        XCTAssertEqual(log.effectiveProvider, "gemini")
+    }
+
+    func testEffectiveProviderIsNilWhenNothingCanBeDerived() {
+        let log = makeLog(provider: nil, model: nil)
+        XCTAssertNil(log.effectiveProvider)
+    }
+
+    // MARK: - Stats Aggregation
+
+    func testStatsAggregateByEffectiveProvider() {
+        var store = RequestHistoryStore.empty
+        // provider is nil but derivable from model name
+        store.addEntry(makeLog(provider: nil, model: "glm-4.6"))
+        store.addEntry(makeLog(provider: "claude", model: "claude-sonnet-4-5"))
+
+        let stats = store.calculateStats()
+        XCTAssertEqual(stats.byProvider["glm"]?.requestCount, 1)
+        XCTAssertEqual(stats.byProvider["claude"]?.requestCount, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makeLog(
+        provider: String?,
+        model: String?,
+        resolvedModel: String? = nil,
+        resolvedProvider: String? = nil
+    ) -> RequestLog {
+        RequestLog(
+            method: "POST",
+            endpoint: "/v1/messages",
+            provider: provider,
+            model: model,
+            resolvedModel: resolvedModel,
+            resolvedProvider: resolvedProvider,
+            durationMs: 100,
+            statusCode: 200
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #238

The Requests tab of the Logs screen did not reliably show which provider each request went to: the provider label was tucked inside the model column and was blank whenever detection missed (Qwen, GLM, Grok, DeepSeek, and any request whose path/model was not recognized), and fallback rows only showed the resolved provider inline.

### Before
- Provider text stacked inside the model column, often empty because `RequestLog.provider` was frequently `nil`.
- Provider filter and search only matched the raw stored `provider` field, so entries with a missing provider could never be filtered.

### After
- A dedicated, color-coded **provider badge column** on every request row (shows a localized "Unknown" placeholder when nothing can be derived).
- Provider is now derived in the model layer via `RequestLog.effectiveProvider`:
  `resolvedProvider` (fallback routing) → detected `provider` → inference from the model name (`RequestLog.inferProvider(fromModel:)`). This also fills the provider for previously persisted history entries.
- `ProxyBridge` reuses the same shared inference, which extends detection to Qwen/GLM/Grok/DeepSeek models and fixes resolved Kiro models (`kiro-claude-*`) being misclassified as Claude.
- The provider filter picker, search, and per-provider stats now all use the derived provider, so the column, filter, and stats stay consistent.
- New localization key `logs.provider.unknown` added for en, fr, vi, zh-Hans.

## Changes

- `Quotio/Models/RequestLog.swift` — `effectiveProvider` + `inferProvider(fromModel:)` derivation; per-provider stats aggregate on the derived provider.
- `Quotio/Services/Proxy/ProxyBridge.swift` — replace inline model-name inference with the shared helper.
- `Quotio/Views/Screens/LogsScreen.swift` — provider badge column in `RequestRow`; filter/search use the derived provider.
- `Quotio/Localizable.xcstrings` — `logs.provider.unknown` (en/fr/vi/zh-Hans).
- `QuotioTests/RequestLogProviderTests.swift` — 12 unit tests for the derivation (precedence, model-family inference, kiro-before-claude ordering, unknown fallback, stats aggregation).

## Testing

- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build` — **BUILD SUCCEEDED**
- `xcodebuild test -project Quotio.xcodeproj -scheme Quotio -destination 'platform=macOS'` — **TEST SUCCEEDED** (all existing suites plus 12 new `RequestLogProviderTests` pass)
