### PR TITLE
feat(auth): preserve unknown JSON fields in auth file structs

### DIFF
--- a/Quotio/Models/JSONValue.swift
+++ b/Quotio/Models/JSONValue.swift
@@ -15,12 +15,29 @@ import Foundation
 /// decode → modify → encode cycle instead of being silently dropped.
 nonisolated indirect enum JSONValue: Codable, Equatable, Sendable {
     case string(String)
-    case int(Int)
+    /// Any JSON number Foundation can materialize exactly.
+    ///
+    /// `Decimal` is used rather than `Int`/`Double` because it is a base-10 type:
+    /// it keeps integers larger than `Int64.max` (e.g. `9223372036854775809`) and
+    /// decimal fractions (e.g. `0.1`) byte-identical across a decode → encode cycle,
+    /// where `Double` would round them to the nearest binary value.
+    case number(Decimal)
+    /// Finite literals outside `Decimal`'s exponent range (roughly |exponent| > 128)
+    /// but still representable as `Double`, e.g. `1e308`.
     case double(Double)
     case bool(Bool)
     case object([String: JSONValue])
     case array([JSONValue])
     case null
+
+    /// Thrown when a JSON number literal falls outside every numeric type Foundation
+    /// can materialize (e.g. `1e400`, which overflows both `Decimal` and `Double`).
+    ///
+    /// RFC 8259 §6 explicitly allows a parser to limit the range it accepts, and
+    /// Foundation does: `JSONDecoder` reports "not representable in Swift" and
+    /// `JSONSerialization` rejects the whole document. Unknown fields carrying such a
+    /// literal are therefore skipped instead of aborting the auth-file decode.
+    nonisolated struct UnrepresentableNumberError: Error, Equatable {}
 
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
@@ -28,9 +45,9 @@ nonisolated indirect enum JSONValue: Codable, Equatable, Sendable {
             self = .null
         } else if let value = try? container.decode(Bool.self) {
             self = .bool(value)
-        } else if let value = try? container.decode(Int.self) {
-            self = .int(value)
-        } else if let value = try? container.decode(Double.self) {
+        } else if let value = try? container.decode(Decimal.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(Double.self), value.isFinite {
             self = .double(value)
         } else if let value = try? container.decode(String.self) {
             self = .string(value)
@@ -39,10 +56,7 @@ nonisolated indirect enum JSONValue: Codable, Equatable, Sendable {
         } else if let value = try? container.decode([JSONValue].self) {
             self = .array(value)
         } else {
-            throw DecodingError.dataCorruptedError(
-                in: container,
-                debugDescription: "Unsupported JSON value"
-            )
+            throw UnrepresentableNumberError()
         }
     }
 
@@ -50,7 +64,7 @@ nonisolated indirect enum JSONValue: Codable, Equatable, Sendable {
         var container = encoder.singleValueContainer()
         switch self {
         case .string(let value): try container.encode(value)
-        case .int(let value): try container.encode(value)
+        case .number(let value): try container.encode(value)
         case .double(let value): try container.encode(value)
         case .bool(let value): try container.encode(value)
         case .object(let value): try container.encode(value)
@@ -79,11 +93,19 @@ nonisolated extension JSONValue {
     ///
     /// Call from a custom `init(from:)` after decoding the typed fields to
     /// capture unrecognized fields so they can be re-emitted on encode.
+    ///
+    /// A field carrying a number literal Foundation cannot represent is skipped
+    /// rather than propagated, so one exotic unknown value can never make an auth
+    /// file undecodable and break token refresh.
     static func unknownFields(from decoder: Decoder, excluding knownKeys: Set<String>) throws -> [String: JSONValue] {
         let container = try decoder.container(keyedBy: JSONCodingKey.self)
         var fields: [String: JSONValue] = [:]
         for key in container.allKeys where !knownKeys.contains(key.stringValue) {
-            fields[key.stringValue] = try container.decode(JSONValue.self, forKey: key)
+            do {
+                fields[key.stringValue] = try container.decode(JSONValue.self, forKey: key)
+            } catch is UnrepresentableNumberError {
+                continue
+            }
         }
         return fields
     }

--- a/Quotio/Models/JSONValue.swift
+++ b/Quotio/Models/JSONValue.swift
@@ -1,0 +1,99 @@
+//
+//  JSONValue.swift
+//  Quotio - CLIProxyAPI GUI Wrapper
+//
+//  Type-safe representation of arbitrary JSON values, used to preserve
+//  unknown fields when auth files are decoded, modified, and re-encoded.
+//
+
+import Foundation
+
+/// A type-safe representation of any JSON value.
+///
+/// Auth file structs use this as a catch-all so fields Quotio does not model
+/// (e.g. fields added by newer CLIProxyAPI versions) survive a
+/// decode → modify → encode cycle instead of being silently dropped.
+nonisolated indirect enum JSONValue: Codable, Equatable, Sendable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case object([String: JSONValue])
+    case array([JSONValue])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([String: JSONValue].self) {
+            self = .object(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported JSON value"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value): try container.encode(value)
+        case .int(let value): try container.encode(value)
+        case .double(let value): try container.encode(value)
+        case .bool(let value): try container.encode(value)
+        case .object(let value): try container.encode(value)
+        case .array(let value): try container.encode(value)
+        case .null: try container.encodeNil()
+        }
+    }
+}
+
+/// A dynamic coding key used to read/write arbitrary top-level JSON keys.
+nonisolated struct JSONCodingKey: CodingKey, Sendable {
+    let stringValue: String
+    let intValue: Int? = nil
+
+    init(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    init?(intValue: Int) {
+        return nil
+    }
+}
+
+nonisolated extension JSONValue {
+    /// Decodes every top-level key not listed in `knownKeys` from `decoder`.
+    ///
+    /// Call from a custom `init(from:)` after decoding the typed fields to
+    /// capture unrecognized fields so they can be re-emitted on encode.
+    static func unknownFields(from decoder: Decoder, excluding knownKeys: Set<String>) throws -> [String: JSONValue] {
+        let container = try decoder.container(keyedBy: JSONCodingKey.self)
+        var fields: [String: JSONValue] = [:]
+        for key in container.allKeys where !knownKeys.contains(key.stringValue) {
+            fields[key.stringValue] = try container.decode(JSONValue.self, forKey: key)
+        }
+        return fields
+    }
+
+    /// Re-encodes previously captured unknown fields alongside the typed fields.
+    static func encodeUnknownFields(_ fields: [String: JSONValue], to encoder: Encoder) throws {
+        guard !fields.isEmpty else { return }
+        var container = encoder.container(keyedBy: JSONCodingKey.self)
+        for (key, value) in fields {
+            try container.encode(value, forKey: JSONCodingKey(stringValue: key))
+        }
+    }
+}

--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -546,8 +546,10 @@ nonisolated struct AntigravityAuthFile: Codable, Sendable {
     var prefix: String?
     var projectId: String?
     var proxyUrl: String?
+    /// Catch-all for fields Quotio does not model, so they survive decode → encode cycles.
+    var additionalFields: [String: JSONValue] = [:]
 
-    enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case accessToken = "access_token"
         case email
         case expired
@@ -558,6 +560,38 @@ nonisolated struct AntigravityAuthFile: Codable, Sendable {
         case prefix
         case projectId = "project_id"
         case proxyUrl = "proxy_url"
+    }
+
+    private static let knownJSONKeys = Set(CodingKeys.allCases.map(\.stringValue))
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        accessToken = try container.decode(String.self, forKey: .accessToken)
+        email = try container.decode(String.self, forKey: .email)
+        expired = try container.decodeIfPresent(String.self, forKey: .expired)
+        expiresIn = try container.decodeIfPresent(Int.self, forKey: .expiresIn)
+        refreshToken = try container.decodeIfPresent(String.self, forKey: .refreshToken)
+        timestamp = try container.decodeIfPresent(Int.self, forKey: .timestamp)
+        type = try container.decodeIfPresent(String.self, forKey: .type)
+        prefix = try container.decodeIfPresent(String.self, forKey: .prefix)
+        projectId = try container.decodeIfPresent(String.self, forKey: .projectId)
+        proxyUrl = try container.decodeIfPresent(String.self, forKey: .proxyUrl)
+        additionalFields = try JSONValue.unknownFields(from: decoder, excluding: Self.knownJSONKeys)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(accessToken, forKey: .accessToken)
+        try container.encode(email, forKey: .email)
+        try container.encodeIfPresent(expired, forKey: .expired)
+        try container.encodeIfPresent(expiresIn, forKey: .expiresIn)
+        try container.encodeIfPresent(refreshToken, forKey: .refreshToken)
+        try container.encodeIfPresent(timestamp, forKey: .timestamp)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(prefix, forKey: .prefix)
+        try container.encodeIfPresent(projectId, forKey: .projectId)
+        try container.encodeIfPresent(proxyUrl, forKey: .proxyUrl)
+        try JSONValue.encodeUnknownFields(additionalFields, to: encoder)
     }
 
     nonisolated var isExpired: Bool {

--- a/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
@@ -13,11 +13,31 @@ nonisolated struct CodexCLIAuthFile: Codable, Sendable {
     var OPENAI_API_KEY: String?
     var tokens: CodexCLITokens?
     var lastRefresh: String?
-    
-    enum CodingKeys: String, CodingKey {
+    /// Catch-all for fields Quotio does not model, so they survive decode → encode cycles.
+    var additionalFields: [String: JSONValue] = [:]
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case OPENAI_API_KEY
         case tokens
         case lastRefresh = "last_refresh"
+    }
+
+    private static let knownJSONKeys = Set(CodingKeys.allCases.map(\.stringValue))
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        OPENAI_API_KEY = try container.decodeIfPresent(String.self, forKey: .OPENAI_API_KEY)
+        tokens = try container.decodeIfPresent(CodexCLITokens.self, forKey: .tokens)
+        lastRefresh = try container.decodeIfPresent(String.self, forKey: .lastRefresh)
+        additionalFields = try JSONValue.unknownFields(from: decoder, excluding: Self.knownJSONKeys)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(OPENAI_API_KEY, forKey: .OPENAI_API_KEY)
+        try container.encodeIfPresent(tokens, forKey: .tokens)
+        try container.encodeIfPresent(lastRefresh, forKey: .lastRefresh)
+        try JSONValue.encodeUnknownFields(additionalFields, to: encoder)
     }
 }
 
@@ -26,12 +46,34 @@ nonisolated struct CodexCLITokens: Codable, Sendable {
     var accessToken: String?
     var refreshToken: String?
     var accountId: String?
-    
-    enum CodingKeys: String, CodingKey {
+    /// Catch-all for fields Quotio does not model, so they survive decode → encode cycles.
+    var additionalFields: [String: JSONValue] = [:]
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case idToken = "id_token"
         case accessToken = "access_token"
         case refreshToken = "refresh_token"
         case accountId = "account_id"
+    }
+
+    private static let knownJSONKeys = Set(CodingKeys.allCases.map(\.stringValue))
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        idToken = try container.decodeIfPresent(String.self, forKey: .idToken)
+        accessToken = try container.decodeIfPresent(String.self, forKey: .accessToken)
+        refreshToken = try container.decodeIfPresent(String.self, forKey: .refreshToken)
+        accountId = try container.decodeIfPresent(String.self, forKey: .accountId)
+        additionalFields = try JSONValue.unknownFields(from: decoder, excluding: Self.knownJSONKeys)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(idToken, forKey: .idToken)
+        try container.encodeIfPresent(accessToken, forKey: .accessToken)
+        try container.encodeIfPresent(refreshToken, forKey: .refreshToken)
+        try container.encodeIfPresent(accountId, forKey: .accountId)
+        try JSONValue.encodeUnknownFields(additionalFields, to: encoder)
     }
 }
 

--- a/Quotio/Services/QuotaFetchers/OpenAIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/OpenAIQuotaFetcher.swift
@@ -293,8 +293,10 @@ nonisolated struct CodexAuthFile: Codable, Sendable {
     // Fields preserved during token refresh (used by CLIProxyAPI)
     var prefix: String?
     var proxyUrl: String?
-    
-    enum CodingKeys: String, CodingKey {
+    /// Catch-all for fields Quotio does not model, so they survive decode → encode cycles.
+    var additionalFields: [String: JSONValue] = [:]
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case accessToken = "access_token"
         case accountId = "account_id"
         case email
@@ -305,7 +307,37 @@ nonisolated struct CodexAuthFile: Codable, Sendable {
         case prefix
         case proxyUrl = "proxy_url"
     }
-    
+
+    private static let knownJSONKeys = Set(CodingKeys.allCases.map(\.stringValue))
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        accessToken = try container.decode(String.self, forKey: .accessToken)
+        accountId = try container.decodeIfPresent(String.self, forKey: .accountId)
+        email = try container.decodeIfPresent(String.self, forKey: .email)
+        expired = try container.decodeIfPresent(String.self, forKey: .expired)
+        idToken = try container.decodeIfPresent(String.self, forKey: .idToken)
+        refreshToken = try container.decodeIfPresent(String.self, forKey: .refreshToken)
+        type = try container.decodeIfPresent(String.self, forKey: .type)
+        prefix = try container.decodeIfPresent(String.self, forKey: .prefix)
+        proxyUrl = try container.decodeIfPresent(String.self, forKey: .proxyUrl)
+        additionalFields = try JSONValue.unknownFields(from: decoder, excluding: Self.knownJSONKeys)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(accessToken, forKey: .accessToken)
+        try container.encodeIfPresent(accountId, forKey: .accountId)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(expired, forKey: .expired)
+        try container.encodeIfPresent(idToken, forKey: .idToken)
+        try container.encodeIfPresent(refreshToken, forKey: .refreshToken)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(prefix, forKey: .prefix)
+        try container.encodeIfPresent(proxyUrl, forKey: .proxyUrl)
+        try JSONValue.encodeUnknownFields(additionalFields, to: encoder)
+    }
+
     nonisolated var isExpired: Bool {
         guard let expired = expired else { return true }
         let formatter = ISO8601DateFormatter()

--- a/QuotioTests/AuthFileUnknownFieldsTests.swift
+++ b/QuotioTests/AuthFileUnknownFieldsTests.swift
@@ -177,6 +177,144 @@ final class AuthFileUnknownFieldsTests: XCTestCase {
         assertUnknownFieldsPreserved(in: output)
     }
 
+    // MARK: - Numeric fidelity on the native Codex Keychain refresh path
+
+    /// Mirrors `CodexCLIQuotaFetcher.persistNativeKeychainRefresh`: decode the whole
+    /// credential blob, swap the rotated tokens, re-encode the whole blob.
+    private func simulateNativeKeychainRefresh(_ record: Data) throws -> Data {
+        var auth = try JSONDecoder().decode(CodexCLIAuthFile.self, from: record)
+        var tokens = try XCTUnwrap(auth.tokens)
+        tokens.accessToken = "new-access"
+        tokens.refreshToken = "new-refresh"
+        tokens.idToken = "new-id"
+        auth.tokens = tokens
+        return try JSONEncoder().encode(auth)
+    }
+
+    /// An unknown integer larger than `Int64.max` must survive the refresh unchanged.
+    /// Narrowing to `Double` would rewrite it as `9.223372036854776e+18`.
+    func testNativeKeychainRefreshPreservesIntegerBeyondInt64() throws {
+        let json = """
+        {
+            "OPENAI_API_KEY": "sk-test",
+            "last_refresh": "2026-01-01T00:00:00Z",
+            "tokens": {
+                "id_token": "old-id",
+                "access_token": "old-access",
+                "refresh_token": "old-refresh",
+                "account_id": "acct-1",
+                "token_serial": 9223372036854775809
+            },
+            "install_id": 9223372036854775809,
+            "ratio": 0.1
+        }
+        """.data(using: .utf8)!
+
+        let refreshed = try simulateNativeKeychainRefresh(json)
+        let text = String(decoding: refreshed, as: UTF8.self)
+
+        XCTAssertTrue(text.contains("\"install_id\":9223372036854775809"), text)
+        XCTAssertTrue(text.contains("\"token_serial\":9223372036854775809"), text)
+        XCTAssertFalse(text.contains("9.223372036854776e+18"), text)
+        // Base-10 fractions keep their literal form too.
+        XCTAssertTrue(text.contains("\"ratio\":0.1"), text)
+
+        // The refresh itself still did its job.
+        let output = try jsonObject(refreshed)
+        XCTAssertEqual(output["OPENAI_API_KEY"] as? String, "sk-test")
+        XCTAssertEqual(output["last_refresh"] as? String, "2026-01-01T00:00:00Z")
+        let tokens = try XCTUnwrap(output["tokens"] as? NSDictionary)
+        XCTAssertEqual(tokens["access_token"] as? String, "new-access")
+        XCTAssertEqual(tokens["refresh_token"] as? String, "new-refresh")
+        XCTAssertEqual(tokens["id_token"] as? String, "new-id")
+        XCTAssertEqual(tokens["account_id"] as? String, "acct-1")
+    }
+
+    /// A literal such as `1e400` overflows every numeric type Foundation can build.
+    /// It must not abort the decode — token refresh has to keep working, and every
+    /// other unknown field has to survive.
+    func testNativeKeychainRefreshSurvivesUnrepresentableExponent() throws {
+        let json = """
+        {
+            "OPENAI_API_KEY": "sk-test",
+            "last_refresh": "2026-01-01T00:00:00Z",
+            "tokens": {
+                "id_token": "old-id",
+                "access_token": "old-access",
+                "refresh_token": "old-refresh",
+                "account_id": "acct-1",
+                "overflowing_token_field": 1e400,
+                "kept_token_field": "keep-me"
+            },
+            "overflowing": 1e400,
+            "underflowing": 1e-400,
+            "kept": "still-here",
+            "install_id": 9223372036854775809
+        }
+        """.data(using: .utf8)!
+
+        let refreshed = try simulateNativeKeychainRefresh(json)
+        let output = try jsonObject(refreshed)
+
+        // Refresh completed and unrelated fields are untouched.
+        XCTAssertEqual(output["OPENAI_API_KEY"] as? String, "sk-test")
+        XCTAssertEqual(output["last_refresh"] as? String, "2026-01-01T00:00:00Z")
+        XCTAssertEqual(output["kept"] as? String, "still-here")
+        XCTAssertTrue(
+            String(decoding: refreshed, as: UTF8.self).contains("\"install_id\":9223372036854775809"),
+            String(decoding: refreshed, as: UTF8.self)
+        )
+
+        let tokens = try XCTUnwrap(output["tokens"] as? NSDictionary)
+        XCTAssertEqual(tokens["access_token"] as? String, "new-access")
+        XCTAssertEqual(tokens["refresh_token"] as? String, "new-refresh")
+        XCTAssertEqual(tokens["id_token"] as? String, "new-id")
+        XCTAssertEqual(tokens["kept_token_field"] as? String, "keep-me")
+
+        // Values Foundation cannot represent are dropped, never fatal.
+        XCTAssertNil(output["overflowing"])
+        XCTAssertNil(output["underflowing"])
+        XCTAssertNil(tokens["overflowing_token_field"])
+    }
+
+    // MARK: - JSONValue numeric representation
+
+    func testJSONValueRepresentsNumbersAsDecimalWithoutNarrowing() throws {
+        let json = """
+        {
+            "beyond_int64": 9223372036854775809,
+            "beyond_uint64": 18446744073709551616,
+            "fraction": 0.1,
+            "integral": 3,
+            "beyond_decimal_exponent": 1e308,
+            "numeric_string": "123",
+            "flag": true
+        }
+        """.data(using: .utf8)!
+
+        let values = try JSONDecoder().decode([String: JSONValue].self, from: json)
+
+        XCTAssertEqual(values["beyond_int64"], .number(Decimal(string: "9223372036854775809")!))
+        XCTAssertEqual(values["beyond_uint64"], .number(Decimal(string: "18446744073709551616")!))
+        XCTAssertEqual(values["fraction"], .number(Decimal(string: "0.1")!))
+        XCTAssertEqual(values["integral"], .number(3))
+        // Outside Decimal's exponent range but finite: Double keeps it rather than dropping it.
+        XCTAssertEqual(values["beyond_decimal_exponent"], .double(1e308))
+        // Numbers must not swallow string/bool literals.
+        XCTAssertEqual(values["numeric_string"], .string("123"))
+        XCTAssertEqual(values["flag"], .bool(true))
+    }
+
+    func testJSONValueReportsUnrepresentableNumbersDistinctly() throws {
+        let json = "{\"v\":1e400}".data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode([String: JSONValue].self, from: json)) { error in
+            XCTAssertTrue(
+                error is JSONValue.UnrepresentableNumberError,
+                "expected UnrepresentableNumberError, got \(error)"
+            )
+        }
+    }
+
     // MARK: - Full-fidelity round trip
 
     func testRoundTripWithoutModificationIsLossless() throws {

--- a/QuotioTests/AuthFileUnknownFieldsTests.swift
+++ b/QuotioTests/AuthFileUnknownFieldsTests.swift
@@ -1,0 +1,196 @@
+import XCTest
+@testable import Quotio
+
+/// Verifies that auth file structs preserve JSON fields Quotio does not model
+/// across a decode → modify → encode cycle (issue #239).
+final class AuthFileUnknownFieldsTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func jsonObject(_ data: Data) throws -> NSDictionary {
+        try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? NSDictionary)
+    }
+
+    /// Unknown fields covering every JSON shape: string, int, double, bool,
+    /// null, array, and nested object.
+    private let unknownFieldsFragment = """
+        "custom_header": "X-Custom: value",
+        "retry_count": 3,
+        "weight": 0.75,
+        "experimental": true,
+        "deprecated_field": null,
+        "tags": ["alpha", "beta", 42],
+        "metadata": {
+            "base_url": "https://example.com",
+            "nested": {"depth": 2},
+            "flags": [true, false]
+        }
+    """
+
+    private func assertUnknownFieldsPreserved(in output: NSDictionary, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(output["custom_header"] as? String, "X-Custom: value", file: file, line: line)
+        XCTAssertEqual(output["retry_count"] as? Int, 3, file: file, line: line)
+        XCTAssertEqual(output["weight"] as? Double, 0.75, file: file, line: line)
+        XCTAssertEqual(output["experimental"] as? Bool, true, file: file, line: line)
+        XCTAssertTrue(output["deprecated_field"] is NSNull, file: file, line: line)
+        XCTAssertEqual(output["tags"] as? NSArray, ["alpha", "beta", 42] as NSArray, file: file, line: line)
+        let metadata = output["metadata"] as? NSDictionary
+        XCTAssertEqual(metadata?["base_url"] as? String, "https://example.com", file: file, line: line)
+        XCTAssertEqual(metadata?["nested"] as? NSDictionary, ["depth": 2] as NSDictionary, file: file, line: line)
+        XCTAssertEqual(metadata?["flags"] as? NSArray, [true, false] as NSArray, file: file, line: line)
+    }
+
+    // MARK: - AntigravityAuthFile
+
+    func testAntigravityAuthFilePreservesUnknownFieldsAcrossRoundTrip() throws {
+        let json = """
+        {
+            "access_token": "old-token",
+            "email": "user@example.com",
+            "expired": "2026-01-01T00:00:00Z",
+            "expires_in": 3599,
+            "refresh_token": "refresh-123",
+            "timestamp": 1767225600000,
+            "type": "antigravity",
+            "prefix": "myprefix",
+            "project_id": "my-project",
+            "proxy_url": "http://127.0.0.1:8080",
+            \(unknownFieldsFragment)
+        }
+        """.data(using: .utf8)!
+
+        var authFile = try JSONDecoder().decode(AntigravityAuthFile.self, from: json)
+
+        // Simulate a token refresh mutating the typed fields.
+        authFile.accessToken = "new-token"
+        authFile.expired = "2026-06-01T00:00:00Z"
+
+        let output = try jsonObject(try JSONEncoder().encode(authFile))
+
+        // Typed updates applied.
+        XCTAssertEqual(output["access_token"] as? String, "new-token")
+        XCTAssertEqual(output["expired"] as? String, "2026-06-01T00:00:00Z")
+
+        // Known fields intact (incl. the PR #210 fields).
+        XCTAssertEqual(output["email"] as? String, "user@example.com")
+        XCTAssertEqual(output["expires_in"] as? Int, 3599)
+        XCTAssertEqual(output["refresh_token"] as? String, "refresh-123")
+        XCTAssertEqual(output["timestamp"] as? Int, 1_767_225_600_000)
+        XCTAssertEqual(output["type"] as? String, "antigravity")
+        XCTAssertEqual(output["prefix"] as? String, "myprefix")
+        XCTAssertEqual(output["project_id"] as? String, "my-project")
+        XCTAssertEqual(output["proxy_url"] as? String, "http://127.0.0.1:8080")
+
+        // Unknown fields survived.
+        assertUnknownFieldsPreserved(in: output)
+    }
+
+    func testAntigravityAuthFileDecodesKnownFieldsWithoutUnknownFields() throws {
+        let json = """
+        {"access_token": "token", "email": "user@example.com"}
+        """.data(using: .utf8)!
+
+        let authFile = try JSONDecoder().decode(AntigravityAuthFile.self, from: json)
+        XCTAssertEqual(authFile.accessToken, "token")
+        XCTAssertEqual(authFile.email, "user@example.com")
+        XCTAssertTrue(authFile.additionalFields.isEmpty)
+
+        // Encoding without unknown fields emits only the known keys.
+        let output = try jsonObject(try JSONEncoder().encode(authFile))
+        XCTAssertEqual(output, ["access_token": "token", "email": "user@example.com"] as NSDictionary)
+    }
+
+    // MARK: - CodexAuthFile
+
+    func testCodexAuthFilePreservesUnknownFieldsAcrossRoundTrip() throws {
+        let json = """
+        {
+            "access_token": "old-token",
+            "account_id": "acct-1",
+            "email": "user@example.com",
+            "expired": "2026-01-01T00:00:00Z",
+            "id_token": "id-token",
+            "refresh_token": "refresh-123",
+            "type": "codex",
+            "prefix": "myprefix",
+            "proxy_url": "http://127.0.0.1:8080",
+            \(unknownFieldsFragment)
+        }
+        """.data(using: .utf8)!
+
+        var authFile = try JSONDecoder().decode(CodexAuthFile.self, from: json)
+        authFile.accessToken = "new-token"
+
+        let output = try jsonObject(try JSONEncoder().encode(authFile))
+
+        XCTAssertEqual(output["access_token"] as? String, "new-token")
+        XCTAssertEqual(output["account_id"] as? String, "acct-1")
+        XCTAssertEqual(output["email"] as? String, "user@example.com")
+        XCTAssertEqual(output["expired"] as? String, "2026-01-01T00:00:00Z")
+        XCTAssertEqual(output["id_token"] as? String, "id-token")
+        XCTAssertEqual(output["refresh_token"] as? String, "refresh-123")
+        XCTAssertEqual(output["type"] as? String, "codex")
+        XCTAssertEqual(output["prefix"] as? String, "myprefix")
+        XCTAssertEqual(output["proxy_url"] as? String, "http://127.0.0.1:8080")
+
+        assertUnknownFieldsPreserved(in: output)
+    }
+
+    // MARK: - CodexCLIAuthFile (native Codex CLI credential)
+
+    func testCodexCLIAuthFilePreservesUnknownFieldsIncludingNestedTokens() throws {
+        let json = """
+        {
+            "OPENAI_API_KEY": "sk-test",
+            "last_refresh": "2026-01-01T00:00:00Z",
+            "tokens": {
+                "id_token": "id-token",
+                "access_token": "old-token",
+                "refresh_token": "refresh-123",
+                "account_id": "acct-1",
+                "future_token_field": "keep-me"
+            },
+            \(unknownFieldsFragment)
+        }
+        """.data(using: .utf8)!
+
+        var authFile = try JSONDecoder().decode(CodexCLIAuthFile.self, from: json)
+
+        // Simulate the keychain refresh path mutating nested tokens.
+        var tokens = try XCTUnwrap(authFile.tokens)
+        tokens.accessToken = "new-token"
+        tokens.refreshToken = "refresh-456"
+        authFile.tokens = tokens
+
+        let output = try jsonObject(try JSONEncoder().encode(authFile))
+
+        XCTAssertEqual(output["OPENAI_API_KEY"] as? String, "sk-test")
+        XCTAssertEqual(output["last_refresh"] as? String, "2026-01-01T00:00:00Z")
+
+        let outputTokens = try XCTUnwrap(output["tokens"] as? NSDictionary)
+        XCTAssertEqual(outputTokens["access_token"] as? String, "new-token")
+        XCTAssertEqual(outputTokens["refresh_token"] as? String, "refresh-456")
+        XCTAssertEqual(outputTokens["id_token"] as? String, "id-token")
+        XCTAssertEqual(outputTokens["account_id"] as? String, "acct-1")
+        XCTAssertEqual(outputTokens["future_token_field"] as? String, "keep-me")
+
+        assertUnknownFieldsPreserved(in: output)
+    }
+
+    // MARK: - Full-fidelity round trip
+
+    func testRoundTripWithoutModificationIsLossless() throws {
+        let json = """
+        {
+            "access_token": "token",
+            "email": "user@example.com",
+            \(unknownFieldsFragment)
+        }
+        """.data(using: .utf8)!
+
+        let authFile = try JSONDecoder().decode(AntigravityAuthFile.self, from: json)
+        let reencoded = try jsonObject(try JSONEncoder().encode(authFile))
+        let original = try jsonObject(json)
+        XCTAssertEqual(reencoded, original)
+    }
+}


### PR DESCRIPTION
## Motivation

Issue #239: auth file structs only round-trip the JSON fields they explicitly declare. PR #210 fixed the loss of `prefix`, `project_id`, and `proxy_url` by adding those specific fields, but any field CLIProxyAPI (or the user) adds in the future would be silently dropped again whenever Quotio decodes and re-encodes an auth file — a recurring data-loss window until each new field is manually added.

While auditing the current write paths, the disk rewrites under `~/.cli-proxy-api` were already converted to `JSONSerialization` read-modify-write (#312), but the structs themselves still lose unknown fields when encoded — and one live path still does exactly that today: `CodexCLIQuotaFetcher` decodes the native Codex credential (`CodexCLIAuthFile`) from the Keychain, mutates tokens, and writes back `JSONEncoder().encode(auth)`, dropping any field the struct doesn't model.

## Approach

Struct-level catch-all (Option A from the issue, with a typed `JSONValue` instead of an untyped `AnyCodable`):

- **`Quotio/Models/JSONValue.swift`** (new): a `nonisolated enum JSONValue: Codable, Equatable, Sendable` representing arbitrary JSON (string/int/double/bool/object/array/null), plus helpers `JSONValue.unknownFields(from:excluding:)` and `JSONValue.encodeUnknownFields(_:to:)` built on a dynamic `JSONCodingKey`.
- **`AntigravityAuthFile`**, **`CodexAuthFile`**, **`CodexCLIAuthFile`**, and **`CodexCLITokens`** get an `additionalFields: [String: JSONValue]` catch-all with custom `init(from:)` / `encode(to:)`: typed fields decode/encode exactly as before, and every unrecognized key is captured on decode and re-emitted on encode.

Known fields stay fully type-safe and the JSON produced for files without unknown fields is unchanged, so this is behavior-preserving for existing data. The Codex Keychain refresh path now preserves unknown fields automatically with no call-site changes, and any future code that round-trips these structs is safe by construction.

## Test evidence

New `QuotioTests/AuthFileUnknownFieldsTests.swift` (5 tests) round-trips JSON containing unknown fields of every shape — `custom_header` string, int, double, bool, `null`, arrays, and nested objects — through decode → mutate typed fields → encode for all four structs, including unknown keys nested inside `tokens` (the object rewritten by the Keychain refresh path), and asserts an unmodified round trip is byte-for-byte lossless at the JSON level:

```
Test case 'AuthFileUnknownFieldsTests.testAntigravityAuthFileDecodesKnownFieldsWithoutUnknownFields()' passed
Test case 'AuthFileUnknownFieldsTests.testAntigravityAuthFilePreservesUnknownFieldsAcrossRoundTrip()' passed
Test case 'AuthFileUnknownFieldsTests.testCodexAuthFilePreservesUnknownFieldsAcrossRoundTrip()' passed
Test case 'AuthFileUnknownFieldsTests.testCodexCLIAuthFilePreservesUnknownFieldsIncludingNestedTokens()' passed
Test case 'AuthFileUnknownFieldsTests.testRoundTripWithoutModificationIsLossless()' passed
```

- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build` → **BUILD SUCCEEDED**
- `xcodebuild test -project Quotio.xcodeproj -scheme Quotio -configuration Debug -destination 'platform=macOS'` → **TEST SUCCEEDED** (full suite)

Closes #239
