### PR TITLE
feat(codex): add configurable model reasoning effort

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -1972,6 +1972,34 @@
         }
       }
     },
+    "agents.reasoningEffort.custom" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (custom)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (personnalisé)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (tùy chỉnh)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@（自定义）"
+          }
+        }
+      }
+    },
     "agents.reasoningEffort.high" : {
       "localizations" : {
         "en" : {
@@ -2056,6 +2084,34 @@
         }
       }
     },
+    "agents.reasoningEffort.max" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Max"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximum"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tối đa"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大"
+          }
+        }
+      }
+    },
     "agents.reasoningEffort.medium" : {
       "localizations" : {
         "en" : {
@@ -2108,6 +2164,62 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最小"
+          }
+        }
+      }
+    },
+    "agents.reasoningEffort.none" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "None"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无"
+          }
+        }
+      }
+    },
+    "agents.reasoningEffort.ultra" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultra"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultra"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Siêu cao"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "超强"
           }
         }
       }

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -1944,6 +1944,202 @@
         }
       }
     },
+    "agents.reasoningEffort" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reasoning Effort"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effort de raisonnement"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mức độ suy luận"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推理强度"
+          }
+        }
+      }
+    },
+    "agents.reasoningEffort.high" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "High"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Élevé"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cao"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高"
+          }
+        }
+      }
+    },
+    "agents.reasoningEffort.info" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sets model_reasoning_effort for Codex CLI. Higher levels improve answer quality but respond slower and use more quota."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Définit model_reasoning_effort pour Codex CLI. Les niveaux élevés améliorent la qualité des réponses mais sont plus lents et consomment plus de quota."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thiết lập model_reasoning_effort cho Codex CLI. Mức cao hơn cải thiện chất lượng trả lời nhưng phản hồi chậm hơn và tốn nhiều hạn mức hơn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置 Codex CLI 的 model_reasoning_effort。等级越高回答质量越好，但响应更慢且消耗更多配额。"
+          }
+        }
+      }
+    },
+    "agents.reasoningEffort.low" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Low"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faible"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thấp"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低"
+          }
+        }
+      }
+    },
+    "agents.reasoningEffort.medium" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medium"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moyen"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trung bình"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中"
+          }
+        }
+      }
+    },
+    "agents.reasoningEffort.minimal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimal"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimal"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tối thiểu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最小"
+          }
+        }
+      }
+    },
+    "agents.reasoningEffort.xhigh" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Extra High"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Très élevé"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rất cao"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "超高"
+          }
+        }
+      }
+    },
     "agents.reconfigure" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Models/AgentModels.swift
+++ b/Quotio/Models/AgentModels.swift
@@ -205,6 +205,27 @@ nonisolated enum ModelSlot: String, CaseIterable, Identifiable, Codable, Sendabl
     }
 }
 
