### PR TITLE
fix(providers): allow deleting accounts imported from Cursor and Trae

### DIFF
--- a/Quotio/Models/Models.swift
+++ b/Quotio/Models/Models.swift
@@ -217,7 +217,19 @@ nonisolated enum AIProvider: String, CaseIterable, Codable, Identifiable, Sendab
             return false
         }
     }
-    
+
+    /// Whether this provider's accounts are imported from a local IDE database by the
+    /// explicit "Scan for IDEs" flow (issue #29) instead of being authenticated inside
+    /// Quotio. Such an account owns no Quotio credential, so it exists only as imported
+    /// quota data and deleting that data deletes the account (issue #213).
+    ///
+    /// Derived from the existing traits rather than listing cases again, so a new IDE
+    /// edition only has to opt into `usesBrowserAuth` / `supportsManualAuth` to inherit
+    /// the same import and delete behaviour.
+    var isImportedFromLocalIDE: Bool {
+        usesBrowserAuth && !supportsManualAuth
+    }
+
     /// Map provider to CLI agent (if applicable)
     var cliAgent: CLIAgent? {
         switch self {

--- a/Quotio/Services/Monitor/MonitorRuntime.swift
+++ b/Quotio/Services/Monitor/MonitorRuntime.swift
@@ -283,6 +283,41 @@ actor MonitorSnapshotStore {
             Log.quota("Failed to persist Monitor snapshot: \(error.localizedDescription)")
         }
     }
+
+    /// Drop a single account from the persisted snapshot, leaving every other entry as
+    /// it is on disk.
+    ///
+    /// `store(_:)` replaces the whole file with the caller's in-memory quotas, which is
+    /// only correct while Monitor mode is active. Deleting an imported IDE account is
+    /// reachable from the other modes too, where the in-memory quotas belong to that
+    /// mode, so the delete path needs this targeted removal instead (issue #213).
+    ///
+    /// - Returns: `true` when an entry was found and the file was rewritten.
+    @discardableResult
+    func removeAccount(provider: AIProvider, accountKey: String) -> Bool {
+        var quotas = load()
+        guard var accountQuotas = quotas[provider] else { return false }
+
+        // Match the identity Monitor itself dedupes on (`MonitorAccount.deduplicationKey`):
+        // the Monitor row carries a trimmed account key while the snapshot key is stored
+        // verbatim, so an exact-only match could leave the entry behind.
+        let normalized = accountKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let matchingKeys = accountQuotas.keys.filter {
+            $0 == accountKey || $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == normalized
+        }
+        guard !matchingKeys.isEmpty else { return false }
+
+        for key in matchingKeys {
+            accountQuotas.removeValue(forKey: key)
+        }
+        if accountQuotas.isEmpty {
+            quotas.removeValue(forKey: provider)
+        } else {
+            quotas[provider] = accountQuotas
+        }
+        store(quotas)
+        return true
+    }
 }
 
 actor MonitorAccountDiscovery {
@@ -636,14 +671,15 @@ actor MonitorRefreshCoordinator {
         source: MonitorAccountSource,
         disabledIDs: Set<String>
     ) -> MonitorAccount {
-        // Cursor/Trae accounts exist only as imported quota snapshots (no owned
-        // credential), so deleting the snapshot fully removes them (issue #213).
+        // Accounts imported from a local IDE (Cursor, Trae) exist only as imported quota
+        // data with no owned credential, so removing that data fully deletes them and
+        // they will not reappear on the next discovery pass (issue #213).
         var account = MonitorAccount.make(
             provider: provider,
             accountKey: accountKey,
             displayName: displayName,
             source: source,
-            canDelete: provider.usesBrowserAuth
+            canDelete: provider.isImportedFromLocalIDE
         )
         account.isDisabled = disabledIDs.contains(account.id)
         return account
@@ -727,6 +763,29 @@ actor MonitorRefreshCoordinator {
 
     func finish(quotas: [AIProvider: [String: ProviderQuotaData]]) async {
         await snapshots.store(quotas)
+    }
+
+    /// Forget every Monitor-owned trace of a single account: its persisted snapshot
+    /// entry (`Monitor/snapshots-v1.json`) and any disabled flag it left behind in
+    /// `Monitor/accounts-v1.json`.
+    ///
+    /// Unlike `finish(quotas:)` this never rewrites unrelated entries, so it is safe to
+    /// call from whichever mode is active. Deleting an account imported from Cursor or
+    /// Trae has to run in every mode: the account row is shown outside Monitor mode, but
+    /// `bootstrap()` reads the snapshot back when Monitor mode is entered, which would
+    /// otherwise resurrect the deleted account (issue #213).
+    func forgetSnapshotAccount(provider: AIProvider, accountKey: String) async {
+        await snapshots.removeAccount(provider: provider, accountKey: accountKey)
+
+        // `MonitorAccount.make` derives the id from provider + normalized account key, so
+        // this resolves the same id the Monitor row used when it was disabled.
+        let accountID = MonitorAccount.make(
+            provider: provider,
+            accountKey: accountKey,
+            source: .localIDE
+        ).id
+        guard await discovery.disabledAccountIDs().contains(accountID) else { return }
+        await discovery.setDisabled(false, accountID: accountID)
     }
 
     func currentIssues() -> [AIProvider: MonitorRefreshIssue] {

--- a/Quotio/Services/Monitor/MonitorRuntime.swift
+++ b/Quotio/Services/Monitor/MonitorRuntime.swift
@@ -636,11 +636,14 @@ actor MonitorRefreshCoordinator {
         source: MonitorAccountSource,
         disabledIDs: Set<String>
     ) -> MonitorAccount {
+        // Cursor/Trae accounts exist only as imported quota snapshots (no owned
+        // credential), so deleting the snapshot fully removes them (issue #213).
         var account = MonitorAccount.make(
             provider: provider,
             accountKey: accountKey,
             displayName: displayName,
-            source: source
+            source: source,
+            canDelete: provider.usesBrowserAuth
         )
         account.isDisabled = disabledIDs.contains(account.id)
         return account

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -483,36 +483,80 @@ final class QuotaViewModel {
     func deleteMonitorAccount(accountID: String) async {
         guard let account = monitorAccounts.first(where: { $0.id == accountID }), account.canDelete else { return }
         await monitorCoordinator.deleteOwnedAccount(accountID: accountID)
-        providerQuotas[account.provider]?.removeValue(forKey: account.accountKey)
-        if providerQuotas[account.provider]?.isEmpty == true {
-            providerQuotas.removeValue(forKey: account.provider)
+        removeQuotaEntry(provider: account.provider, accountKey: account.accountKey)
+
+        // Drop the entry from the persisted Monitor snapshot directly. Rewriting the
+        // whole snapshot from `providerQuotas` below is only correct while Monitor mode
+        // is active, so the targeted removal is what makes the deletion stick in every
+        // mode (issue #213).
+        await monitorCoordinator.forgetSnapshotAccount(
+            provider: account.provider,
+            accountKey: account.accountKey
+        )
+        // Re-read the state after the suspension: a concurrent refresh may have written
+        // the account back into `providerQuotas` while this task was suspended.
+        removeQuotaEntry(provider: account.provider, accountKey: account.accountKey)
+
+        if modeManager.isMonitorMode {
+            await monitorCoordinator.finish(quotas: providerQuotas)
+            monitorAccounts = await monitorCoordinator.discoverAccounts(merging: providerQuotas)
         }
-        if Self.ideProvidersToSave.contains(account.provider) {
-            // Cursor/Trae quotas are also persisted to UserDefaults; clear them so
-            // the deleted account does not resurrect on next launch (issue #213).
-            savePersistedIDEQuotas()
-        }
-        await monitorCoordinator.finish(quotas: providerQuotas)
-        monitorAccounts = await monitorCoordinator.discoverAccounts(merging: providerQuotas)
         syncMenuBarSelection()
     }
 
-    /// Delete an auto-detected IDE account (Cursor, Trae) imported via "Scan for IDEs".
-    /// These accounts exist only as imported quota data, so removing the quota entry
-    /// and its persisted copies deletes the account (issue #213).
+    /// Delete an account imported from a local IDE (Cursor, Trae) via "Scan for IDEs".
+    ///
+    /// These accounts own no credential — they exist only as imported quota data — so
+    /// deleting one means clearing every copy of that data: the in-memory quotas, the
+    /// `persisted.ideQuotas` UserDefaults mirror, the Monitor snapshot, any Monitor
+    /// disabled flag, and the menu bar selection (issue #213).
+    ///
+    /// The Monitor state is cleared in **every** mode, not only Monitor mode: these rows
+    /// are only shown outside Monitor mode (Monitor rows are dispatched to
+    /// `deleteMonitorAccount` first), while `initializeQuotaOnlyMode()` bootstraps from
+    /// the Monitor snapshot, so a stale entry would restore the account on the next
+    /// switch back into Monitor mode. The removal is targeted rather than a
+    /// `finish(quotas:)` rewrite because outside Monitor mode `providerQuotas` holds
+    /// that mode's quota data, which must not overwrite the Monitor snapshot.
     func deleteAutoDetectedAccount(provider: AIProvider, accountKey: String) async {
-        guard Self.ideProvidersToSave.contains(provider) else { return }
-        providerQuotas[provider]?.removeValue(forKey: accountKey)
-        if providerQuotas[provider]?.isEmpty == true {
-            providerQuotas.removeValue(forKey: provider)
-        }
-        savePersistedIDEQuotas()
+        guard provider.isImportedFromLocalIDE else { return }
+        removeQuotaEntry(provider: provider, accountKey: accountKey)
+
+        await monitorCoordinator.forgetSnapshotAccount(provider: provider, accountKey: accountKey)
+        // Re-read the state after the suspension rather than trusting the pre-await
+        // snapshot: a concurrent refresh may have re-added the account meanwhile.
+        removeQuotaEntry(provider: provider, accountKey: accountKey)
+
         if modeManager.isMonitorMode {
             await monitorCoordinator.finish(quotas: providerQuotas)
             monitorAccounts = await monitorCoordinator.discoverAccounts(merging: providerQuotas)
         }
         syncMenuBarSelection()
         notifyQuotaDataChanged()
+    }
+
+    /// Remove one account's quota entry from the in-memory map and, for IDE-imported
+    /// providers, from the `persisted.ideQuotas` UserDefaults mirror.
+    ///
+    /// Deliberately synchronous so it can be re-applied after a suspension point without
+    /// introducing another one.
+    ///
+    /// - Returns: `true` when an entry was actually removed.
+    @discardableResult
+    private func removeQuotaEntry(provider: AIProvider, accountKey: String) -> Bool {
+        guard var quotas = providerQuotas[provider],
+              quotas.removeValue(forKey: accountKey) != nil else { return false }
+        if quotas.isEmpty {
+            providerQuotas.removeValue(forKey: provider)
+        } else {
+            providerQuotas[provider] = quotas
+        }
+        if Self.ideProvidersToSave.contains(provider) {
+            // Cursor/Trae quotas are mirrored into UserDefaults; rewrite the mirror so
+            // the deleted account does not resurrect on the next launch (issue #213).
+            savePersistedIDEQuotas()
+        }
+        return true
     }
 
     func saveOpenRouterAccount(label: String, apiKey: String, existingAccountID: String? = nil) async throws {
@@ -2038,7 +2082,7 @@ final class QuotaViewModel {
     /// (issue #29) and re-importing here would resurrect deleted accounts (issue #213).
     /// They can still be refreshed via their scoped refresh actions while imported.
     func refreshAutoDetectedProviders() async {
-        let autoDetectedProviders = AIProvider.allCases.filter { !$0.supportsManualAuth && !$0.usesBrowserAuth }
+        let autoDetectedProviders = AIProvider.allCases.filter { !$0.supportsManualAuth && !$0.isImportedFromLocalIDE }
 
         for provider in autoDetectedProviders {
             await refreshQuotaForProvider(provider)

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -484,8 +484,35 @@ final class QuotaViewModel {
         guard let account = monitorAccounts.first(where: { $0.id == accountID }), account.canDelete else { return }
         await monitorCoordinator.deleteOwnedAccount(accountID: accountID)
         providerQuotas[account.provider]?.removeValue(forKey: account.accountKey)
+        if providerQuotas[account.provider]?.isEmpty == true {
+            providerQuotas.removeValue(forKey: account.provider)
+        }
+        if Self.ideProvidersToSave.contains(account.provider) {
+            // Cursor/Trae quotas are also persisted to UserDefaults; clear them so
+            // the deleted account does not resurrect on next launch (issue #213).
+            savePersistedIDEQuotas()
+        }
         await monitorCoordinator.finish(quotas: providerQuotas)
         monitorAccounts = await monitorCoordinator.discoverAccounts(merging: providerQuotas)
+        syncMenuBarSelection()
+    }
+
+    /// Delete an auto-detected IDE account (Cursor, Trae) imported via "Scan for IDEs".
+    /// These accounts exist only as imported quota data, so removing the quota entry
+    /// and its persisted copies deletes the account (issue #213).
+    func deleteAutoDetectedAccount(provider: AIProvider, accountKey: String) async {
+        guard Self.ideProvidersToSave.contains(provider) else { return }
+        providerQuotas[provider]?.removeValue(forKey: accountKey)
+        if providerQuotas[provider]?.isEmpty == true {
+            providerQuotas.removeValue(forKey: provider)
+        }
+        savePersistedIDEQuotas()
+        if modeManager.isMonitorMode {
+            await monitorCoordinator.finish(quotas: providerQuotas)
+            monitorAccounts = await monitorCoordinator.discoverAccounts(merging: providerQuotas)
+        }
+        syncMenuBarSelection()
+        notifyQuotaDataChanged()
     }
 
     func saveOpenRouterAccount(label: String, apiKey: String, existingAccountID: String? = nil) async throws {
@@ -2007,9 +2034,12 @@ final class QuotaViewModel {
     }
 
     /// Refresh all auto-detected providers (those that don't support manual auth)
+    /// Cursor and Trae are excluded: they are imported only via explicit "Scan for IDEs"
+    /// (issue #29) and re-importing here would resurrect deleted accounts (issue #213).
+    /// They can still be refreshed via their scoped refresh actions while imported.
     func refreshAutoDetectedProviders() async {
-        let autoDetectedProviders = AIProvider.allCases.filter { !$0.supportsManualAuth }
-        
+        let autoDetectedProviders = AIProvider.allCases.filter { !$0.supportsManualAuth && !$0.usesBrowserAuth }
+
         for provider in autoDetectedProviders {
             await refreshQuotaForProvider(provider)
         }

--- a/Quotio/Views/Components/AccountRow.swift
+++ b/Quotio/Views/Components/AccountRow.swift
@@ -113,6 +113,8 @@ struct AccountRowData: Identifiable, Hashable {
     }
     
     /// Create from auto-detected account (Cursor, Trae)
+    /// Cursor/Trae accounts are imported from local IDE databases via "Scan for IDEs";
+    /// deleting them removes the imported quota data from Quotio (issue #213).
     static func from(provider: AIProvider, accountKey: String) -> AccountRowData {
         AccountRowData(
             id: "\(provider.rawValue)_\(accountKey)",
@@ -123,7 +125,7 @@ struct AccountRowData: Identifiable, Hashable {
             status: nil,
             statusMessage: nil,
             isDisabled: false,
-            canDelete: false
+            canDelete: provider.usesBrowserAuth
         )
     }
 

--- a/Quotio/Views/Components/AccountRow.swift
+++ b/Quotio/Views/Components/AccountRow.swift
@@ -125,7 +125,7 @@ struct AccountRowData: Identifiable, Hashable {
             status: nil,
             statusMessage: nil,
             isDisabled: false,
-            canDelete: provider.usesBrowserAuth
+            canDelete: provider.isImportedFromLocalIDE
         )
     }
 

--- a/Quotio/Views/Screens/ProvidersScreen.swift
+++ b/Quotio/Views/Screens/ProvidersScreen.swift
@@ -504,6 +504,15 @@ struct ProvidersScreen: View {
             return
         }
 
+        // Handle auto-detected IDE accounts (Cursor, Trae) imported via "Scan for IDEs"
+        if account.source == .autoDetected {
+            await viewModel.deleteAutoDetectedAccount(
+                provider: account.provider,
+                accountKey: account.menuBarAccountKey
+            )
+            return
+        }
+
         // Handle GLM accounts (stored in CustomProviderService)
         if account.provider == .glm {
             // GLM accounts are stored as custom providers

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -1032,6 +1032,73 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertTrue(derived.isDisabled)
     }
 
+    func testQuotaDerivedIDEAccountsAllowDeletion() {
+        // Cursor/Trae accounts imported from local IDE databases must be deletable (issue #213).
+        for provider in [AIProvider.cursor, .trae] {
+            let account = MonitorRefreshCoordinator.makeQuotaDerivedAccount(
+                provider: provider,
+                accountKey: "user@example.com",
+                source: .localIDE,
+                disabledIDs: []
+            )
+            XCTAssertTrue(account.canDelete, "\(provider.rawValue) account should be deletable")
+        }
+
+        // Quota-derived placeholders for credential-backed providers would resurrect
+        // on the next discovery pass, so they must stay non-deletable.
+        for (provider, source) in [(AIProvider.claude, MonitorAccountSource.nativeCredential), (.amp, .apiKey)] {
+            let account = MonitorRefreshCoordinator.makeQuotaDerivedAccount(
+                provider: provider,
+                accountKey: "user@example.com",
+                source: source,
+                disabledIDs: []
+            )
+            XCTAssertFalse(account.canDelete, "\(provider.rawValue) account should not be deletable")
+        }
+    }
+
+    @MainActor
+    func testAutoDetectedAccountRowsAllowDeleteOnlyForIDEProviders() {
+        // Providers screen rows for scanned IDE accounts must offer delete (issue #213).
+        for provider in [AIProvider.cursor, .trae] {
+            let row = AccountRowData.from(provider: provider, accountKey: "user@example.com")
+            XCTAssertTrue(row.canDelete, "\(provider.rawValue) row should be deletable")
+            XCTAssertEqual(row.source, .autoDetected)
+        }
+        for provider in [AIProvider.devin, .grok] {
+            let row = AccountRowData.from(provider: provider, accountKey: "user@example.com")
+            XCTAssertFalse(row.canDelete, "\(provider.rawValue) row should not be deletable")
+        }
+    }
+
+    func testSnapshotStoreDropsDeletedIDEAccountAcrossReload() async {
+        // Mirrors deleteMonitorAccount: after the Cursor quota entry is removed and the
+        // snapshot re-persisted, a fresh load must not resurrect the account (issue #213).
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let url = directory.appendingPathComponent("snapshots-v1.json")
+        let store = MonitorSnapshotStore(url: url)
+        let quota = ProviderQuotaData(
+            models: [ModelQuota(name: "gpt", percentage: 50, resetTime: "")],
+            lastUpdated: Date(timeIntervalSince1970: 1234)
+        )
+
+        var quotas: [AIProvider: [String: ProviderQuotaData]] = [
+            .cursor: ["cursor@example.com": quota],
+            .codex: ["codex@example.com": quota],
+        ]
+        await store.store(quotas)
+
+        quotas[.cursor]?.removeValue(forKey: "cursor@example.com")
+        if quotas[.cursor]?.isEmpty == true {
+            quotas.removeValue(forKey: .cursor)
+        }
+        await store.store(quotas)
+
+        let reloaded = await MonitorSnapshotStore(url: url).load()
+        XCTAssertNil(reloaded[.cursor], "Deleted Cursor account must not survive a reload")
+        XCTAssertEqual(reloaded[.codex]?["codex@example.com"]?.models.first?.percentage, 50)
+    }
+
     func testQuotaDisplayNameEnrichmentPreservesFactoryAccountIdentity() {
         let account = MonitorAccount.make(
             provider: .factoryDroid,

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -1071,32 +1071,168 @@ final class MonitorRuntimeTests: XCTestCase {
         }
     }
 
-    func testSnapshotStoreDropsDeletedIDEAccountAcrossReload() async {
-        // Mirrors deleteMonitorAccount: after the Cursor quota entry is removed and the
-        // snapshot re-persisted, a fresh load must not resurrect the account (issue #213).
+    private func ideQuota(_ percentage: Double) -> ProviderQuotaData {
+        ProviderQuotaData(
+            models: [ModelQuota(name: "gpt", percentage: percentage, resetTime: "")],
+            lastUpdated: Date(timeIntervalSince1970: 1234)
+        )
+    }
+
+    /// A credential vault with nothing in it, so Monitor discovery in these tests depends
+    /// only on the injected snapshot/metadata files and never on the host Keychain.
+    private struct EmptyCredentialVault: MonitorCredentialStore {
+        func accounts() async -> [MonitorAccount] { [] }
+        func credential(for accountID: String) async -> MonitorOAuthCredential? { nil }
+        func reloadLatest(accountID: String) async -> MonitorOAuthCredential? { nil }
+        func save(_ credential: MonitorOAuthCredential, metadata: MonitorAccount) async throws {}
+        func delete(accountID: String) async {}
+    }
+
+    private func makeIsolatedCoordinator(
+        snapshots: URL,
+        metadata: URL
+    ) -> MonitorRefreshCoordinator {
+        MonitorRefreshCoordinator(
+            discovery: MonitorAccountDiscovery(
+                vault: EmptyCredentialVault(),
+                metadata: MonitorMetadataStore(url: metadata)
+            ),
+            snapshots: MonitorSnapshotStore(url: snapshots)
+        )
+    }
+
+    /// Reproduces the exact resurrection sequence from issue #213: import Cursor in
+    /// Monitor mode, delete the auto-detected row while a different mode is active, then
+    /// re-enter Monitor mode. `initializeQuotaOnlyMode()` bootstraps from the snapshot, so
+    /// the deletion only sticks if it cleared the snapshot outside Monitor mode too.
+    func testDeletingIDEAccountOutsideMonitorModeSurvivesMonitorBootstrap() async {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let snapshots = directory.appendingPathComponent("snapshots-v1.json")
+        let metadata = directory.appendingPathComponent("accounts-v1.json")
+
+        // 1. Monitor mode imports Cursor and persists it in the Monitor snapshot, next to
+        //    an unrelated Monitor-only account.
+        await makeIsolatedCoordinator(snapshots: snapshots, metadata: metadata).finish(quotas: [
+            .cursor: ["cursor@example.com": ideQuota(50)],
+            .codex: ["codex@example.com": ideQuota(42)],
+        ])
+
+        let imported = await makeIsolatedCoordinator(snapshots: snapshots, metadata: metadata).bootstrap()
+        XCTAssertNotNil(imported.quotas[.cursor]?["cursor@example.com"])
+        XCTAssertTrue(
+            imported.accounts.contains { $0.provider == .cursor && $0.accountKey == "cursor@example.com" },
+            "Precondition: the Monitor snapshot restores the imported Cursor account"
+        )
+
+        // 2. Local Proxy mode: deleting the auto-detected Cursor row. This is the call
+        //    `QuotaViewModel.deleteAutoDetectedAccount` makes, and it runs regardless of
+        //    the active mode.
+        await makeIsolatedCoordinator(snapshots: snapshots, metadata: metadata)
+            .forgetSnapshotAccount(provider: .cursor, accountKey: "cursor@example.com")
+
+        // 3. Back in Monitor mode: `initializeQuotaOnlyMode()` calls `bootstrap()`.
+        let rebootstrapped = await makeIsolatedCoordinator(snapshots: snapshots, metadata: metadata).bootstrap()
+        XCTAssertNil(
+            rebootstrapped.quotas[.cursor],
+            "Deleted Cursor account must not come back from the Monitor snapshot"
+        )
+        XCTAssertFalse(
+            rebootstrapped.accounts.contains { $0.provider == .cursor },
+            "Deleted Cursor account must not reappear as a Monitor account"
+        )
+        // The delete must not take the rest of the Monitor snapshot with it, and must not
+        // replace it with the quota data of whichever mode performed the deletion.
+        XCTAssertEqual(rebootstrapped.quotas[.codex]?["codex@example.com"]?.models.first?.percentage, 42)
+    }
+
+    /// The targeted removal must not rewrite the snapshot from the deleting mode's quota
+    /// data: entries for other providers, and other accounts of the same provider, stay
+    /// exactly as they were written by Monitor mode.
+    func testForgettingIDEAccountLeavesUnrelatedSnapshotEntriesIntact() async {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let snapshots = directory.appendingPathComponent("snapshots-v1.json")
+        let metadata = directory.appendingPathComponent("accounts-v1.json")
+
+        await makeIsolatedCoordinator(snapshots: snapshots, metadata: metadata).finish(quotas: [
+            .cursor: ["gone@example.com": ideQuota(10), "kept@example.com": ideQuota(20)],
+            .trae: ["trae@example.com": ideQuota(30)],
+        ])
+
+        await makeIsolatedCoordinator(snapshots: snapshots, metadata: metadata)
+            .forgetSnapshotAccount(provider: .cursor, accountKey: "gone@example.com")
+
+        let reloaded = await MonitorSnapshotStore(url: snapshots).load()
+        XCTAssertNil(reloaded[.cursor]?["gone@example.com"])
+        XCTAssertEqual(reloaded[.cursor]?["kept@example.com"]?.models.first?.percentage, 20)
+        XCTAssertEqual(reloaded[.trae]?["trae@example.com"]?.models.first?.percentage, 30)
+    }
+
+    /// The Monitor row carries a trimmed account key while the snapshot stores the key
+    /// verbatim, so the removal has to match on the identity Monitor dedupes on rather
+    /// than on an exact string.
+    func testSnapshotRemovalMatchesMonitorAccountIdentity() async {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let url = directory.appendingPathComponent("snapshots-v1.json")
         let store = MonitorSnapshotStore(url: url)
-        let quota = ProviderQuotaData(
-            models: [ModelQuota(name: "gpt", percentage: 50, resetTime: "")],
-            lastUpdated: Date(timeIntervalSince1970: 1234)
+
+        await store.store([.cursor: [" Cursor@Example.com ": ideQuota(50)]])
+        let account = MonitorAccount.make(
+            provider: .cursor,
+            accountKey: " Cursor@Example.com ",
+            source: .localIDE
         )
 
-        var quotas: [AIProvider: [String: ProviderQuotaData]] = [
-            .cursor: ["cursor@example.com": quota],
-            .codex: ["codex@example.com": quota],
-        ]
-        await store.store(quotas)
+        let removed = await store.removeAccount(provider: .cursor, accountKey: account.accountKey)
 
-        quotas[.cursor]?.removeValue(forKey: "cursor@example.com")
-        if quotas[.cursor]?.isEmpty == true {
-            quotas.removeValue(forKey: .cursor)
-        }
-        await store.store(quotas)
-
+        XCTAssertTrue(removed)
         let reloaded = await MonitorSnapshotStore(url: url).load()
         XCTAssertNil(reloaded[.cursor], "Deleted Cursor account must not survive a reload")
-        XCTAssertEqual(reloaded[.codex]?["codex@example.com"]?.models.first?.percentage, 50)
+    }
+
+    /// Deleting an imported IDE account must also drop the Monitor disabled flag it left
+    /// in `accounts-v1.json`; otherwise a later re-scan brings the account back disabled.
+    func testForgettingIDEAccountClearsItsMonitorDisabledFlag() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let snapshots = directory.appendingPathComponent("snapshots-v1.json")
+        let metadataURL = directory.appendingPathComponent("accounts-v1.json")
+        let metadata = MonitorMetadataStore(url: metadataURL)
+
+        let account = MonitorAccount.make(
+            provider: .cursor,
+            accountKey: "cursor@example.com",
+            source: .localIDE,
+            canDelete: true
+        )
+        try await metadata.setDisabled(true, accountID: account.id)
+        await makeIsolatedCoordinator(snapshots: snapshots, metadata: metadataURL)
+            .finish(quotas: [.cursor: [account.accountKey: ideQuota(50)]])
+
+        await makeIsolatedCoordinator(snapshots: snapshots, metadata: metadataURL)
+            .forgetSnapshotAccount(provider: .cursor, accountKey: account.accountKey)
+
+        let disabled = await MonitorMetadataStore(url: metadataURL).disabledAccountIDs()
+        XCTAssertFalse(disabled.contains(account.id), "Deleted account must not keep a disabled flag")
+    }
+
+    /// The delete affordance keys off a named IDE-import capability rather than
+    /// `usesBrowserAuth` doubling as "is deletable"; it is derived from the existing
+    /// traits so a new IDE edition inherits it automatically.
+    func testImportedFromLocalIDECapabilityStaysDerivedFromProviderTraits() {
+        for provider in AIProvider.allCases {
+            XCTAssertEqual(
+                provider.isImportedFromLocalIDE,
+                provider.usesBrowserAuth && !provider.supportsManualAuth,
+                "\(provider.rawValue) IDE-import capability must stay derived from the existing traits"
+            )
+        }
+        for provider in [AIProvider.cursor, .trae] {
+            XCTAssertTrue(provider.isImportedFromLocalIDE, "\(provider.rawValue) is scanned from a local IDE")
+        }
+        // Providers that also refuse manual auth but are added from their own storage
+        // must not become deletable through this path.
+        for provider in [AIProvider.devin, .grok, .glm, .clinePass] {
+            XCTAssertFalse(provider.isImportedFromLocalIDE, "\(provider.rawValue) is not an IDE import")
+        }
     }
 
     func testQuotaDisplayNameEnrichmentPreservesFactoryAccountIdentity() {


### PR DESCRIPTION
## Problem

Accounts imported from Cursor (and Trae) via **Providers → Scan for IDEs** cannot be deleted (#213, likely also the report in #352):

- In Local Proxy / quota-only mode these accounts render as auto-detected rows with a hardcoded `canDelete: false` (`AccountRowData.from(provider:accountKey:)`), so `AccountRow` shows no trash button and no context-menu delete entry.
- In Monitor mode they surface as quota-derived accounts (`MonitorRefreshCoordinator.makeQuotaDerivedAccount`) which default to `canDelete: false`, and `deleteMonitorAccount` guards on that flag, so deletion is refused there too.
- The imported quota data is persisted in two places — UserDefaults (`persisted.ideQuotas`) and the Monitor snapshot (`Monitor/snapshots-v1.json`) — with no cleanup path, so the account survives every restart with no way to remove it.

## Fix

- Allow delete for auto-detected Cursor/Trae rows and for their quota-derived Monitor accounts (gated on `usesBrowserAuth`, so credential-backed placeholders that would just resurrect on the next discovery pass stay non-deletable).
- New `QuotaViewModel.deleteAutoDetectedAccount(provider:accountKey:)` and a hardened `deleteMonitorAccount` remove **all** backing state: the `providerQuotas` entry (dropping the provider key when it empties), the persisted IDE quotas in UserDefaults, the Monitor snapshot, and the menu bar selection — so the account does not resurrect on the next launch or refresh.
- `refreshAutoDetectedProviders()` (invoked by the generic Providers toolbar refresh) no longer re-imports Cursor/Trae from the local IDE databases. Those providers are documented as import-only-via-explicit-scan (issue #29 consent model), and re-importing here would both bypass that consent and resurrect deleted accounts. Scoped per-provider/per-account refresh still works while an account is imported, and "Scan for IDEs" re-imports on demand.

## Tests

Added to `QuotioTests/MonitorRuntimeTests`:

- `testQuotaDerivedIDEAccountsAllowDeletion` — Cursor/Trae quota-derived Monitor accounts are deletable; credential-backed (`claude`) and API-key (`amp`) placeholders remain non-deletable.
- `testAutoDetectedAccountRowsAllowDeleteOnlyForIDEProviders` — Providers-screen rows offer delete for Cursor/Trae only (not Devin/Grok).
- `testSnapshotStoreDropsDeletedIDEAccountAcrossReload` — after the Cursor entry is removed and the snapshot re-persisted, a fresh load does not resurrect the account while sibling providers are preserved.

## Verification

- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build` — succeeds
- `xcodebuild test -project Quotio.xcodeproj -scheme Quotio -configuration Debug -destination 'platform=macOS'` — all tests pass

Fixes #213