+// MARK: - Codex Reasoning Effort
+
+/// Reasoning effort levels accepted by Codex CLI's `model_reasoning_effort`
+/// key in `~/.codex/config.toml`.
+nonisolated enum CodexReasoningEffort: String, CaseIterable, Identifiable, Codable, Sendable {
+    case minimal = "minimal"
+    case low = "low"
+    case medium = "medium"
+    case high = "high"
+    case xhigh = "xhigh"
+
+    var id: String { rawValue }
+
+    /// Default effort, matching the value Quotio has historically written.
+    static let defaultEffort: CodexReasoningEffort = .high
+
+    var displayName: String {
+        "agents.reasoningEffort.\(rawValue)".localizedStatic()
+    }
+}
+
 // MARK: - Available Models for Routing
 
 nonisolated struct AvailableModel: Identifiable, Codable, Hashable, Sendable {
@@ -295,6 +316,9 @@ nonisolated struct AgentConfiguration: Codable, Sendable {
     var apiKey: String
     var useOAuth: Bool
     var setupMode: ConfigurationSetup
+    /// Reasoning effort written to Codex CLI's `model_reasoning_effort`.
+    /// Only used when `agent == .codexCLI`.
+    var codexReasoningEffort: CodexReasoningEffort
 
     init(agent: CLIAgent, proxyURL: String, apiKey: String, setupMode: ConfigurationSetup = .proxy) {
         self.agent = agent
@@ -302,6 +326,7 @@ nonisolated struct AgentConfiguration: Codable, Sendable {
         self.apiKey = apiKey
         self.useOAuth = false
         self.setupMode = setupMode
+        self.codexReasoningEffort = .defaultEffort
         self.modelSlots = Dictionary(uniqueKeysWithValues: ModelSlot.allCases.compactMap { slot in
             AvailableModel.defaultModels[slot].map { (slot, $0.name) }
         })
@@ -314,6 +339,7 @@ nonisolated struct AgentConfiguration: Codable, Sendable {
         self.apiKey = apiKey
         self.useOAuth = false
         self.setupMode = setupMode
+        self.codexReasoningEffort = .defaultEffort
 
         // Start with defaults, then overlay saved slots
         var slots = Dictionary(uniqueKeysWithValues: ModelSlot.allCases.compactMap { slot in

--- a/Quotio/Models/AgentModels.swift
+++ b/Quotio/Models/AgentModels.swift
@@ -207,14 +207,65 @@ nonisolated enum ModelSlot: String, CaseIterable, Identifiable, Codable, Sendabl
 
 // MARK: - Codex Reasoning Effort
 
-/// Reasoning effort levels accepted by Codex CLI's `model_reasoning_effort`
-/// key in `~/.codex/config.toml`.
-nonisolated enum CodexReasoningEffort: String, CaseIterable, Identifiable, Codable, Sendable {
-    case minimal = "minimal"
-    case low = "low"
-    case medium = "medium"
-    case high = "high"
-    case xhigh = "xhigh"
+/// Reasoning effort accepted by Codex CLI's `model_reasoning_effort` key in
+/// `~/.codex/config.toml`.
+///
+/// Codex treats this key as an **open** set. `ReasoningEffort` in
+/// `codex-rs/protocol/src/openai_models.rs` names `none`, `minimal`, `low`,
+/// `medium`, `high`, `xhigh`, `max` and `ultra`, and its hand-written
+/// `FromStr` maps every other non-empty string to `ReasoningEffort::Custom`;
+/// only the empty string is rejected. `custom` mirrors that escape hatch so a
+/// value Quotio does not know is round-tripped verbatim instead of being
+/// silently replaced.
+nonisolated enum CodexReasoningEffort: RawRepresentable, CaseIterable, Identifiable, Codable, Hashable, Sendable {
+    case none
+    case minimal
+    case low
+    case medium
+    case high
+    case xhigh
+    case max
+    case ultra
+    /// A valid Codex value Quotio does not have a named case for.
+    /// Never produced for a value that maps to a named case — see `init(rawValue:)`.
+    case custom(String)
+
+    /// Fails only for the empty string, which Codex itself rejects with
+    /// "reasoning_effort must not be empty".
+    init?(rawValue: String) {
+        switch rawValue {
+        case "none": self = .none
+        case "minimal": self = .minimal
+        case "low": self = .low
+        case "medium": self = .medium
+        case "high": self = .high
+        case "xhigh": self = .xhigh
+        case "max": self = .max
+        case "ultra": self = .ultra
+        case "": return nil
+        default: self = .custom(rawValue)
+        }
+    }
+
+    var rawValue: String {
+        switch self {
+        case .none: return "none"
+        case .minimal: return "minimal"
+        case .low: return "low"
+        case .medium: return "medium"
+        case .high: return "high"
+        case .xhigh: return "xhigh"
+        case .max: return "max"
+        case .ultra: return "ultra"
+        case .custom(let value): return value
+        }
+    }
+
+    /// The named values Quotio offers in the picker, ordered by effort.
+    /// A `custom` value read from the user's config is offered alongside these.
+    static let allCases: [CodexReasoningEffort] = [
+        .none, .minimal, .low, .medium, .high, .xhigh, .max, .ultra
+    ]
 
     var id: String { rawValue }
 
@@ -222,7 +273,24 @@ nonisolated enum CodexReasoningEffort: String, CaseIterable, Identifiable, Codab
     static let defaultEffort: CodexReasoningEffort = .high
 
     var displayName: String {
-        "agents.reasoningEffort.\(rawValue)".localizedStatic()
+        if case .custom(let value) = self {
+            return String.localizedStringWithFormat(
+                "agents.reasoningEffort.custom".localizedStatic(),
+                value
+            )
+        }
+        return "agents.reasoningEffort.\(rawValue)".localizedStatic()
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        self = CodexReasoningEffort(rawValue: rawValue) ?? .defaultEffort
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
     }
 }
 

--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -157,7 +157,7 @@ actor AgentConfigurationService {
         // Simple TOML parsing for the values we need
         var baseURL: String?
         var model: String?
-        var reasoningEffort: CodexReasoningEffort?
+        let reasoningEffort = parseTopLevelCodexReasoningEffort(from: content)
         var isProxy = false
 
         for line in content.components(separatedBy: .newlines) {
@@ -170,10 +170,6 @@ actor AgentConfigurationService {
                 }
             } else if trimmed.hasPrefix("model =") {
                 model = extractTOMLValue(from: trimmed)
-            } else if trimmed.hasPrefix("model_reasoning_effort") {
-                if let value = extractTOMLValue(from: trimmed) {
-                    reasoningEffort = CodexReasoningEffort(rawValue: value)
-                }
             } else if trimmed.contains("model_provider") && trimmed.contains("cliproxyapi") {
                 isProxy = true
             }
@@ -352,12 +348,14 @@ actor AgentConfigurationService {
     ) -> String {
         let escapedModel = escapeTOMLString(model)
         let escapedProxyURL = escapeTOMLString(proxyURL)
+        // A `custom` effort carries a literal value read from the user's file.
+        let escapedReasoningEffort = escapeTOMLString(reasoningEffort.rawValue)
 
         return """
         # CLIProxyAPI Configuration for Codex CLI
         model_provider = "cliproxyapi"
         model = "\(escapedModel)"
-        model_reasoning_effort = "\(reasoningEffort.rawValue)"
+        model_reasoning_effort = "\(escapedReasoningEffort)"
 
         [model_providers.cliproxyapi]
         name = "cliproxyapi"
@@ -391,6 +389,180 @@ actor AgentConfigurationService {
         return key == "model_provider" || key == "model" || key == "model_reasoning_effort"
     }
 
+    /// Tracks TOML multi-line string state (`"""` / `'''`) across a line-by-line
+    /// scan so that text inside a string body is never mistaken for a table
+    /// header or a key/value pair.
+    private struct CodexTOMLScanner {
+        /// Quote character of the multi-line string currently open, or `nil`
+        /// when the scanner is at TOML structure level.
+        private var openMultilineQuote: Character?
+
+        /// Feeds one line to the scanner.
+        /// - Returns: `true` when the line is TOML structure, `false` when it is
+        ///   part of a multi-line string body (including its closing delimiter).
+        mutating func isStructuralLine(_ line: String) -> Bool {
+            let characters = Array(line)
+            let startedInsideMultiline = openMultilineQuote != nil
+            var index = 0
+
+            while index < characters.count {
+                let character = characters[index]
+
+                if let quote = openMultilineQuote {
+                    if character == quote, Self.isTriple(characters, at: index, quote: quote) {
+                        openMultilineQuote = nil
+                        index += 3
+                    } else {
+                        index += 1
+                    }
+                    continue
+                }
+
+                switch character {
+                case "#":
+                    // A comment runs to the end of the line.
+                    index = characters.count
+                case "\"", "'":
+                    if Self.isTriple(characters, at: index, quote: character) {
+                        openMultilineQuote = character
+                        index += 3
+                    } else {
+                        index = Self.endOfSingleLineString(characters, from: index, quote: character)
+                    }
+                default:
+                    index += 1
+                }
+            }
+
+            return !startedInsideMultiline
+        }
+
+        private static func isTriple(_ characters: [Character], at index: Int, quote: Character) -> Bool {
+            guard index + 2 < characters.count else { return false }
+            return characters[index + 1] == quote && characters[index + 2] == quote
+        }
+
+        private static func endOfSingleLineString(
+            _ characters: [Character],
+            from index: Int,
+            quote: Character
+        ) -> Int {
+            var cursor = index + 1
+            while cursor < characters.count {
+                let character = characters[cursor]
+                // Literal strings ('...') do not support escapes.
+                if quote == "\"", character == "\\" {
+                    cursor += 2
+                    continue
+                }
+                if character == quote {
+                    return cursor + 1
+                }
+                cursor += 1
+            }
+            return characters.count
+        }
+    }
+
+    /// Reads the **top-level** `model_reasoning_effort` from a Codex `config.toml`.
+    ///
+    /// `model_reasoning_effort` is a top-level key, but the same key is also legal
+    /// under `[profiles.*]` and other tables. Table headers are tracked so a
+    /// profile's value is never reported as — and then used to overwrite — the
+    /// top-level setting. Returns `nil` when the top-level key is absent, so the
+    /// caller keeps its default.
+    func parseTopLevelCodexReasoningEffort(from content: String) -> CodexReasoningEffort? {
+        var scanner = CodexTOMLScanner()
+        var effort: CodexReasoningEffort?
+
+        for line in content.components(separatedBy: .newlines) {
+            guard scanner.isStructuralLine(line) else { continue }
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            // Everything from the first table header on belongs to that table.
+            if parseTOMLSectionName(from: trimmed) != nil {
+                return effort
+            }
+
+            if let value = extractCodexTOMLStringValue(from: trimmed, key: "model_reasoning_effort") {
+                effort = CodexReasoningEffort(rawValue: value)
+            }
+        }
+
+        return effort
+    }
+
+    /// Reads the value of a TOML assignment to `key`, tolerating quoted keys,
+    /// literal strings and trailing comments. Returns `nil` unless the line is
+    /// an assignment to exactly `key` with a value this parser can round-trip.
+    private func extractCodexTOMLStringValue(from line: String, key: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.hasPrefix("#"), let equalIndex = trimmed.firstIndex(of: "=") else { return nil }
+
+        var lineKey = String(trimmed[..<equalIndex]).trimmingCharacters(in: .whitespaces)
+        if lineKey.count >= 2, let first = lineKey.first, lineKey.last == first, first == "\"" || first == "'" {
+            lineKey = String(lineKey.dropFirst().dropLast())
+        }
+        guard lineKey == key else { return nil }
+
+        let value = String(trimmed[trimmed.index(after: equalIndex)...])
+            .trimmingCharacters(in: .whitespaces)
+        return parseCodexTOMLScalarString(value)
+    }
+
+    private func parseCodexTOMLScalarString(_ value: String) -> String? {
+        let characters = Array(value)
+        guard let first = characters.first else { return nil }
+
+        // Multi-line strings are not a value Quotio can safely round-trip.
+        if characters.count >= 3, characters[1] == first, characters[2] == first,
+           first == "\"" || first == "'" {
+            return nil
+        }
+
+        if first == "\"" {
+            var result = ""
+            var index = 1
+            while index < characters.count {
+                let character = characters[index]
+                if character == "\\" {
+                    index += 1
+                    guard index < characters.count else { return nil }
+                    switch characters[index] {
+                    case "n": result.append("\n")
+                    case "t": result.append("\t")
+                    case "r": result.append("\r")
+                    case "\"": result.append("\"")
+                    case "\\": result.append("\\")
+                    // Don't guess at \u / \b / \f — leave the value untouched.
+                    default: return nil
+                    }
+                    index += 1
+                    continue
+                }
+                if character == "\"" {
+                    return result.isEmpty ? nil : result
+                }
+                result.append(character)
+                index += 1
+            }
+            return nil  // Unterminated string.
+        }
+
+        if first == "'" {
+            guard let closingIndex = value.dropFirst().firstIndex(of: "'") else { return nil }
+            let literal = String(value[value.index(after: value.startIndex)..<closingIndex])
+            return literal.isEmpty ? nil : literal
+        }
+
+        // Bare value: invalid TOML for a string, but read it leniently rather
+        // than discarding what the user wrote.
+        let bare = value
+            .split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)[0]
+            .trimmingCharacters(in: .whitespaces)
+        return bare.isEmpty ? nil : bare
+    }
+
     private typealias ManagedCodexConfigParts = (topLevel: [String], section: [String])
 
     private func splitManagedCodexConfig(_ managedConfig: String) -> ManagedCodexConfigParts {
@@ -415,11 +587,14 @@ actor AgentConfigurationService {
         var filteredLines: [String] = []
         var skippingCliproxySection = false
         var hasSeenAnySection = false
+        var scanner = CodexTOMLScanner()
 
         for line in lines {
+            // Lines inside a multi-line string body are content, never structure.
+            let isStructural = scanner.isStructuralLine(line)
             let trimmed = line.trimmingCharacters(in: .whitespaces)
 
-            if let sectionName = parseTOMLSectionName(from: trimmed) {
+            if isStructural, let sectionName = parseTOMLSectionName(from: trimmed) {
                 let cliproxySection = "model_providers.cliproxyapi"
                 if sectionName == cliproxySection || sectionName.hasPrefix(cliproxySection + ".") {
                     skippingCliproxySection = true
@@ -433,11 +608,11 @@ actor AgentConfigurationService {
                 continue
             }
 
-            if let managedBanner, !hasSeenAnySection && trimmed == managedBanner {
+            if let managedBanner, isStructural, !hasSeenAnySection && trimmed == managedBanner {
                 continue
             }
 
-            if !hasSeenAnySection && isCodexManagedTopLevelKey(trimmed) {
+            if isStructural, !hasSeenAnySection && isCodexManagedTopLevelKey(trimmed) {
                 continue
             }
 
@@ -453,8 +628,13 @@ actor AgentConfigurationService {
 
     private func composeMergedCodexConfig(filteredLines: [String], managedParts: ManagedCodexConfigParts) -> String {
         var firstSectionIndex = filteredLines.count
-        if let sectionIndex = filteredLines.firstIndex(where: { parseTOMLSectionName(from: $0) != nil }) {
-            firstSectionIndex = sectionIndex
+        var scanner = CodexTOMLScanner()
+        for (index, line) in filteredLines.enumerated() {
+            guard scanner.isStructuralLine(line) else { continue }
+            if parseTOMLSectionName(from: line) != nil {
+                firstSectionIndex = index
+                break
+            }
         }
 
         var topLevelLines = Array(filteredLines[..<firstSectionIndex])

--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -17,6 +17,8 @@ actor AgentConfigurationService {
         let modelSlots: [ModelSlot: String]
         let isProxyConfigured: Bool
         let backupFiles: [BackupFile]
+        /// Reasoning effort read from Codex CLI's `model_reasoning_effort` (Codex only).
+        var reasoningEffort: CodexReasoningEffort? = nil
     }
     
     /// Represents a backup file that can be restored
@@ -155,11 +157,12 @@ actor AgentConfigurationService {
         // Simple TOML parsing for the values we need
         var baseURL: String?
         var model: String?
+        var reasoningEffort: CodexReasoningEffort?
         var isProxy = false
-        
+
         for line in content.components(separatedBy: .newlines) {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
-            
+
             if trimmed.hasPrefix("base_url") {
                 if let value = extractTOMLValue(from: trimmed) {
                     baseURL = value
@@ -167,6 +170,10 @@ actor AgentConfigurationService {
                 }
             } else if trimmed.hasPrefix("model =") {
                 model = extractTOMLValue(from: trimmed)
+            } else if trimmed.hasPrefix("model_reasoning_effort") {
+                if let value = extractTOMLValue(from: trimmed) {
+                    reasoningEffort = CodexReasoningEffort(rawValue: value)
+                }
             } else if trimmed.contains("model_provider") && trimmed.contains("cliproxyapi") {
                 isProxy = true
             }
@@ -182,7 +189,8 @@ actor AgentConfigurationService {
             apiKey: nil,  // API key is in auth.json
             modelSlots: modelSlots,
             isProxyConfigured: isProxy,
-            backupFiles: listBackups(agent: .codexCLI)
+            backupFiles: listBackups(agent: .codexCLI),
+            reasoningEffort: reasoningEffort
         )
     }
     
@@ -337,7 +345,11 @@ actor AgentConfigurationService {
         return escaped
     }
 
-    private func buildManagedCodexTOML(model: String, proxyURL: String) -> String {
+    func buildManagedCodexTOML(
+        model: String,
+        proxyURL: String,
+        reasoningEffort: CodexReasoningEffort = .defaultEffort
+    ) -> String {
         let escapedModel = escapeTOMLString(model)
         let escapedProxyURL = escapeTOMLString(proxyURL)
 
@@ -345,7 +357,7 @@ actor AgentConfigurationService {
         # CLIProxyAPI Configuration for Codex CLI
         model_provider = "cliproxyapi"
         model = "\(escapedModel)"
-        model_reasoning_effort = "high"
+        model_reasoning_effort = "\(reasoningEffort.rawValue)"
 
         [model_providers.cliproxyapi]
         name = "cliproxyapi"
@@ -510,7 +522,7 @@ actor AgentConfigurationService {
             .trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
     }
 
-    private func mergeCodexConfig(existingContent: String, managedConfig: String) -> String {
+    func mergeCodexConfig(existingContent: String, managedConfig: String) -> String {
         let managedBanner = extractManagedCodexBanner(from: managedConfig)
         let managedParts = splitManagedCodexConfig(managedConfig)
         let filteredLines = filterExistingCodexLines(existingContent: existingContent, managedBanner: managedBanner)
@@ -989,7 +1001,8 @@ actor AgentConfigurationService {
 
         let managedConfigTOML = buildManagedCodexTOML(
             model: config.modelSlots[.sonnet] ?? "gpt-5-codex",
-            proxyURL: config.proxyURL
+            proxyURL: config.proxyURL,
+            reasoningEffort: config.codexReasoningEffort
         )
 
         let configTOML: String

--- a/Quotio/ViewModels/AgentSetupViewModel.swift
+++ b/Quotio/ViewModels/AgentSetupViewModel.swift
@@ -142,7 +142,12 @@ final class AgentSetupViewModel {
         for (slot, model) in saved.modelSlots {
             currentConfiguration?.modelSlots[slot] = model
         }
-        
+
+        // Restore saved Codex reasoning effort
+        if let effort = saved.reasoningEffort {
+            currentConfiguration?.codexReasoningEffort = effort
+        }
+
         // Update setup mode in current configuration
         currentConfiguration?.setupMode = selectedSetupMode
     }
@@ -178,6 +183,10 @@ final class AgentSetupViewModel {
 
     func updateModelSlot(_ slot: ModelSlot, model: String) {
         currentConfiguration?.modelSlots[slot] = model
+    }
+
+    func updateReasoningEffort(_ effort: CodexReasoningEffort) {
+        currentConfiguration?.codexReasoningEffort = effort
     }
 
     func applyConfiguration() async {

--- a/Quotio/Views/Components/AgentConfigSheet.swift
+++ b/Quotio/Views/Components/AgentConfigSheet.swift
@@ -128,7 +128,11 @@ struct AgentConfigSheet: View {
                 if agent == .claudeCode {
                     modelSlotsSection
                 }
-                
+
+                if agent == .codexCLI {
+                    reasoningEffortSection
+                }
+
                 if isManualMode {
                     manualPreviewSection
                 }
@@ -370,6 +374,42 @@ struct AgentConfigSheet: View {
         .clipShape(RoundedRectangle(cornerRadius: 10))
     }
     
+    private var reasoningEffortSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("agents.reasoningEffort".localized())
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Spacer(minLength: 12)
+
+                Picker("", selection: Binding(
+                    get: { viewModel.currentConfiguration?.codexReasoningEffort ?? .defaultEffort },
+                    set: { effort in
+                        viewModel.updateReasoningEffort(effort)
+                        if isManualMode {
+                            generatePreview()
+                        }
+                    }
+                )) {
+                    ForEach(CodexReasoningEffort.allCases) { effort in
+                        Text(effort.displayName)
+                            .tag(effort)
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(maxWidth: 280)
+            }
+
+            Text("agents.reasoningEffort.info".localized())
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(14)
+        .background(Color(.controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
     private var oauthToggleSection: some View {
         Toggle(isOn: Binding(
             get: { viewModel.currentConfiguration?.useOAuth ?? true },

--- a/Quotio/Views/Components/AgentConfigSheet.swift
+++ b/Quotio/Views/Components/AgentConfigSheet.swift
@@ -374,6 +374,17 @@ struct AgentConfigSheet: View {
         .clipShape(RoundedRectangle(cornerRadius: 10))
     }
     
+    /// Named efforts plus, when the existing config holds a value Quotio does
+    /// not name, that value — so it stays selected and survives a save.
+    private var reasoningEffortOptions: [CodexReasoningEffort] {
+        let current = viewModel.currentConfiguration?.codexReasoningEffort ?? .defaultEffort
+        var options = CodexReasoningEffort.allCases
+        if !options.contains(current) {
+            options.append(current)
+        }
+        return options
+    }
+
     private var reasoningEffortSection: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
@@ -392,7 +403,7 @@ struct AgentConfigSheet: View {
                         }
                     }
                 )) {
-                    ForEach(CodexReasoningEffort.allCases) { effort in
+                    ForEach(reasoningEffortOptions) { effort in
                         Text(effort.displayName)
                             .tag(effort)
                     }

--- a/QuotioTests/CodexReasoningEffortTests.swift
+++ b/QuotioTests/CodexReasoningEffortTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import Quotio
+
+final class CodexReasoningEffortTests: XCTestCase {
+    private let service = AgentConfigurationService()
+
+    // MARK: - Managed TOML Generation
+
+    func testManagedTOMLEmitsSelectedReasoningEffort() async {
+        for effort in CodexReasoningEffort.allCases {
+            let toml = await service.buildManagedCodexTOML(
+                model: "gpt-5-codex",
+                proxyURL: "http://127.0.0.1:8317/v1",
+                reasoningEffort: effort
+            )
+
+            XCTAssertTrue(
+                toml.contains("model_reasoning_effort = \"\(effort.rawValue)\""),
+                "Expected managed TOML to contain effort \(effort.rawValue)"
+            )
+        }
+    }
+
+    func testManagedTOMLDefaultsToHighReasoningEffort() async {
+        let toml = await service.buildManagedCodexTOML(
+            model: "gpt-5-codex",
+            proxyURL: "http://127.0.0.1:8317/v1"
+        )
+
+        XCTAssertTrue(toml.contains("model_reasoning_effort = \"high\""))
+    }
+
+    func testDefaultConfigurationUsesHighReasoningEffort() {
+        let config = AgentConfiguration(
+            agent: .codexCLI,
+            proxyURL: "http://127.0.0.1:8317/v1",
+            apiKey: "quotio-test-key"
+        )
+
+        XCTAssertEqual(config.codexReasoningEffort, .high)
+        XCTAssertEqual(CodexReasoningEffort.defaultEffort, .high)
+    }
+
+    func testReasoningEffortRawValuesMatchCodexCLI() {
+        XCTAssertEqual(
+            CodexReasoningEffort.allCases.map(\.rawValue),
+            ["minimal", "low", "medium", "high", "xhigh"]
+        )
+    }
+
+    // MARK: - Managed-Key Merge
+
+    func testMergeReplacesManagedReasoningEffortAndPreservesUserKeys() async {
+        let existing = """
+        # user banner
+        approval_policy = "never"
+        model_provider = "cliproxyapi"
+        model = "gpt-5-codex"
+        model_reasoning_effort = "high"
+
+        [profiles.fast]
+        model = "gpt-5-codex-mini"
+        """
+
+        let managed = await service.buildManagedCodexTOML(
+            model: "gpt-5.1-codex-max",
+            proxyURL: "http://127.0.0.1:8317/v1",
+            reasoningEffort: .xhigh
+        )
+
+        let merged = await service.mergeCodexConfig(
+            existingContent: existing,
+            managedConfig: managed
+        )
+
+        // Managed keys are replaced with the newly selected values
+        XCTAssertTrue(merged.contains("model_reasoning_effort = \"xhigh\""))
+        XCTAssertFalse(merged.contains("model_reasoning_effort = \"high\""))
+        XCTAssertTrue(merged.contains("model = \"gpt-5.1-codex-max\""))
+
+        // User content survives the merge
+        XCTAssertTrue(merged.contains("approval_policy = \"never\""))
+        XCTAssertTrue(merged.contains("[profiles.fast]"))
+        XCTAssertTrue(merged.contains("model = \"gpt-5-codex-mini\""))
+    }
+
+    func testMergeEmitsSingleReasoningEffortKey() async {
+        let existing = """
+        model_reasoning_effort = "low"
+        custom_key = "value"
+        """
+
+        let managed = await service.buildManagedCodexTOML(
+            model: "gpt-5-codex",
+            proxyURL: "http://127.0.0.1:8317/v1",
+            reasoningEffort: .medium
+        )
+
+        let merged = await service.mergeCodexConfig(
+            existingContent: existing,
+            managedConfig: managed
+        )
+
+        let occurrences = merged
+            .components(separatedBy: .newlines)
+            .filter { $0.trimmingCharacters(in: .whitespaces).hasPrefix("model_reasoning_effort") }
+
+        XCTAssertEqual(occurrences.count, 1)
+        XCTAssertTrue(merged.contains("model_reasoning_effort = \"medium\""))
+        XCTAssertTrue(merged.contains("custom_key = \"value\""))
+    }
+}

--- a/QuotioTests/CodexReasoningEffortTests.swift
+++ b/QuotioTests/CodexReasoningEffortTests.swift
@@ -4,13 +4,176 @@ import XCTest
 final class CodexReasoningEffortTests: XCTestCase {
     private let service = AgentConfigurationService()
 
+    private let proxyURL = "http://127.0.0.1:8317/v1"
+
+    // MARK: - Accepted Values
+    //
+    // Codex parses `model_reasoning_effort` as an OPEN set. `ReasoningEffort` in
+    // codex-rs/protocol/src/openai_models.rs names none/minimal/low/medium/high/
+    // xhigh/max/ultra and its `FromStr` maps every other non-empty string to
+    // `ReasoningEffort::Custom`; only the empty string is rejected.
+
+    func testNamedEffortsCoverEveryValueCodexNames() {
+        XCTAssertEqual(
+            CodexReasoningEffort.allCases.map(\.rawValue),
+            ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
+        )
+    }
+
+    func testNamedValuesDecodeToNamedCasesNotCustom() {
+        for effort in CodexReasoningEffort.allCases {
+            let decoded = CodexReasoningEffort(rawValue: effort.rawValue)
+            XCTAssertEqual(decoded, effort)
+            if case .custom = decoded {
+                XCTFail("\(effort.rawValue) must not decode as a custom value")
+            }
+        }
+    }
+
+    func testUnknownNonEmptyValueDecodesAsCustomAndRoundTrips() {
+        let decoded = CodexReasoningEffort(rawValue: "turbo")
+        XCTAssertEqual(decoded, .custom("turbo"))
+        XCTAssertEqual(decoded?.rawValue, "turbo")
+    }
+
+    func testEmptyValueIsRejected() {
+        // Codex errors with "reasoning_effort must not be empty".
+        XCTAssertNil(CodexReasoningEffort(rawValue: ""))
+    }
+
+    func testCodableRoundTripsCustomValue() throws {
+        let encoded = try JSONEncoder().encode(CodexReasoningEffort.custom("turbo"))
+        XCTAssertEqual(String(data: encoded, encoding: .utf8), "\"turbo\"")
+
+        let decoded = try JSONDecoder().decode(CodexReasoningEffort.self, from: encoded)
+        XCTAssertEqual(decoded, .custom("turbo"))
+    }
+
+    // MARK: - Section-Aware Parsing
+
+    func testTopLevelValueWinsOverProfileValues() async {
+        let content = """
+        model_provider = "cliproxyapi"
+        model_reasoning_effort = "low"
+
+        [profiles.work]
+        model_reasoning_effort = "minimal"
+
+        [profiles.deep]
+        model_reasoning_effort = "xhigh"
+        """
+
+        let effort = await service.parseTopLevelCodexReasoningEffort(from: content)
+        XCTAssertEqual(effort, .low)
+    }
+
+    func testProfileOnlyValueIsNotReportedAsTopLevel() async {
+        let content = """
+        model_provider = "cliproxyapi"
+
+        [profiles.work]
+        model_reasoning_effort = "minimal"
+        """
+
+        // Nothing at the top level: the caller must keep its default rather than
+        // adopt (and later write back) the profile's value.
+        let effort = await service.parseTopLevelCodexReasoningEffort(from: content)
+        XCTAssertNil(effort)
+    }
+
+    func testArrayOfTablesEndsTheTopLevelRegion() async {
+        let content = """
+        model = "gpt-5-codex"
+
+        [[mcp_servers]]
+        model_reasoning_effort = "ultra"
+        """
+
+        let effort = await service.parseTopLevelCodexReasoningEffort(from: content)
+        XCTAssertNil(effort)
+    }
+
+    func testMissingKeyReturnsNil() async {
+        let content = """
+        model_provider = "cliproxyapi"
+        model = "gpt-5-codex"
+        """
+
+        let effort = await service.parseTopLevelCodexReasoningEffort(from: content)
+        XCTAssertNil(effort)
+    }
+
+    func testCommentedKeyIsIgnored() async {
+        let content = """
+        # model_reasoning_effort = "minimal"
+          #model_reasoning_effort = "low"
+        model = "gpt-5-codex"
+        """
+
+        let effort = await service.parseTopLevelCodexReasoningEffort(from: content)
+        XCTAssertNil(effort)
+    }
+
+    func testKeyInsideMultiLineStringIsIgnored() async {
+        let content = """
+        notify = \"\"\"
+        model_reasoning_effort = "minimal"
+        [profiles.work]
+        \"\"\"
+        model_reasoning_effort = "max"
+        """
+
+        // The string body must not be read as a key, and the `[profiles.work]`
+        // line inside it must not end the top-level region.
+        let effort = await service.parseTopLevelCodexReasoningEffort(from: content)
+        XCTAssertEqual(effort, .max)
+    }
+
+    func testTrailingCommentIsNotPartOfTheValue() async {
+        let content = #"model_reasoning_effort = "ultra"  # deepest"#
+
+        let effort = await service.parseTopLevelCodexReasoningEffort(from: content)
+        XCTAssertEqual(effort, .ultra)
+    }
+
+    func testQuotedKeyIsRecognised() async {
+        let content = #""model_reasoning_effort" = "none""#
+
+        let effort = await service.parseTopLevelCodexReasoningEffort(from: content)
+        XCTAssertEqual(effort, CodexReasoningEffort.none)
+    }
+
+    func testLiteralStringValueIsRead() async {
+        let content = "model_reasoning_effort = 'ultra'"
+
+        let effort = await service.parseTopLevelCodexReasoningEffort(from: content)
+        XCTAssertEqual(effort, .ultra)
+    }
+
+    func testSimilarlyNamedKeysAreNotMatched() async {
+        let content = """
+        model_reasoning_effort_override = "minimal"
+        plan_mode_reasoning_effort = "low"
+        """
+
+        let effort = await service.parseTopLevelCodexReasoningEffort(from: content)
+        XCTAssertNil(effort)
+    }
+
+    func testEmptyValueParsesAsNoValue() async {
+        let content = #"model_reasoning_effort = """#
+
+        let effort = await service.parseTopLevelCodexReasoningEffort(from: content)
+        XCTAssertNil(effort)
+    }
+
     // MARK: - Managed TOML Generation
 
     func testManagedTOMLEmitsSelectedReasoningEffort() async {
         for effort in CodexReasoningEffort.allCases {
             let toml = await service.buildManagedCodexTOML(
                 model: "gpt-5-codex",
-                proxyURL: "http://127.0.0.1:8317/v1",
+                proxyURL: proxyURL,
                 reasoningEffort: effort
             )
 
@@ -22,18 +185,25 @@ final class CodexReasoningEffortTests: XCTestCase {
     }
 
     func testManagedTOMLDefaultsToHighReasoningEffort() async {
-        let toml = await service.buildManagedCodexTOML(
-            model: "gpt-5-codex",
-            proxyURL: "http://127.0.0.1:8317/v1"
-        )
+        let toml = await service.buildManagedCodexTOML(model: "gpt-5-codex", proxyURL: proxyURL)
 
         XCTAssertTrue(toml.contains("model_reasoning_effort = \"high\""))
+    }
+
+    func testManagedTOMLEscapesCustomReasoningEffort() async {
+        let toml = await service.buildManagedCodexTOML(
+            model: "gpt-5-codex",
+            proxyURL: proxyURL,
+            reasoningEffort: .custom("we\"ird")
+        )
+
+        XCTAssertTrue(toml.contains(#"model_reasoning_effort = "we\"ird""#))
     }
 
     func testDefaultConfigurationUsesHighReasoningEffort() {
         let config = AgentConfiguration(
             agent: .codexCLI,
-            proxyURL: "http://127.0.0.1:8317/v1",
+            proxyURL: proxyURL,
             apiKey: "quotio-test-key"
         )
 
@@ -41,11 +211,92 @@ final class CodexReasoningEffortTests: XCTestCase {
         XCTAssertEqual(CodexReasoningEffort.defaultEffort, .high)
     }
 
-    func testReasoningEffortRawValuesMatchCodexCLI() {
-        XCTAssertEqual(
-            CodexReasoningEffort.allCases.map(\.rawValue),
-            ["minimal", "low", "medium", "high", "xhigh"]
+    // MARK: - Open → Save Is Non-Destructive
+    //
+    // Reproduces what the sheet does: read the existing config, seed the picker
+    // with what was read, then save without touching the picker.
+
+    private func openThenSave(existing: String, model: String = "gpt-5-codex") async -> String {
+        let effort = await service.parseTopLevelCodexReasoningEffort(from: existing)
+            ?? .defaultEffort
+        let managed = await service.buildManagedCodexTOML(
+            model: model,
+            proxyURL: proxyURL,
+            reasoningEffort: effort
         )
+        return await service.mergeCodexConfig(existingContent: existing, managedConfig: managed)
+    }
+
+    func testOpenThenSavePreservesUnknownTopLevelValue() async {
+        for value in ["none", "max", "ultra", "turbo"] {
+            let existing = """
+            model_provider = "cliproxyapi"
+            model = "gpt-5-codex"
+            model_reasoning_effort = "\(value)"
+            """
+
+            let merged = await openThenSave(existing: existing)
+
+            XCTAssertTrue(
+                merged.contains("model_reasoning_effort = \"\(value)\""),
+                "Saving must preserve the existing value \(value)"
+            )
+            let reread = await service.parseTopLevelCodexReasoningEffort(from: merged)
+            XCTAssertEqual(reread?.rawValue, value)
+        }
+    }
+
+    func testOpenThenSaveDoesNotAdoptProfileValue() async {
+        let existing = """
+        model_provider = "cliproxyapi"
+        model = "gpt-5-codex"
+        model_reasoning_effort = "ultra"
+
+        [profiles.work]
+        model_reasoning_effort = "minimal"
+        """
+
+        let merged = await openThenSave(existing: existing)
+
+        // The top-level setting survives...
+        let mergedEffort = await service.parseTopLevelCodexReasoningEffort(from: merged)
+        XCTAssertEqual(mergedEffort, .ultra)
+        // ...and the profile is left exactly as the user wrote it.
+        XCTAssertTrue(merged.contains("[profiles.work]"))
+        XCTAssertTrue(merged.contains("model_reasoning_effort = \"minimal\""))
+    }
+
+    func testOpenThenSaveWithNoTopLevelKeyWritesTheDefault() async {
+        let existing = """
+        approval_policy = "never"
+
+        [profiles.work]
+        model_reasoning_effort = "minimal"
+        """
+
+        let merged = await openThenSave(existing: existing)
+
+        let mergedEffort = await service.parseTopLevelCodexReasoningEffort(from: merged)
+        XCTAssertEqual(mergedEffort, .high)
+        XCTAssertTrue(merged.contains("approval_policy = \"never\""))
+        XCTAssertTrue(merged.contains("model_reasoning_effort = \"minimal\""))
+    }
+
+    func testOpenThenSavePreservesMultiLineStringBodies() async {
+        let existing = """
+        model_reasoning_effort = "ultra"
+        notify = \"\"\"
+        model = "do not touch"
+        model_provider = "do not touch either"
+        \"\"\"
+        """
+
+        let merged = await openThenSave(existing: existing)
+
+        XCTAssertTrue(merged.contains(#"model = "do not touch""#))
+        XCTAssertTrue(merged.contains(#"model_provider = "do not touch either""#))
+        let mergedEffort = await service.parseTopLevelCodexReasoningEffort(from: merged)
+        XCTAssertEqual(mergedEffort, .ultra)
     }
 
     // MARK: - Managed-Key Merge
@@ -64,7 +315,7 @@ final class CodexReasoningEffortTests: XCTestCase {
 
         let managed = await service.buildManagedCodexTOML(
             model: "gpt-5.1-codex-max",
-            proxyURL: "http://127.0.0.1:8317/v1",
+            proxyURL: proxyURL,
             reasoningEffort: .xhigh
         )
 
@@ -84,7 +335,7 @@ final class CodexReasoningEffortTests: XCTestCase {
         XCTAssertTrue(merged.contains("model = \"gpt-5-codex-mini\""))
     }
 
-    func testMergeEmitsSingleReasoningEffortKey() async {
+    func testMergeEmitsSingleTopLevelReasoningEffortKey() async {
         let existing = """
         model_reasoning_effort = "low"
         custom_key = "value"
@@ -92,7 +343,7 @@ final class CodexReasoningEffortTests: XCTestCase {
 
         let managed = await service.buildManagedCodexTOML(
             model: "gpt-5-codex",
-            proxyURL: "http://127.0.0.1:8317/v1",
+            proxyURL: proxyURL,
             reasoningEffort: .medium
         )
 


### PR DESCRIPTION
## Motivation

Quotio hardcodes `model_reasoning_effort = "high"` when generating `~/.codex/config.toml`, so there is no way to pick a different effort level from the app. Codex CLI accepts `minimal`, `low`, `medium`, `high`, and `xhigh` (model-dependent), and users want to tune this per their workflow.

Closes #384

## What changed

- **New `CodexReasoningEffort` enum** (`AgentModels.swift`) with the five values Codex CLI accepts, plus a `defaultEffort` of `.high` that preserves current behavior.
- **`AgentConfiguration.codexReasoningEffort`** carries the selection into config generation; `buildManagedCodexTOML` now emits the selected value instead of the hardcoded string.
- **UI**: the Codex agent configuration sheet gains a "Reasoning Effort" section with a menu picker (proxy mode), styled like the existing Model Slots section. In manual mode, changing the effort regenerates the raw config preview.
- **Round-trip**: `readCodexConfig` now parses `model_reasoning_effort` from an existing `config.toml`, so reopening the sheet pre-selects the currently saved level. The managed-key merge logic already treats `model_reasoning_effort` as a managed top-level key, so user-edited config files keep round-tripping correctly with exactly one effort key emitted.
- **Localization**: new strings added for all catalog languages (en, fr, vi, zh-Hans).

## UI

The Codex configuration sheet now shows a "Reasoning Effort" card between Connection Info and the manual preview/test sections, with a dropdown of Minimal / Low / Medium / High / Extra High and a caption explaining the tradeoff. Default selection is High.

## Testing

- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build` — succeeds
- `xcodebuild test -scheme Quotio -destination 'platform=macOS'` — all tests pass, including 6 new tests in `QuotioTests/CodexReasoningEffortTests.swift`:
  - managed TOML emits each selected effort value
  - default stays `high` (both enum default and generated TOML)
  - raw values match Codex CLI's accepted set
  - merge with a user-edited config replaces the managed effort key, preserves user keys/sections, and emits the key exactly once