### PR TITLE
feat(menubar): add quota bucket selector for menu bar value

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -14098,6 +14098,118 @@
     "Refresh" : {
 
     },
+    "quota.window.daily" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daily"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quotidien"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hàng ngày"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每日"
+          }
+        }
+      }
+    },
+    "quota.window.monthly" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monthly"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mensuel"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hàng tháng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每月"
+          }
+        }
+      }
+    },
+    "quota.window.session" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session (5h)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session (5 h)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phiên (5 giờ)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "会话（5 小时）"
+          }
+        }
+      }
+    },
+    "quota.window.weekly" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weekly"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hebdomadaire"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hàng tuần"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每周"
+          }
+        }
+      }
+    },
     "remote.advanced" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -16650,6 +16762,90 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "彩色"
+          }
+        }
+      }
+    },
+    "settings.menubar.bucket.auto" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatic"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatique"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tự động"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动"
+          }
+        }
+      }
+    },
+    "settings.menubar.bucket.help" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pick which quota each menu bar item shows. Options come from the quotas the provider actually reports for that account. Automatic keeps the combined value described in Usage Display."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisissez le quota affiché par chaque élément de la barre de menus. Les options proviennent des quotas réellement signalés par le fournisseur pour ce compte. Automatique conserve la valeur combinée décrite dans Affichage de l’utilisation."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn hạn mức mà mỗi mục trên thanh menu hiển thị. Các lựa chọn đến từ những hạn mức mà nhà cung cấp thực sự báo cáo cho tài khoản đó. Tự động giữ nguyên giá trị tổng hợp được mô tả trong Hiển thị mức sử dụng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择每个菜单栏项目显示的配额。选项来自提供商为该账户实际报告的配额。“自动”保留“用量显示”中描述的合并值。"
+          }
+        }
+      }
+    },
+    "settings.menubar.bucket.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menu Bar Value"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valeur de la barre de menus"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giá trị trên thanh menu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "菜单栏数值"
           }
         }
       }

--- a/Quotio/Models/MenuBarBucketSelection.swift
+++ b/Quotio/Models/MenuBarBucketSelection.swift
@@ -1,0 +1,147 @@
+//
+//  MenuBarBucketSelection.swift
+//  Quotio
+//
+//  Per-item choice of which quota bucket the menu bar value shows (issue #393).
+//
+
+import Foundation
+
+// MARK: - Selection
+
+/// What a single menu bar item shows.
+///
+/// Buckets are addressed either by the window their producing fetcher declared
+/// (`QuotaWindow`) or by the exact `ModelQuota.name`, so a user can pin the
+/// Factory Standard five-hour pool, the Antigravity Gemini session pool, or a
+/// paid on-demand bucket rather than an aggregate.
+nonisolated enum MenuBarBucketSelection: Codable, Hashable, Sendable {
+    /// Existing behaviour: aggregate every bucket per the usage display settings.
+    case auto
+    /// Every bucket the fetcher declared as this window, aggregated per
+    /// `ModelAggregationMode`.
+    case window(QuotaWindow)
+    /// One exact bucket, addressed by `ModelQuota.name`.
+    case bucket(String)
+}
+
+// MARK: - Resolution
+
+nonisolated enum MenuBarBucketResolver {
+    /// The remaining percentage for `selection`, or `nil` when the selection is
+    /// not available for this account — no bucket carries that window, the named
+    /// bucket is gone, or the value is the `-1` unknown sentinel. Callers fall
+    /// back to the aggregate total in that case.
+    static func percent(
+        models: [ModelQuota],
+        selection: MenuBarBucketSelection,
+        aggregation: ModelAggregationMode
+    ) -> Double? {
+        switch selection {
+        case .auto:
+            return nil
+
+        case .window(let window):
+            let matching = models.filter { $0.window == window }.map(\.percentage)
+            let value = QuotaUsageCalculator.aggregate(matching, mode: aggregation)
+            return value >= 0 ? value : nil
+
+        case .bucket(let name):
+            guard let model = models.first(where: { $0.name == name }), model.percentage >= 0 else {
+                return nil
+            }
+            return model.percentage
+        }
+    }
+
+    /// Selections offered for an account, in menu order: automatic, then each
+    /// window at least one bucket declares, then every individual bucket that
+    /// reports a percentage.
+    ///
+    /// Buckets with the `-1` unknown sentinel (status rows such as
+    /// `grok-extra-usage`, currency balances such as `factory-extra-balance`) are
+    /// omitted: the menu bar renders a percentage, which they do not have.
+    static func options(for models: [ModelQuota]) -> [MenuBarBucketSelection] {
+        var options: [MenuBarBucketSelection] = [.auto]
+
+        for window in QuotaWindow.allCases where models.contains(where: { $0.window == window }) {
+            options.append(.window(window))
+        }
+
+        var seen = Set<String>()
+        for model in models where model.percentage >= 0 && seen.insert(model.name).inserted {
+            options.append(.bucket(model.name))
+        }
+
+        return options
+    }
+
+    /// Whether a stored selection can still be honored for this account.
+    static func isAvailable(
+        _ selection: MenuBarBucketSelection,
+        in models: [ModelQuota]
+    ) -> Bool {
+        switch selection {
+        case .auto:
+            return true
+        case .window(let window):
+            return models.contains { $0.window == window }
+        case .bucket(let name):
+            return models.contains { $0.name == name }
+        }
+    }
+}
+
+// MARK: - Labels
+
+extension MenuBarBucketSelection {
+    /// Localization key for the selection, or `nil` for `.bucket` — a specific
+    /// bucket is labelled with `ModelQuota.displayName`.
+    var localizationKey: String? {
+        switch self {
+        case .auto:
+            return "settings.menubar.bucket.auto"
+        case .window(let window):
+            return window.localizationKey
+        case .bucket:
+            return nil
+        }
+    }
+}
+
+extension QuotaWindow {
+    var localizationKey: String {
+        switch self {
+        case .session: return "quota.window.session"
+        case .daily: return "quota.window.daily"
+        case .weekly: return "quota.window.weekly"
+        case .monthly: return "quota.window.monthly"
+        }
+    }
+}
+
+// MARK: - Quota Lookup
+
+@MainActor
+extension QuotaViewModel {
+    /// Quota data for a menu bar item, tolerating the account-key variants the
+    /// menu bar selection can hold (`.json` suffix, Codex filename keys).
+    func menuBarQuotaData(for item: MenuBarQuotaItem) -> ProviderQuotaData? {
+        guard let provider = item.aiProvider,
+              let accountQuotas = providerQuotas[provider] else { return nil }
+
+        if let quotaData = accountQuotas[item.accountKey] {
+            return quotaData
+        }
+
+        let cleanKey = item.accountKey.hasSuffix(".json")
+            ? String(item.accountKey.dropLast(".json".count))
+            : item.accountKey
+        if let quotaData = accountQuotas[cleanKey] {
+            return quotaData
+        }
+
+        guard provider == .codex else { return nil }
+        return accountQuotas[item.accountKey.codexFilenameKey]
+    }
+}

--- a/Quotio/Models/MenuBarSettings.swift
+++ b/Quotio/Models/MenuBarSettings.swift
@@ -46,8 +46,17 @@ extension String {
 struct MenuBarQuotaItem: Codable, Identifiable, Hashable {
     let provider: String      // AIProvider.rawValue
     let accountKey: String    // email or account identifier
-    
+
+    /// Which quota bucket this item shows. Absent in selections persisted before
+    /// the bucket selector existed, which read as `.auto`.
+    var bucketSelection: MenuBarBucketSelection?
+
     var id: String { "\(provider)_\(accountKey)" }
+
+    /// The effective selection, defaulting to the aggregate value.
+    var resolvedBucketSelection: MenuBarBucketSelection {
+        bucketSelection ?? .auto
+    }
     
     /// Get the AIProvider enum value
     var aiProvider: AIProvider? {
@@ -524,7 +533,9 @@ final class MenuBarSettingsManager {
     }
     
     func addItem(_ item: MenuBarQuotaItem) {
-        guard !selectedItems.contains(item) else { return }
+        // Compare by identity: the bucket selection is an attribute of the item,
+        // not part of which account it points at.
+        guard !selectedItems.contains(where: { $0.id == item.id }) else { return }
         guard selectedItems.count < menuBarMaxItems else { return }
         if !showQuotaInMenuBar {
             showQuotaInMenuBar = true
@@ -543,7 +554,7 @@ final class MenuBarSettingsManager {
 
     /// Check if item is selected
     func isSelected(_ item: MenuBarQuotaItem) -> Bool {
-        selectedItems.contains(item)
+        selectedItems.contains { $0.id == item.id }
     }
 
     /// Toggle item selection (marks as user-modified to prevent auto-add)
@@ -556,6 +567,18 @@ final class MenuBarSettingsManager {
         }
     }
     
+    /// Read the bucket selection stored for an item
+    func bucketSelection(for item: MenuBarQuotaItem) -> MenuBarBucketSelection {
+        selectedItems.first { $0.id == item.id }?.resolvedBucketSelection ?? .auto
+    }
+
+    /// Store the bucket a menu bar item should display
+    func setBucketSelection(_ selection: MenuBarBucketSelection, for item: MenuBarQuotaItem) {
+        guard let index = selectedItems.firstIndex(where: { $0.id == item.id }) else { return }
+        guard selectedItems[index].resolvedBucketSelection != selection else { return }
+        selectedItems[index].bucketSelection = selection == .auto ? nil : selection
+    }
+
     /// Remove items that no longer exist in quota data
     func pruneInvalidItems(validItems: [MenuBarQuotaItem]) {
         let validIds = Set(validItems.map(\.id))

--- a/Quotio/Models/MenuBarSettings.swift
+++ b/Quotio/Models/MenuBarSettings.swift
@@ -284,52 +284,18 @@ enum ModelAggregationMode: String, CaseIterable, Identifiable, Codable {
 // MARK: - Usage Calculation Helpers
 
 extension MenuBarSettingsManager {
-    /// Compute total usage percentage using session/extra logic
-    /// Treats extra-usage, codex-extra, on-demand as extra models; all others as session
-    func totalUsagePercent(models: [(name: String, percentage: Double)]) -> Double {
-        let extraModelNames: Set<String> = ["extra-usage", "codex-extra", "on-demand"]
-        
-        var sessionPercentages: [Double] = []
-        var extraPercentages: [Double] = []
-        
-        for model in models {
-            if extraModelNames.contains(model.name) {
-                extraPercentages.append(model.percentage)
-            } else {
-                sessionPercentages.append(model.percentage)
-            }
-        }
-        
-        let sessionRemaining = aggregateModelPercentages(sessionPercentages)
-        let extraRemaining = aggregateModelPercentages(extraPercentages)
-        
-        let hasExtraModels = !extraPercentages.isEmpty
-        
-        switch totalUsageMode {
-        case .sessionOnly:
-            if sessionRemaining >= 0 {
-                return sessionRemaining
-            }
-            if hasExtraModels {
-                return extraRemaining
-            }
-            return -1
-            
-        case .combined:
-            let session = sessionRemaining >= 0 ? sessionRemaining : -1
-            let extra = extraRemaining >= 0 ? extraRemaining : -1
-            
-            if session < 0 && extra < 0 {
-                return -1
-            }
-            if session < 0 {
-                return extra
-            }
-            if extra < 0 {
-                return session
-            }
-            return max(session, extra)
-        }
+    /// Compute total usage percentage using session/extra logic.
+    ///
+    /// A bucket counts as paid extra usage only when the fetcher that produced it
+    /// declared `billing == .paidOverage`. Buckets with no declared billing kind
+    /// stay in the subscription group, so an unclassified bucket is never dropped
+    /// from `.sessionOnly` totals.
+    func totalUsagePercent(models: [ModelQuota]) -> Double {
+        QuotaUsageCalculator.totalUsagePercent(
+            models: models,
+            totalMode: totalUsageMode,
+            aggregation: modelAggregationMode
+        )
     }
     
     func calculateTotalUsagePercent(sessionPercent: Double?, extraPercent: Double?) -> Double {
@@ -358,15 +324,7 @@ extension MenuBarSettingsManager {
     }
     
     func aggregateModelPercentages(_ percentages: [Double]) -> Double {
-        let validPercentages = percentages.filter { $0 >= 0 }
-        guard !validPercentages.isEmpty else { return -1 }
-        
-        switch modelAggregationMode {
-        case .lowest:
-            return validPercentages.min() ?? -1
-        case .average:
-            return validPercentages.reduce(0, +) / Double(validPercentages.count)
-        }
+        QuotaUsageCalculator.aggregate(percentages, mode: modelAggregationMode)
     }
 }
 

--- a/Quotio/Models/QuotaBucketKind.swift
+++ b/Quotio/Models/QuotaBucketKind.swift
@@ -1,0 +1,117 @@
+//
+//  QuotaBucketKind.swift
+//  Quotio
+//
+//  Explicit, fetcher-declared classification of a quota bucket.
+//
+
+import Foundation
+
+// MARK: - Quota Window
+
+/// The recurring window a quota bucket refills on.
+///
+/// This is set by the fetcher that produced the bucket, from evidence in the
+/// provider payload (a declared window length, a period type, an explicit
+/// limit type). It is deliberately never derived from `ModelQuota.name`:
+/// those strings are display/identifier slugs — several of them are built at
+/// runtime from provider fields (`codex-<metered feature>`,
+/// `antigravity-<group>-<period>`, `warp-bonus-<n>`) — so they carry no
+/// reliable domain meaning.
+///
+/// A bucket whose window the provider does not state keeps `nil`. Unknown
+/// stays unknown; it is never guessed.
+nonisolated enum QuotaWindow: String, Codable, Sendable, CaseIterable, Hashable {
+    /// Short rolling window (Codex/Claude five-hour, ClinePass five-hour, ...).
+    case session
+    case daily
+    case weekly
+    case monthly
+}
+
+// MARK: - Quota Billing
+
+/// How a quota bucket is paid for.
+///
+/// Like `QuotaWindow`, this is declared by the producing fetcher and never
+/// inferred from the bucket name. `nil` means the provider payload gives no
+/// billing signal, and is treated as "not paid overage" so an unclassified
+/// bucket keeps counting toward subscription totals.
+nonisolated enum QuotaBilling: String, Codable, Sendable, Hashable {
+    /// Included in the plan.
+    case subscription
+    /// Billed on top of the plan (extra usage credits, on-demand spend).
+    case paidOverage
+}
+
+// MARK: - Usage Calculation
+
+/// Pure quota math shared by the menu bar, the dashboard and the quota screen.
+///
+/// Kept free of `MenuBarSettingsManager` so the calculation can be exercised
+/// without mutating (and persisting to) the app's real preferences.
+nonisolated enum QuotaUsageCalculator {
+    /// Aggregate a set of remaining percentages, ignoring the `-1` "unknown"
+    /// sentinel that fetchers use for status/balance rows.
+    /// Returns `-1` when nothing is known.
+    static func aggregate(_ percentages: [Double], mode: ModelAggregationMode) -> Double {
+        let valid = percentages.filter { $0 >= 0 }
+        guard !valid.isEmpty else { return -1 }
+
+        switch mode {
+        case .lowest:
+            return valid.min() ?? -1
+        case .average:
+            return valid.reduce(0, +) / Double(valid.count)
+        }
+    }
+
+    /// Split buckets into subscription and paid-overage groups using the
+    /// billing kind each fetcher declared, then combine per `totalMode`.
+    static func totalUsagePercent(
+        models: [ModelQuota],
+        totalMode: TotalUsageMode,
+        aggregation: ModelAggregationMode
+    ) -> Double {
+        var sessionPercentages: [Double] = []
+        var extraPercentages: [Double] = []
+
+        for model in models {
+            if model.billing == .paidOverage {
+                extraPercentages.append(model.percentage)
+            } else {
+                sessionPercentages.append(model.percentage)
+            }
+        }
+
+        let sessionRemaining = aggregate(sessionPercentages, mode: aggregation)
+        let extraRemaining = aggregate(extraPercentages, mode: aggregation)
+        let hasExtraModels = !extraPercentages.isEmpty
+
+        switch totalMode {
+        case .sessionOnly:
+            if sessionRemaining >= 0 {
+                return sessionRemaining
+            }
+            if hasExtraModels {
+                return extraRemaining
+            }
+            return -1
+
+        case .combined:
+            let session = sessionRemaining >= 0 ? sessionRemaining : -1
+            let extra = extraRemaining >= 0 ? extraRemaining : -1
+
+            if session < 0 && extra < 0 {
+                return -1
+            }
+            if session < 0 {
+                return extra
+            }
+            if extra < 0 {
+                return session
+            }
+            return max(session, extra)
+        }
+    }
+}

--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -120,8 +120,7 @@ final class AppBootstrap {
                ) {
                 isForbidden = quotaData.isForbidden
                 if !quotaData.models.isEmpty {
-                    let models = quotaData.models.map { (name: $0.name, percentage: $0.percentage) }
-                    displayPercent = menuBarSettings.totalUsagePercent(models: models)
+                    displayPercent = menuBarSettings.totalUsagePercent(models: quotaData.models)
                 }
             }
 

--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -112,15 +112,16 @@ final class AppBootstrap {
             var displayPercent: Double = -1
             var isForbidden = false
 
-            if let accountQuotas = viewModel.providerQuotas[provider],
-               let quotaData = resolveQuotaData(
-                   for: selectedItem,
-                   provider: provider,
-                   accountQuotas: accountQuotas
-               ) {
+            if let quotaData = viewModel.menuBarQuotaData(for: selectedItem) {
                 isForbidden = quotaData.isForbidden
                 if !quotaData.models.isEmpty {
-                    displayPercent = menuBarSettings.totalUsagePercent(models: quotaData.models)
+                    // The item's chosen bucket wins; the aggregate total is the
+                    // fallback when that bucket is absent for this account.
+                    displayPercent = MenuBarBucketResolver.percent(
+                        models: quotaData.models,
+                        selection: selectedItem.resolvedBucketSelection,
+                        aggregation: menuBarSettings.modelAggregationMode
+                    ) ?? menuBarSettings.totalUsagePercent(models: quotaData.models)
                 }
             }
 
@@ -137,25 +138,6 @@ final class AppBootstrap {
         return items
     }
 
-    private func resolveQuotaData(
-        for selectedItem: MenuBarQuotaItem,
-        provider: AIProvider,
-        accountQuotas: [String: ProviderQuotaData]
-    ) -> ProviderQuotaData? {
-        if let quotaData = accountQuotas[selectedItem.accountKey] {
-            return quotaData
-        }
-
-        let cleanKey = selectedItem.accountKey.hasSuffix(".json")
-            ? String(selectedItem.accountKey.dropLast(".json".count))
-            : selectedItem.accountKey
-        if let quotaData = accountQuotas[cleanKey] {
-            return quotaData
-        }
-
-        guard provider == .codex else { return nil }
-        return accountQuotas[selectedItem.accountKey.codexFilenameKey]
-    }
 }
 
 @main

--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -140,6 +140,16 @@ nonisolated struct ModelQuota: Codable, Identifiable, Sendable {
     // Optional tooltip message (e.g., Warp bonus userFacingMessage)
     var tooltip: String?
 
+    /// Recurring window this bucket refills on, declared by the producing fetcher.
+    /// `nil` means the provider payload states no window (or the value was cached
+    /// by a build that predates this field). Never inferred from `name`.
+    var window: QuotaWindow?
+
+    /// How this bucket is paid for, declared by the producing fetcher.
+    /// `nil` means the provider payload gives no billing signal; it is treated as
+    /// "not paid overage". Never inferred from `name`.
+    var billing: QuotaBilling?
+
     init(
         name: String,
         percentage: Double,
@@ -148,7 +158,9 @@ nonisolated struct ModelQuota: Codable, Identifiable, Sendable {
         used: Int? = nil,
         limit: Int? = nil,
         remaining: Int? = nil,
-        tooltip: String? = nil
+        tooltip: String? = nil,
+        window: QuotaWindow? = nil,
+        billing: QuotaBilling? = nil
     ) {
         self.name = name
         self.percentage = percentage
@@ -158,6 +170,8 @@ nonisolated struct ModelQuota: Codable, Identifiable, Sendable {
         self.limit = limit
         self.remaining = remaining
         self.tooltip = tooltip
+        self.window = window
+        self.billing = billing
     }
 
     var id: String { name }
@@ -734,7 +748,13 @@ actor AntigravityQuotaFetcher {
                         // Clamp to 0-100 range (API can return remainingFraction > 1.0)
                         let percentage = min(100, max(0, (quotaInfo.remainingFraction ?? 0) * 100))
                         let resetTime = quotaInfo.resetTime ?? ""
-                        models.append(ModelQuota(name: name, percentage: percentage, resetTime: resetTime))
+                        // Per-model pools: the endpoint states no window, so it stays unknown.
+                        models.append(ModelQuota(
+                            name: name,
+                            percentage: percentage,
+                            resetTime: resetTime,
+                            billing: .subscription
+                        ))
                     }
                 }
 
@@ -819,10 +839,14 @@ actor AntigravityQuotaFetcher {
                     continue
                 }
 
+                // The period is parsed once here, from the provider's own bucket
+                // descriptor, and carried explicitly so no consumer re-parses the name.
                 models.append(ModelQuota(
                     name: "antigravity-\(groupID)-\(period.id)",
                     percentage: (remainingFraction.clamped(to: 0...1) * 100).clamped(to: 0...100),
-                    resetTime: trimmedString(bucket["resetTime"] ?? bucket["reset_time"] ?? bucket["resetAt"] ?? bucket["reset_at"]) ?? ""
+                    resetTime: trimmedString(bucket["resetTime"] ?? bucket["reset_time"] ?? bucket["resetAt"] ?? bucket["reset_at"]) ?? "",
+                    window: period.window,
+                    billing: .subscription
                 ))
             }
         }
@@ -867,13 +891,13 @@ actor AntigravityQuotaFetcher {
         return nil
     }
 
-    private static func quotaSummaryPeriod(from label: String) -> (id: String, displayName: String)? {
+    private static func quotaSummaryPeriod(from label: String) -> (id: String, displayName: String, window: QuotaWindow)? {
         let lower = label.lowercased()
         if lower.contains("week") || lower.contains("7d") || lower.contains("seven") {
-            return ("weekly", "Weekly")
+            return ("weekly", "Weekly", .weekly)
         }
         if lower.contains("session") || lower.contains("5") || lower.contains("hour") {
-            return ("session", "Session")
+            return ("session", "Session", .session)
         }
         return nil
     }

--- a/Quotio/Services/GLMQuotaFetcher.swift
+++ b/Quotio/Services/GLMQuotaFetcher.swift
@@ -177,11 +177,15 @@ actor GLMQuotaFetcher {
                let percentage = limit.percentage,
                let unit = limit.unit,
                let number = limit.number,
-               let windowName = tokenWindowName(unit: unit, number: number) {
+               let window = tokenWindow(unit: unit, number: number) {
+                // Both the name and the window come from the API's `unit`/`number`
+                // pair, so the window is derived from the payload, not the name.
                 models.append(ModelQuota(
-                    name: windowName,
+                    name: window.modelName,
                     percentage: max(0, min(100, 100 - percentage)),
-                    resetTime: resetTime
+                    resetTime: resetTime,
+                    window: window.quotaWindow,
+                    billing: .subscription
                 ))
             } else if kind == "TIME_LIMIT",
                       let used = limit.currentValue,
@@ -199,7 +203,8 @@ actor GLMQuotaFetcher {
                         unit: .searches
                     ),
                     used: Int(used),
-                    limit: Int(quotaLimit)
+                    limit: Int(quotaLimit),
+                    billing: .subscription
                 ))
             }
         }
@@ -207,18 +212,43 @@ actor GLMQuotaFetcher {
         return ProviderQuotaData(models: models, lastUpdated: Date(), planType: planName)
     }
 
-    private nonisolated static func tokenWindowName(unit: Double, number: Double) -> String? {
+    nonisolated enum GLMTokenWindow {
+        case session
+        case daily
+        case weekly
+        case monthly
+
+        var modelName: String {
+            switch self {
+            case .session: "zai-session"
+            case .daily: "zai-daily"
+            case .weekly: "zai-weekly"
+            case .monthly: "zai-monthly"
+            }
+        }
+
+        var quotaWindow: QuotaWindow {
+            switch self {
+            case .session: .session
+            case .daily: .daily
+            case .weekly: .weekly
+            case .monthly: .monthly
+            }
+        }
+    }
+
+    nonisolated static func tokenWindow(unit: Double, number: Double) -> GLMTokenWindow? {
         guard number > 0 else { return nil }
         switch unit {
         case 3:
-            return number < 24 ? "zai-session" : "zai-daily"
+            return number < 24 ? .session : .daily
         case 4:
-            if number <= 1 { return "zai-daily" }
-            return number < 28 ? "zai-weekly" : "zai-monthly"
+            if number <= 1 { return .daily }
+            return number < 28 ? .weekly : .monthly
         case 5:
-            return "zai-monthly"
+            return .monthly
         case 6:
-            return number < 4 ? "zai-weekly" : "zai-monthly"
+            return number < 4 ? .weekly : .monthly
         default: return nil
         }
     }

--- a/Quotio/Services/QuotaFetchers/AmpQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/AmpQuotaFetcher.swift
@@ -71,10 +71,13 @@ nonisolated enum AmpQuotaParser {
             #"(?im)^\s*Amp Free:\s*([\d.]+)%\s+remaining(?:\s+today)?(?:\s*\(resets\s+daily\))?"#,
             in: text
         ), let remaining = validPercentage(match[0]) {
+            // This shape is the "resets daily" free allowance.
             models.append(ModelQuota(
                 name: "amp-free",
                 percentage: remaining,
-                resetTime: nextMidnightUTC(after: now)
+                resetTime: nextMidnightUTC(after: now),
+                window: .daily,
+                billing: .subscription
             ))
         }
 
@@ -85,9 +88,10 @@ nonisolated enum AmpQuotaParser {
         ), let agent = validPercentage(subscription[1]),
            let orb = validPercentage(subscription[2]) {
             plan = subscription[0]
+            // Matched from the CLI's "Subscription <plan>: ..." line.
             let resetTime = relativeResetTime(value: subscription[3], unit: subscription[4], after: now)
-            models.append(ModelQuota(name: "amp-agent-usage", percentage: agent, resetTime: resetTime))
-            models.append(ModelQuota(name: "amp-orb-usage", percentage: orb, resetTime: resetTime))
+            models.append(ModelQuota(name: "amp-agent-usage", percentage: agent, resetTime: resetTime, billing: .subscription))
+            models.append(ModelQuota(name: "amp-orb-usage", percentage: orb, resetTime: resetTime, billing: .subscription))
         } else {
             for match in allCaptures(
                 #"(?im)^\s*(agent|other|orb)(?:\s+(?:usage|quota))?\s*:\s*([\d.]+)%"#,

--- a/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
@@ -541,20 +541,53 @@ actor ClaudeCodeQuotaFetcher {
 
     private func quotaData(from info: ClaudeCodeQuotaInfo) -> ProviderQuotaData? {
         var models: [ModelQuota] = []
+        // Window/billing come from which field of the Anthropic payload produced the
+        // bucket (`five_hour`, `seven_day*`, `extra_usage`), not from the bucket name.
         if let value = info.fiveHour {
-            models.append(ModelQuota(name: "five-hour-session", percentage: value.remaining, resetTime: value.resetsAt))
+            models.append(ModelQuota(
+                name: "five-hour-session",
+                percentage: value.remaining,
+                resetTime: value.resetsAt,
+                window: .session,
+                billing: .subscription
+            ))
         }
         if let value = info.sevenDay {
-            models.append(ModelQuota(name: "seven-day-weekly", percentage: value.remaining, resetTime: value.resetsAt))
+            models.append(ModelQuota(
+                name: "seven-day-weekly",
+                percentage: value.remaining,
+                resetTime: value.resetsAt,
+                window: .weekly,
+                billing: .subscription
+            ))
         }
         if let value = info.sevenDaySonnet {
-            models.append(ModelQuota(name: "seven-day-sonnet", percentage: value.remaining, resetTime: value.resetsAt))
+            models.append(ModelQuota(
+                name: "seven-day-sonnet",
+                percentage: value.remaining,
+                resetTime: value.resetsAt,
+                window: .weekly,
+                billing: .subscription
+            ))
         }
         if let value = info.sevenDayOpus {
-            models.append(ModelQuota(name: "seven-day-opus", percentage: value.remaining, resetTime: value.resetsAt))
+            models.append(ModelQuota(
+                name: "seven-day-opus",
+                percentage: value.remaining,
+                resetTime: value.resetsAt,
+                window: .weekly,
+                billing: .subscription
+            ))
         }
         if let extra = info.extraUsage, let remaining = extra.remaining {
-            var model = ModelQuota(name: "extra-usage", percentage: remaining, resetTime: "")
+            // `extra_usage` is the paid credit pool, capped by `monthly_limit`.
+            var model = ModelQuota(
+                name: "extra-usage",
+                percentage: remaining,
+                resetTime: "",
+                window: .monthly,
+                billing: .paidOverage
+            )
             if let used = extra.usedCredits, let limit = extra.monthlyLimit {
                 model.used = Int(used)
                 model.limit = Int(limit)

--- a/Quotio/Services/QuotaFetchers/ClinePassQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/ClinePassQuotaFetcher.swift
@@ -106,7 +106,9 @@ actor ClinePassQuotaFetcher {
             modelsByName[name] = ModelQuota(
                 name: name,
                 percentage: 100 - usedPercentage,
-                resetTime: try normalizedResetTime(limit.resetsAt)
+                resetTime: try normalizedResetTime(limit.resetsAt),
+                window: window(for: limit.type),
+                billing: .subscription
             )
         }
 
@@ -120,6 +122,16 @@ actor ClinePassQuotaFetcher {
         case "five_hour": return "clinepass-five-hour"
         case "weekly": return "clinepass-weekly"
         case "monthly": return "clinepass-monthly"
+        default: return nil
+        }
+    }
+
+    /// The window comes from the API's own `type` discriminator.
+    private func window(for limitType: String) -> QuotaWindow? {
+        switch limitType {
+        case "five_hour": return .session
+        case "weekly": return .weekly
+        case "monthly": return .monthly
         default: return nil
         }
     }

--- a/Quotio/Services/QuotaFetchers/CodexUsageMapper.swift
+++ b/Quotio/Services/QuotaFetchers/CodexUsageMapper.swift
@@ -26,12 +26,19 @@ nonisolated enum CodexUsageMapper {
         )
     }
 
-    private static func modelQuota(name: String, from snapshot: CodexUsageResponseV2.WindowSnapshot?) -> ModelQuota? {
+    private static func modelQuota(
+        name: String,
+        from snapshot: CodexUsageResponseV2.WindowSnapshot?,
+        window: QuotaWindow?,
+        billing: QuotaBilling?
+    ) -> ModelQuota? {
         guard let snapshot else { return nil }
         return ModelQuota(
             name: name,
             percentage: Double(100 - snapshot.usedPercent),
-            resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? ""
+            resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? "",
+            window: window,
+            billing: billing
         )
     }
 
@@ -46,7 +53,8 @@ nonisolated enum CodexUsageMapper {
             guard let snapshot else { return nil }
             let kind = standardWindowKind(for: snapshot, fallback: fallbackKind)
             guard usedKinds.insert(kind).inserted else { return nil }
-            return modelQuota(name: kind.id, from: snapshot)
+            // `rate_limit` is the plan's own rate limit, so the billing kind is known.
+            return modelQuota(name: kind.id, from: snapshot, window: kind.window, billing: .subscription)
         }
     }
 
@@ -74,12 +82,27 @@ nonisolated enum CodexUsageMapper {
             else {
                 return []
             }
+            // An `additional_rate_limits` entry carries no billing signal: the same
+            // collection holds model-specific *subscription* limits (Spark is one).
+            // Billing therefore stays nil (unknown, i.e. not paid overage) and the
+            // window comes only from the declared `limit_window_seconds`.
             return [ModelQuota(
                 name: id,
                 percentage: Double(100 - snapshot.usedPercent),
-                resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? ""
+                resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? "",
+                window: declaredWindow(for: snapshot),
+                billing: nil
             )]
         }
+    }
+
+    /// Window implied by the API's own `limit_window_seconds`, using the same
+    /// thresholds as `standardWindowKind`. Nil when the field is absent.
+    private static func declaredWindow(for snapshot: CodexUsageResponseV2.WindowSnapshot) -> QuotaWindow? {
+        guard let seconds = snapshot.limitWindowSeconds, seconds > 0 else { return nil }
+        if seconds >= 6 * 24 * 60 * 60 { return .weekly }
+        if seconds <= 24 * 60 * 60 { return .session }
+        return nil
     }
 
     private static func sparkModels(
@@ -91,10 +114,13 @@ nonisolated enum CodexUsageMapper {
             (limit.rateLimit?.secondaryWindow, sparkKind(for: limit.rateLimit?.secondaryWindow, fallback: .weekly))
         ].compactMap { snapshot, kind in
             guard let snapshot, usedIDs.insert(kind.id).inserted else { return nil }
+            // Spark is a model-specific limit included in the plan, not paid overage.
             return ModelQuota(
                 name: kind.id,
                 percentage: Double(100 - snapshot.usedPercent),
-                resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? ""
+                resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? "",
+                window: kind.window,
+                billing: .subscription
             )
         }
     }
@@ -204,6 +230,13 @@ nonisolated enum CodexUsageMapper {
             case .weekly: "codex-spark-weekly"
             }
         }
+
+        var window: QuotaWindow {
+            switch self {
+            case .fiveHour: .session
+            case .weekly: .weekly
+            }
+        }
     }
 
     private enum StandardWindowKind {
@@ -214,6 +247,13 @@ nonisolated enum CodexUsageMapper {
             switch self {
             case .session: "codex-session"
             case .weekly: "codex-weekly"
+            }
+        }
+
+        var window: QuotaWindow {
+            switch self {
+            case .session: .session
+            case .weekly: .weekly
             }
         }
     }

--- a/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
@@ -228,7 +228,7 @@ actor CopilotQuotaFetcher {
         
         do {
             let entitlement = try await fetchEntitlement(accessToken: authFile.accessToken)
-            return convertToQuotaData(entitlement: entitlement)
+            return Self.convertToQuotaData(entitlement: entitlement)
         } catch {
             Log.quota("Copilot quota fetch error: \(error)")
             return nil
@@ -275,7 +275,7 @@ actor CopilotQuotaFetcher {
 
     private func fetchQuota(accessToken: String) async -> ProviderQuotaData? {
         do {
-            return convertToQuotaData(entitlement: try await fetchEntitlement(accessToken: accessToken))
+            return Self.convertToQuotaData(entitlement: try await fetchEntitlement(accessToken: accessToken))
         } catch {
             return nil
         }
@@ -291,7 +291,7 @@ actor CopilotQuotaFetcher {
                 guard let credential = await MonitorCredentialVault.shared.credential(for: account.id) else { continue }
                 do {
                     let entitlement = try await fetchEntitlement(accessToken: credential.accessToken)
-                    results[account.accountKey] = convertToQuotaData(entitlement: entitlement)
+                    results[account.accountKey] = Self.convertToQuotaData(entitlement: entitlement)
                 } catch {
                     continue
                 }
@@ -304,7 +304,7 @@ actor CopilotQuotaFetcher {
                 let entitlement = try await fetchEntitlement(accessToken: token)
                 let key = await fetchGitHubLogin(accessToken: token) ?? "GitHub Copilot"
                 if results[key] == nil {
-                    results[key] = convertToQuotaData(entitlement: entitlement)
+                    results[key] = Self.convertToQuotaData(entitlement: entitlement)
                 }
             } catch {
                 continue
@@ -427,7 +427,9 @@ actor CopilotQuotaFetcher {
         return try JSONDecoder().decode(CopilotEntitlement.self, from: data)
     }
     
-    private func convertToQuotaData(entitlement: CopilotEntitlement) -> ProviderQuotaData {
+    /// Pure mapping from the entitlement payload to quota buckets.
+    /// `nonisolated static` so it can be exercised directly from tests.
+    nonisolated static func convertToQuotaData(entitlement: CopilotEntitlement) -> ProviderQuotaData {
         var models: [ModelQuota] = []
         let resetTimeString = entitlement.resetDate?.ISO8601Format() ?? ""
 

--- a/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
@@ -431,13 +431,17 @@ actor CopilotQuotaFetcher {
         var models: [ModelQuota] = []
         let resetTimeString = entitlement.resetDate?.ISO8601Format() ?? ""
 
+        // Copilot entitlement quotas are monthly: both shapes are capped by
+        // `monthly_quotas` and reset on `quota_reset_date` / `quota_reset_date_utc`.
         // Method 1: Parse quota_snapshots (used by some plans)
         if let snapshots = entitlement.quotaSnapshots {
             if let chat = snapshots.chat, chat.unlimited != true {
                 models.append(ModelQuota(
                     name: "copilot-chat",
                     percentage: chat.calculatePercent(defaultTotal: 50),
-                    resetTime: resetTimeString
+                    resetTime: resetTimeString,
+                    window: .monthly,
+                    billing: .subscription
                 ))
             }
 
@@ -445,7 +449,9 @@ actor CopilotQuotaFetcher {
                 models.append(ModelQuota(
                     name: "copilot-completions",
                     percentage: completions.calculatePercent(defaultTotal: 2000),
-                    resetTime: resetTimeString
+                    resetTime: resetTimeString,
+                    window: .monthly,
+                    billing: .subscription
                 ))
             }
 
@@ -453,7 +459,9 @@ actor CopilotQuotaFetcher {
                 models.append(ModelQuota(
                     name: "copilot-premium",
                     percentage: premium.calculatePercent(defaultTotal: 50),
-                    resetTime: resetTimeString
+                    resetTime: resetTimeString,
+                    window: .monthly,
+                    billing: .subscription
                 ))
             }
         }
@@ -468,7 +476,9 @@ actor CopilotQuotaFetcher {
                 models.append(ModelQuota(
                     name: "copilot-chat",
                     percentage: percentage,
-                    resetTime: resetTimeString
+                    resetTime: resetTimeString,
+                    window: .monthly,
+                    billing: .subscription
                 ))
             }
 
@@ -478,7 +488,9 @@ actor CopilotQuotaFetcher {
                 models.append(ModelQuota(
                     name: "copilot-completions",
                     percentage: percentage,
-                    resetTime: resetTimeString
+                    resetTime: resetTimeString,
+                    window: .monthly,
+                    billing: .subscription
                 ))
             }
         }

--- a/Quotio/Services/QuotaFetchers/CursorQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CursorQuotaFetcher.swift
@@ -341,10 +341,13 @@ actor CursorQuotaFetcher {
                 resetTimeStr = ""
             }
             
+            // Cursor states no window length, only a billing cycle boundary, so the
+            // window stays unknown. The billing kind is known: this is plan quota.
             var planModel = ModelQuota(
                 name: "plan-usage",
                 percentage: plan.remainingPercentage,
-                resetTime: resetTimeStr
+                resetTime: resetTimeStr,
+                billing: .subscription
             )
             planModel.used = plan.used
             planModel.limit = plan.limit
@@ -362,10 +365,12 @@ actor CursorQuotaFetcher {
                 percentage = 100 // Unlimited or no limit set
             }
             
+            // `individualUsage.onDemand` is spend billed on top of the plan.
             var onDemandModel = ModelQuota(
                 name: "on-demand",
                 percentage: percentage,
-                resetTime: ""
+                resetTime: "",
+                billing: .paidOverage
             )
             onDemandModel.used = onDemand.used
             onDemandModel.limit = onDemand.limit
@@ -378,7 +383,8 @@ actor CursorQuotaFetcher {
             models.append(ModelQuota(
                 name: "cursor-usage",
                 percentage: info.isUnlimited ? 100 : -1,
-                resetTime: ""
+                resetTime: "",
+                billing: .subscription
             ))
         }
         

--- a/Quotio/Services/QuotaFetchers/DevinQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/DevinQuotaFetcher.swift
@@ -24,23 +24,30 @@ nonisolated enum DevinQuotaMapper {
             models.append(ModelQuota(
                 name: "devin-daily",
                 percentage: clamp(dailyRemaining),
-                resetTime: dailyReset
+                resetTime: dailyReset,
+                window: .daily,
+                billing: .subscription
             ))
         }
         if let weeklyRemaining {
             models.append(ModelQuota(
                 name: "devin-weekly",
                 percentage: clamp(weeklyRemaining),
-                resetTime: weeklyReset
+                resetTime: weeklyReset,
+                window: .weekly,
+                billing: .subscription
             ))
         } else if hideDaily, let dailyRemaining {
             models.append(ModelQuota(
                 name: "devin-weekly",
                 percentage: clamp(dailyRemaining),
-                resetTime: weeklyReset
+                resetTime: weeklyReset,
+                window: .weekly,
+                billing: .subscription
             ))
         }
         if let micros = number(planStatus["overageBalanceMicros"]) {
+            // `overageBalanceMicros` is spend billed beyond the plan.
             models.append(ModelQuota(
                 name: "devin-extra-balance",
                 percentage: -1,
@@ -49,7 +56,8 @@ nonisolated enum DevinQuotaMapper {
                     value: max(0, micros) / 1_000_000,
                     unit: .usd,
                     semantics: .balance
-                )
+                ),
+                billing: .paidOverage
             ))
         }
 

--- a/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
@@ -197,6 +197,7 @@ nonisolated enum FactoryDroidQuotaMapper {
         append(pool: response.limits?.core, prefix: "factory-core", now: now, to: &models)
 
         if let cents = response.extraUsageBalanceCents {
+            // `extra_usage_balance_cents` is prepaid spend on top of the plan.
             models.append(ModelQuota(
                 name: "factory-extra-balance",
                 percentage: -1,
@@ -205,7 +206,8 @@ nonisolated enum FactoryDroidQuotaMapper {
                     value: max(0, cents) / 100,
                     unit: .usd,
                     semantics: .balance
-                )
+                ),
+                billing: .paidOverage
             ))
         }
 
@@ -219,17 +221,20 @@ nonisolated enum FactoryDroidQuotaMapper {
         to models: inout [ModelQuota]
     ) {
         guard let pool else { return }
-        for (suffix, window) in [
-            ("five-hour", pool.fiveHour),
-            ("weekly", pool.weekly),
-            ("monthly", pool.monthly),
+        // The window is the pool field the entry came from, not the name suffix.
+        for (suffix, quotaWindow, window) in [
+            ("five-hour", QuotaWindow.session, pool.fiveHour),
+            ("weekly", QuotaWindow.weekly, pool.weekly),
+            ("monthly", QuotaWindow.monthly, pool.monthly),
         ] {
             guard let window else { continue }
             let usedPercent = isExpired(window.windowEnd, now: now) ? 0 : window.usedPercent
             models.append(ModelQuota(
                 name: prefix + "-" + suffix,
                 percentage: max(0, min(100, 100 - usedPercent)),
-                resetTime: window.windowEnd ?? ""
+                resetTime: window.windowEnd ?? "",
+                window: quotaWindow,
+                billing: .subscription
             ))
         }
     }

--- a/Quotio/Services/QuotaFetchers/GrokQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/GrokQuotaFetcher.swift
@@ -27,10 +27,13 @@ nonisolated enum GrokQuotaMapper {
            let endString = period["end"] as? String,
            parseDate(endString) != nil {
             let used = number(config["creditUsagePercent"]) ?? 0
+            // Guarded above on `config.currentPeriod.type == USAGE_PERIOD_TYPE_WEEKLY`.
             models.append(ModelQuota(
                 name: "grok-weekly",
                 percentage: max(0, min(100, 100 - used)),
-                resetTime: ISO8601DateFormatter().string(from: parseDate(endString)!)
+                resetTime: ISO8601DateFormatter().string(from: parseDate(endString)!),
+                window: .weekly,
+                billing: .subscription
             ))
         }
 
@@ -38,11 +41,13 @@ nonisolated enum GrokQuotaMapper {
         let status = cap > 0
             ? String(format: "grok.status.cap".localizedStatic(), formatUnits(cap))
             : "grok.status.disabled".localizedStatic()
+        // `config.onDemandCap` is the paid on-demand allowance beyond the plan.
         models.append(ModelQuota(
             name: "grok-extra-usage",
             percentage: -1,
             resetTime: "",
-            presentation: .status(text: status)
+            presentation: .status(text: status),
+            billing: .paidOverage
         ))
         return ProviderQuotaData(models: models, lastUpdated: Date(), planType: plan)
     }

--- a/Quotio/Services/QuotaFetchers/WarpQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/WarpQuotaFetcher.swift
@@ -188,13 +188,16 @@ actor WarpQuotaFetcher {
                 percentage = 0
             }
 
+            // Warp reports only `nextRefreshTime`, never the refresh period, so the
+            // window stays unknown; the billing kind is known (plan request quota).
             models.append(ModelQuota(
                 name: "warp-usage",
                 percentage: percentage,
                 resetTime: stripMilliseconds(from: info.nextRefreshTime) ?? "",
                 used: used,
                 limit: limit,
-                remaining: remaining
+                remaining: remaining,
+                billing: .subscription
             ))
 
             let dateFormatter = ISO8601DateFormatter()

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -2475,7 +2475,8 @@ final class QuotaViewModel {
                let canonicalKey = candidates.first {
                 migratedItem = MenuBarQuotaItem(
                     provider: provider.rawValue,
-                    accountKey: canonicalKey
+                    accountKey: canonicalKey,
+                    bucketSelection: item.bucketSelection
                 )
             }
 

--- a/Quotio/Views/Screens/DashboardScreen.swift
+++ b/Quotio/Views/Screens/DashboardScreen.swift
@@ -54,8 +54,7 @@ struct DashboardScreen: View {
         
         for (_, accountQuotas) in viewModel.providerQuotas {
             for (_, quotaData) in accountQuotas {
-                let models = quotaData.models.map { (name: $0.name, percentage: $0.percentage) }
-                let total = settings.totalUsagePercent(models: models)
+                let total = settings.totalUsagePercent(models: quotaData.models)
                 if total >= 0 {
                     allTotals.append(total)
                 }

--- a/Quotio/Views/Screens/QuotaScreen.swift
+++ b/Quotio/Views/Screens/QuotaScreen.swift
@@ -57,8 +57,7 @@ struct QuotaScreen: View {
         
         var allTotals: [Double] = []
         for (_, quotaData) in accounts {
-            let models = quotaData.models.map { (name: $0.name, percentage: $0.percentage) }
-            let total = settings.totalUsagePercent(models: models)
+            let total = settings.totalUsagePercent(models: quotaData.models)
             if total >= 0 {
                 allTotals.append(total)
             }

--- a/Quotio/Views/Screens/SettingsScreen.swift
+++ b/Quotio/Views/Screens/SettingsScreen.swift
@@ -1742,6 +1742,34 @@ struct MenuBarSettingsSection: View {
         )
     }
     
+    /// Selections offered for an item: automatic plus whatever this account's
+    /// buckets actually declare. The stored selection is always included so a
+    /// choice made while the account was loaded does not vanish during a refresh.
+    private func bucketOptions(for item: MenuBarQuotaItem) -> [MenuBarBucketSelection] {
+        let models = viewModel.menuBarQuotaData(for: item)?.models ?? []
+        var options = MenuBarBucketResolver.options(for: models)
+        let current = item.resolvedBucketSelection
+        if !options.contains(current) {
+            options.append(current)
+        }
+        return options
+    }
+
+    private func bucketOptionLabel(_ option: MenuBarBucketSelection) -> String {
+        if let key = option.localizationKey {
+            return key.localized()
+        }
+        guard case .bucket(let name) = option else { return "" }
+        return ModelQuota(name: name, percentage: 0, resetTime: "").displayName
+    }
+
+    private func bucketSelectionBinding(for item: MenuBarQuotaItem) -> Binding<MenuBarBucketSelection> {
+        Binding(
+            get: { settings.bucketSelection(for: item) },
+            set: { settings.setBucketSelection($0, for: item) }
+        )
+    }
+
     var body: some View {
         Section {
             Toggle("settings.showInDock".localized(), isOn: showInDockBinding)
@@ -1772,6 +1800,31 @@ struct MenuBarSettingsSection: View {
                         Text("settings.menubar.monochrome".localized()).tag(MenuBarColorMode.monochrome)
                     }
                     .pickerStyle(.segmented)
+
+                    if !settings.selectedItems.isEmpty {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("settings.menubar.bucket.title".localized())
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+
+                            ForEach(settings.selectedItems) { item in
+                                Picker(
+                                    selection: bucketSelectionBinding(for: item)
+                                ) {
+                                    ForEach(bucketOptions(for: item), id: \.self) { option in
+                                        Text(bucketOptionLabel(option)).tag(option)
+                                    }
+                                } label: {
+                                    Text(item.accountKey.masked(if: settings.hideSensitiveInfo))
+                                }
+                            }
+
+                            Text("settings.menubar.bucket.help".localized())
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 4)
+                    }
                 }
             }
         } header: {

--- a/QuotioTests/MenuBarBucketSelectionTests.swift
+++ b/QuotioTests/MenuBarBucketSelectionTests.swift
@@ -1,0 +1,336 @@
+import XCTest
+@testable import Quotio
+
+/// Covers the per-menu-bar-item quota bucket selector (issue #393) and the
+/// provider shapes whose windows a name-substring matcher gets wrong.
+final class MenuBarBucketSelectionTests: XCTestCase {
+
+    // MARK: - Codex Spark regression
+
+    /// Codex maps the Spark five-hour window to `codex-spark`. Its name contains
+    /// none of `session`, `five-hour` or `5h`, so a name matcher would report the
+    /// 80% plan session bucket and hide the 10% Spark bucket. The window is taken
+    /// from the payload's `limit_window_seconds` instead.
+    func testCodexSessionWindowIncludesSparkFiveHourBucket() throws {
+        let quota = try CodexUsageMapper.map(data: Self.codexSparkPayload())
+        let byName = Dictionary(uniqueKeysWithValues: quota.models.map { ($0.name, $0) })
+
+        XCTAssertEqual(byName["codex-session"]?.percentage, 80)
+        XCTAssertEqual(byName["codex-spark"]?.percentage, 10)
+        XCTAssertEqual(byName["codex-spark"]?.window, .session)
+
+        let value = MenuBarBucketResolver.percent(
+            models: quota.models,
+            selection: .window(.session),
+            aggregation: .lowest
+        )
+        XCTAssertEqual(try XCTUnwrap(value), 10, accuracy: 0.001)
+    }
+
+    /// The same account can also pin one exact Codex bucket.
+    func testCodexIndividualBucketsAreSelectable() throws {
+        let quota = try CodexUsageMapper.map(data: Self.codexSparkPayload())
+
+        XCTAssertEqual(
+            MenuBarBucketResolver.percent(
+                models: quota.models,
+                selection: .bucket("codex-spark"),
+                aggregation: .lowest
+            ),
+            10
+        )
+        XCTAssertEqual(
+            MenuBarBucketResolver.percent(
+                models: quota.models,
+                selection: .bucket("codex-session"),
+                aggregation: .lowest
+            ),
+            80
+        )
+    }
+
+    // MARK: - Copilot monthly regression
+
+    /// Copilot's monthly quotas are named `copilot-chat` / `copilot-completions`,
+    /// which contain no monthly marker. The window comes from the entitlement
+    /// payload (`monthly_quotas`, `quota_reset_date`).
+    func testCopilotQuotasAreSelectableAsMonthly() throws {
+        for payload in [Self.copilotSnapshotPayload(), Self.copilotLimitedUserPayload()] {
+            let entitlement = try JSONDecoder().decode(CopilotEntitlement.self, from: payload)
+            let quota = CopilotQuotaFetcher.convertToQuotaData(entitlement: entitlement)
+
+            XCTAssertFalse(quota.models.isEmpty)
+            XCTAssertTrue(quota.models.allSatisfy { $0.window == .monthly }, "\(quota.models.map(\.name))")
+
+            let value = MenuBarBucketResolver.percent(
+                models: quota.models,
+                selection: .window(.monthly),
+                aggregation: .lowest
+            )
+            XCTAssertNotNil(value)
+        }
+    }
+
+    func testCopilotMonthlyWindowAggregatesWithSelectedMode() throws {
+        let entitlement = try JSONDecoder().decode(CopilotEntitlement.self, from: Self.copilotSnapshotPayload())
+        let quota = CopilotQuotaFetcher.convertToQuotaData(entitlement: entitlement)
+
+        // chat 40% remaining, completions 90%, premium 60%.
+        XCTAssertEqual(
+            try XCTUnwrap(MenuBarBucketResolver.percent(models: quota.models, selection: .window(.monthly), aggregation: .lowest)),
+            40,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(MenuBarBucketResolver.percent(models: quota.models, selection: .window(.monthly), aggregation: .average)),
+            (40 + 90 + 60) / 3,
+            accuracy: 0.001
+        )
+    }
+
+    // MARK: - Specific buckets asked for by #393
+
+    /// "users cannot choose Factory Standard vs Core five-hour quota".
+    func testFactoryStandardAndCoreFiveHourPoolsAreSeparatelySelectable() throws {
+        let response = try JSONDecoder().decode(FactoryDroidQuotaResponse.self, from: Self.factoryPayload())
+        let quota = FactoryDroidQuotaMapper.map(response, now: Date(timeIntervalSince1970: 0))
+
+        XCTAssertEqual(
+            MenuBarBucketResolver.percent(
+                models: quota.models,
+                selection: .bucket("factory-standard-five-hour"),
+                aggregation: .lowest
+            ),
+            75
+        )
+        XCTAssertEqual(
+            MenuBarBucketResolver.percent(
+                models: quota.models,
+                selection: .bucket("factory-core-five-hour"),
+                aggregation: .lowest
+            ),
+            30
+        )
+        // The session window still aggregates both pools.
+        XCTAssertEqual(
+            MenuBarBucketResolver.percent(
+                models: quota.models,
+                selection: .window(.session),
+                aggregation: .lowest
+            ),
+            30
+        )
+    }
+
+    /// "Antigravity Gemini vs Claude/GPT session quota".
+    func testAntigravityGroupSessionPoolsAreSeparatelySelectable() {
+        let models = [
+            ModelQuota(name: "antigravity-gemini-session", percentage: 60, resetTime: "", window: .session, billing: .subscription),
+            ModelQuota(name: "antigravity-claude-gpt-session", percentage: 20, resetTime: "", window: .session, billing: .subscription),
+            ModelQuota(name: "antigravity-gemini-weekly", percentage: 70, resetTime: "", window: .weekly, billing: .subscription)
+        ]
+
+        XCTAssertEqual(
+            MenuBarBucketResolver.percent(models: models, selection: .bucket("antigravity-gemini-session"), aggregation: .lowest),
+            60
+        )
+        XCTAssertEqual(
+            MenuBarBucketResolver.percent(models: models, selection: .bucket("antigravity-claude-gpt-session"), aggregation: .lowest),
+            20
+        )
+    }
+
+    /// "or an extra/on-demand quota".
+    func testPaidOverageBucketIsSelectable() {
+        let models = [
+            ModelQuota(name: "plan-usage", percentage: 15, resetTime: "", billing: .subscription),
+            ModelQuota(name: "on-demand", percentage: 90, resetTime: "", billing: .paidOverage)
+        ]
+
+        XCTAssertEqual(
+            MenuBarBucketResolver.percent(models: models, selection: .bucket("on-demand"), aggregation: .lowest),
+            90
+        )
+    }
+
+    // MARK: - Option list
+
+    func testOptionsOfferAutoDeclaredWindowsAndEveryPercentageBucket() throws {
+        let quota = try CodexUsageMapper.map(data: Self.codexSparkPayload())
+
+        XCTAssertEqual(
+            MenuBarBucketResolver.options(for: quota.models),
+            [
+                .auto,
+                .window(.session),
+                .window(.weekly),
+                .bucket("codex-session"),
+                .bucket("codex-weekly"),
+                .bucket("codex-spark"),
+                .bucket("codex-spark-weekly")
+            ]
+        )
+    }
+
+    /// Status and balance rows carry the `-1` unknown sentinel and cannot be
+    /// rendered as a menu bar percentage, so they are not offered.
+    func testOptionsOmitBucketsWithoutAPercentage() throws {
+        let quota = try XCTUnwrap(GrokQuotaMapper.mapBilling(Self.grokPayload(), plan: nil))
+
+        XCTAssertEqual(
+            MenuBarBucketResolver.options(for: quota.models),
+            [.auto, .window(.weekly), .bucket("grok-weekly")]
+        )
+    }
+
+    // MARK: - Fallback behaviour
+
+    func testSelectionUnavailableForAnAccountFallsBackToTheAggregate() {
+        // Claude Code exposes no monthly subscription window.
+        let models = [
+            ModelQuota(name: "five-hour-session", percentage: 80, resetTime: "", window: .session, billing: .subscription),
+            ModelQuota(name: "seven-day-weekly", percentage: 40, resetTime: "", window: .weekly, billing: .subscription)
+        ]
+
+        XCTAssertNil(MenuBarBucketResolver.percent(models: models, selection: .window(.monthly), aggregation: .lowest))
+        XCTAssertNil(MenuBarBucketResolver.percent(models: models, selection: .bucket("codex-session"), aggregation: .lowest))
+        XCTAssertNil(MenuBarBucketResolver.percent(models: models, selection: .auto, aggregation: .lowest))
+    }
+
+    func testSelectionWithOnlyUnknownValuesFallsBack() {
+        let models = [
+            ModelQuota(name: "five-hour-session", percentage: -1, resetTime: "", window: .session, billing: .subscription),
+            ModelQuota(name: "seven-day-weekly", percentage: 40, resetTime: "", window: .weekly, billing: .subscription)
+        ]
+
+        XCTAssertNil(MenuBarBucketResolver.percent(models: models, selection: .window(.session), aggregation: .lowest))
+        XCTAssertNil(MenuBarBucketResolver.percent(models: models, selection: .bucket("five-hour-session"), aggregation: .lowest))
+    }
+
+    func testAvailabilityCheckMatchesTheResolver() {
+        let models = [
+            ModelQuota(name: "codex-spark", percentage: 10, resetTime: "", window: .session, billing: .subscription)
+        ]
+
+        XCTAssertTrue(MenuBarBucketResolver.isAvailable(.auto, in: models))
+        XCTAssertTrue(MenuBarBucketResolver.isAvailable(.window(.session), in: models))
+        XCTAssertTrue(MenuBarBucketResolver.isAvailable(.bucket("codex-spark"), in: models))
+        XCTAssertFalse(MenuBarBucketResolver.isAvailable(.window(.monthly), in: models))
+        XCTAssertFalse(MenuBarBucketResolver.isAvailable(.bucket("codex-session"), in: models))
+    }
+
+    // MARK: - Persistence
+
+    @MainActor
+    func testSelectionRoundTripsThroughTheStoredMenuBarItem() throws {
+        let items = [
+            MenuBarQuotaItem(provider: "codex", accountKey: "a@example.com", bucketSelection: .bucket("codex-spark")),
+            MenuBarQuotaItem(provider: "claude", accountKey: "b@example.com", bucketSelection: .window(.weekly)),
+            MenuBarQuotaItem(provider: "cursor", accountKey: "c@example.com")
+        ]
+
+        let decoded = try JSONDecoder().decode(
+            [MenuBarQuotaItem].self,
+            from: try JSONEncoder().encode(items)
+        )
+
+        XCTAssertEqual(decoded, items)
+        XCTAssertEqual(decoded[0].resolvedBucketSelection, .bucket("codex-spark"))
+        XCTAssertEqual(decoded[1].resolvedBucketSelection, .window(.weekly))
+        XCTAssertEqual(decoded[2].resolvedBucketSelection, .auto)
+    }
+
+    /// Selections persisted before this feature existed must still decode.
+    @MainActor
+    func testMenuBarItemsStoredBeforeTheSelectorStillDecode() throws {
+        let legacy = Data("""
+        [{ "provider": "codex", "accountKey": "a@example.com" }]
+        """.utf8)
+
+        let decoded = try JSONDecoder().decode([MenuBarQuotaItem].self, from: legacy)
+        XCTAssertEqual(decoded.first?.resolvedBucketSelection, .auto)
+    }
+
+    /// The bucket choice is an attribute of an item, not part of its identity, so
+    /// adding the same account twice is still rejected.
+    @MainActor
+    func testIdentityIgnoresTheBucketSelection() {
+        let plain = MenuBarQuotaItem(provider: "codex", accountKey: "a@example.com")
+        let chosen = MenuBarQuotaItem(provider: "codex", accountKey: "a@example.com", bucketSelection: .window(.weekly))
+
+        XCTAssertEqual(plain.id, chosen.id)
+        XCTAssertNotEqual(plain, chosen, "the stored value must still differ so changes persist")
+    }
+
+    // MARK: - Fixtures
+
+    private static func codexSparkPayload() -> Data {
+        // Plan session 80% remaining, Spark five-hour 10% remaining.
+        Data("""
+        {
+          "plan_type": "pro",
+          "rate_limit": {
+            "primary_window": { "used_percent": 20, "reset_at": 1800000000, "limit_window_seconds": 18000 },
+            "secondary_window": { "used_percent": 45, "reset_at": 1800500000, "limit_window_seconds": 604800 }
+          },
+          "additional_rate_limits": [
+            {
+              "limit_name": "codex_spark",
+              "metered_feature": "spark",
+              "rate_limit": {
+                "primary_window": { "used_percent": 90, "reset_at": 1800000000, "limit_window_seconds": 18000 },
+                "secondary_window": { "used_percent": 30, "reset_at": 1800500000, "limit_window_seconds": 604800 }
+              }
+            }
+          ]
+        }
+        """.utf8)
+    }
+
+    private static func copilotSnapshotPayload() -> Data {
+        Data("""
+        {
+          "quota_reset_date": "2999-01-01",
+          "quota_snapshots": {
+            "chat": { "entitlement": 50, "remaining": 20, "unlimited": false },
+            "completions": { "entitlement": 2000, "remaining": 1800, "unlimited": false },
+            "premium_interactions": { "entitlement": 50, "remaining": 30, "unlimited": false }
+          }
+        }
+        """.utf8)
+    }
+
+    private static func copilotLimitedUserPayload() -> Data {
+        Data("""
+        {
+          "quota_reset_date": "2999-01-01",
+          "limited_user_quotas": { "chat": 25, "completions": 1000 },
+          "monthly_quotas": { "chat": 50, "completions": 2000 }
+        }
+        """.utf8)
+    }
+
+    private static func factoryPayload() -> Data {
+        Data("""
+        {
+          "usesTokenRateLimitsBilling": true,
+          "limits": {
+            "standard": { "fiveHour": { "usedPercent": 25, "windowEnd": "2999-01-01T00:00:00Z" } },
+            "core": { "fiveHour": { "usedPercent": 70, "windowEnd": "2999-01-01T00:00:00Z" } }
+          }
+        }
+        """.utf8)
+    }
+
+    private static func grokPayload() -> Data {
+        Data("""
+        {
+          "config": {
+            "currentPeriod": { "type": "USAGE_PERIOD_TYPE_WEEKLY", "end": "2999-01-08T00:00:00Z" },
+            "creditUsagePercent": 55,
+            "onDemandCap": { "val": 0 }
+          }
+        }
+        """.utf8)
+    }
+}

--- a/QuotioTests/QuotaBucketKindTests.swift
+++ b/QuotioTests/QuotaBucketKindTests.swift
@@ -1,0 +1,274 @@
+import XCTest
+@testable import Quotio
+
+/// Covers the fetcher-declared bucket kinds and the total-usage math that reads them.
+///
+/// Every fixture below is a provider payload run through the real mapper, so the
+/// classification under test is the one the app actually produces at runtime.
+/// Nothing here mutates `MenuBarSettingsManager.shared`: the calculation is a pure
+/// function that takes the two display modes as arguments.
+final class QuotaBucketKindTests: XCTestCase {
+
+    // MARK: - Codex: additional_rate_limits carry no billing signal
+
+    /// `CodexUsageMapper.extraModels` names `additional_rate_limits` entries
+    /// `codex-<metered_feature/limit_name slug>`. That slug is provider text, so it
+    /// cannot decide billing: the same collection holds model-specific *subscription*
+    /// limits. This payload contains one whose slug ends in `on-demand`, which a
+    /// suffix rule would misread as paid overage and drop from session totals.
+    func testCodexAdditionalRateLimitsAreNeverClassifiedAsPaidOverage() throws {
+        let data = Self.codexUsagePayload()
+        let quota = try CodexUsageMapper.map(data: data)
+
+        let names = quota.models.map(\.name)
+        XCTAssertEqual(
+            names,
+            ["codex-session", "codex-weekly", "codex-spark", "codex-spark-weekly", "codex-code-review-on-demand"]
+        )
+
+        for model in quota.models {
+            XCTAssertNotEqual(
+                model.billing,
+                .paidOverage,
+                "\(model.name) is a rate limit, not paid overage"
+            )
+        }
+
+        let dynamicLimit = try XCTUnwrap(quota.models.first { $0.name == "codex-code-review-on-demand" })
+        XCTAssertNil(dynamicLimit.billing, "an additional rate limit states no billing kind")
+    }
+
+    /// The subscription bucket above must keep counting toward `.sessionOnly` totals.
+    func testSessionOnlyTotalKeepsCodexAdditionalRateLimits() throws {
+        let quota = try CodexUsageMapper.map(data: Self.codexUsagePayload())
+
+        let total = QuotaUsageCalculator.totalUsagePercent(
+            models: quota.models,
+            totalMode: .sessionOnly,
+            aggregation: .lowest
+        )
+
+        // codex-code-review-on-demand is the lowest bucket at 5% remaining.
+        XCTAssertEqual(total, 5, accuracy: 0.001)
+    }
+
+    /// Codex maps the Spark five-hour window to `codex-spark`, whose name contains
+    /// none of `session`, `five-hour` or `5h`. The window must come from the payload's
+    /// `limit_window_seconds`, not from the name.
+    func testCodexDeclaresWindowsFromThePayloadNotTheName() throws {
+        let quota = try CodexUsageMapper.map(data: Self.codexUsagePayload())
+        let windows = Dictionary(uniqueKeysWithValues: quota.models.map { ($0.name, $0.window) })
+
+        XCTAssertEqual(windows["codex-session"], .session)
+        XCTAssertEqual(windows["codex-weekly"], .weekly)
+        XCTAssertEqual(windows["codex-spark"], .session)
+        XCTAssertEqual(windows["codex-spark-weekly"], .weekly)
+        XCTAssertEqual(windows["codex-code-review-on-demand"], .session)
+    }
+
+    /// Codex paid credits are an analytics row (`CodexUsageMapper.analytics`), not a
+    /// `ModelQuota`, so no Codex bucket may be treated as paid overage.
+    func testCodexPaidCreditsRemainAnAnalyticsRow() throws {
+        let quota = try CodexUsageMapper.map(data: Self.codexUsagePayload())
+
+        XCTAssertTrue(quota.models.allSatisfy { $0.billing != .paidOverage })
+        XCTAssertEqual(
+            quota.analytics?.rows.first(where: { $0.id == "codex-extra-usage" })?.title,
+            "Extra Usage"
+        )
+    }
+
+    // MARK: - Providers that really do emit a paid bucket
+
+    func testFactoryDeclaresPoolWindowsAndPaidBalance() throws {
+        let response = try JSONDecoder().decode(
+            FactoryDroidQuotaResponse.self,
+            from: Self.factoryQuotaPayload()
+        )
+        let quota = FactoryDroidQuotaMapper.map(response, now: Date(timeIntervalSince1970: 0))
+        let byName = Dictionary(uniqueKeysWithValues: quota.models.map { ($0.name, $0) })
+
+        XCTAssertEqual(byName["factory-standard-five-hour"]?.window, .session)
+        XCTAssertEqual(byName["factory-standard-weekly"]?.window, .weekly)
+        XCTAssertEqual(byName["factory-core-monthly"]?.window, .monthly)
+        XCTAssertEqual(byName["factory-standard-five-hour"]?.billing, .subscription)
+
+        let balance = try XCTUnwrap(byName["factory-extra-balance"])
+        XCTAssertEqual(balance.billing, .paidOverage)
+        XCTAssertNil(balance.window, "a prepaid balance refills on no schedule")
+    }
+
+    func testGrokDeclaresWeeklyWindowAndOnDemandCap() throws {
+        let quota = try XCTUnwrap(GrokQuotaMapper.mapBilling(Self.grokBillingPayload(), plan: "SuperGrok"))
+        let byName = Dictionary(uniqueKeysWithValues: quota.models.map { ($0.name, $0) })
+
+        // Guarded on config.currentPeriod.type == USAGE_PERIOD_TYPE_WEEKLY.
+        XCTAssertEqual(byName["grok-weekly"]?.window, .weekly)
+        XCTAssertEqual(byName["grok-weekly"]?.billing, .subscription)
+        XCTAssertEqual(byName["grok-extra-usage"]?.billing, .paidOverage)
+    }
+
+    // MARK: - Total usage math
+
+    func testSessionOnlyTotalExcludesDeclaredPaidOverage() {
+        let models = [
+            ModelQuota(name: "five-hour-session", percentage: 55, resetTime: "", window: .session, billing: .subscription),
+            ModelQuota(name: "seven-day-weekly", percentage: 70, resetTime: "", window: .weekly, billing: .subscription),
+            ModelQuota(name: "extra-usage", percentage: 0, resetTime: "", window: .monthly, billing: .paidOverage)
+        ]
+
+        let total = QuotaUsageCalculator.totalUsagePercent(
+            models: models,
+            totalMode: .sessionOnly,
+            aggregation: .lowest
+        )
+        XCTAssertEqual(total, 55, accuracy: 0.001)
+    }
+
+    /// A bucket with no declared billing kind is *not* paid overage, so it must stay
+    /// in the subscription group rather than silently vanishing from the total.
+    func testSessionOnlyTotalKeepsUnclassifiedBuckets() {
+        let models = [
+            ModelQuota(name: "codex-session", percentage: 42, resetTime: "", window: .session, billing: .subscription),
+            ModelQuota(name: "codex-some-overage", percentage: 12, resetTime: "")
+        ]
+
+        let total = QuotaUsageCalculator.totalUsagePercent(
+            models: models,
+            totalMode: .sessionOnly,
+            aggregation: .lowest
+        )
+        XCTAssertEqual(total, 12, accuracy: 0.001)
+    }
+
+    func testCombinedTotalCountsPaidOverage() {
+        let models = [
+            ModelQuota(name: "plan-usage", percentage: 10, resetTime: "", billing: .subscription),
+            ModelQuota(name: "on-demand", percentage: 80, resetTime: "", billing: .paidOverage)
+        ]
+
+        let total = QuotaUsageCalculator.totalUsagePercent(
+            models: models,
+            totalMode: .combined,
+            aggregation: .lowest
+        )
+        XCTAssertEqual(total, 80, accuracy: 0.001)
+    }
+
+    func testSessionOnlyFallsBackToPaidOverageWhenNoSubscriptionValueIsKnown() {
+        let models = [
+            ModelQuota(name: "on-demand", percentage: 25, resetTime: "", billing: .paidOverage)
+        ]
+
+        let total = QuotaUsageCalculator.totalUsagePercent(
+            models: models,
+            totalMode: .sessionOnly,
+            aggregation: .lowest
+        )
+        XCTAssertEqual(total, 25, accuracy: 0.001)
+    }
+
+    func testUnknownPercentagesAreIgnoredByAggregation() {
+        // Status/balance rows use -1 as the "unknown" sentinel.
+        let models = [
+            ModelQuota(name: "grok-weekly", percentage: 30, resetTime: "", window: .weekly, billing: .subscription),
+            ModelQuota(name: "grok-extra-usage", percentage: -1, resetTime: "", billing: .paidOverage)
+        ]
+
+        XCTAssertEqual(
+            QuotaUsageCalculator.totalUsagePercent(models: models, totalMode: .combined, aggregation: .lowest),
+            30,
+            accuracy: 0.001
+        )
+    }
+
+    // MARK: - Persistence compatibility
+
+    /// `ProviderQuotaData` is cached to disk. Data written before the bucket kinds
+    /// existed must still decode, with both kinds left unknown.
+    func testQuotaDataCachedBeforeBucketKindsStillDecodes() throws {
+        let legacy = Data("""
+        {
+          "models": [
+            { "name": "codex-session", "percentage": 40, "resetTime": "" }
+          ],
+          "lastUpdated": 0,
+          "isForbidden": false
+        }
+        """.utf8)
+
+        let decoded = try JSONDecoder().decode(ProviderQuotaData.self, from: legacy)
+        let model = try XCTUnwrap(decoded.models.first)
+        XCTAssertNil(model.window)
+        XCTAssertNil(model.billing)
+    }
+
+    // MARK: - Fixtures
+
+    /// Shaped after `GET /backend-api/wham/usage`: a plan rate limit plus
+    /// `additional_rate_limits` holding the Spark windows and one other
+    /// model-specific limit.
+    private static func codexUsagePayload() -> Data {
+        Data("""
+        {
+          "plan_type": "pro",
+          "rate_limit": {
+            "limit_reached": false,
+            "primary_window": { "used_percent": 20, "reset_at": 1800000000, "limit_window_seconds": 18000 },
+            "secondary_window": { "used_percent": 35, "reset_at": 1800500000, "limit_window_seconds": 604800 }
+          },
+          "additional_rate_limits": [
+            {
+              "limit_name": "codex_spark",
+              "metered_feature": "spark",
+              "rate_limit": {
+                "primary_window": { "used_percent": 90, "reset_at": 1800000000, "limit_window_seconds": 18000 },
+                "secondary_window": { "used_percent": 50, "reset_at": 1800500000, "limit_window_seconds": 604800 }
+              }
+            },
+            {
+              "limit_name": "code_review_on_demand",
+              "metered_feature": "code review on-demand",
+              "rate_limit": {
+                "primary_window": { "used_percent": 95, "reset_at": 1800000000, "limit_window_seconds": 18000 }
+              }
+            }
+          ],
+          "credits": { "balance": 12.5 }
+        }
+        """.utf8)
+    }
+
+    private static func factoryQuotaPayload() -> Data {
+        Data("""
+        {
+          "usesTokenRateLimitsBilling": true,
+          "limits": {
+            "standard": {
+              "fiveHour": { "usedPercent": 25, "windowEnd": "2999-01-01T00:00:00Z" },
+              "weekly": { "usedPercent": 40, "windowEnd": "2999-01-02T00:00:00Z" }
+            },
+            "core": {
+              "monthly": { "usedPercent": 10, "windowEnd": "2999-02-01T00:00:00Z" }
+            }
+          },
+          "extraUsageBalanceCents": 750
+        }
+        """.utf8)
+    }
+
+    private static func grokBillingPayload() -> Data {
+        Data("""
+        {
+          "config": {
+            "currentPeriod": {
+              "type": "USAGE_PERIOD_TYPE_WEEKLY",
+              "end": "2999-01-08T00:00:00Z"
+            },
+            "creditUsagePercent": 60,
+            "onDemandCap": { "val": 2500 }
+          }
+        }
+        """.utf8)
+    }
+}


### PR DESCRIPTION
Closes #393.

## What this does

Each menu bar item picks what it shows, instead of one global mode for every account:

```swift
nonisolated enum MenuBarBucketSelection: Codable, Hashable, Sendable {
    case auto              // unchanged aggregate, per the Usage Display settings
    case window(QuotaWindow)
    case bucket(String)    // exact ModelQuota.name
}
```

The choice is stored on `MenuBarQuotaItem` and defaults to `nil`, which reads as `.auto`, so existing selections keep their current value. The picker lives in Settings → Menu Bar, one row per selected item; new strings are localized in en/fr/vi/zh-Hans.

Options come from the buckets the provider actually reports for that account, so the cases #393 asks for are reachable: `factory-standard-five-hour` vs `factory-core-five-hour`, `antigravity-gemini-session` vs `antigravity-claude-gpt-session`, and paid buckets such as Cursor `on-demand`.

## Window classification

Windows are declared by the producing fetcher via `ModelQuota.window`, set from the payload field the bucket came from, not matched against the bucket name. This is the shared foundation commit also present in #485.

Name matching would be wrong for shapes shipping today: Codex names the Spark five-hour window `codex-spark`, and Copilot names its monthly quotas `copilot-chat` / `copilot-completions`. Both are covered by regression tests built from real payloads.

Nine producers state no window (Cursor exposes only a `billingCycleEnd` boundary, Warp only a `nextRefreshTime`, Trae only a `resetTime`, Kiro and OpenRouter neither). Those stay unclassified rather than guessed, so those accounts get Automatic plus their individual buckets.

## Behaviour details

- a selection an account no longer offers falls back to the aggregate total rather than showing nothing
- buckets that report no percentage (status rows, currency balances) are not offered, since the menu bar renders a percentage
- `MenuBarQuotaItem` identity stays provider + account key; the bucket choice is an attribute, so adding the same account twice is still rejected

## Verification

```
xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build   ** BUILD SUCCEEDED **
xcodebuild test -project Quotio.xcodeproj -scheme Quotio -destination 'platform=macOS'  ** TEST SUCCEEDED **  (98 tests)
```

`QuotioTests/MenuBarBucketSelectionTests.swift` (15 tests) drives real payloads through `CodexUsageMapper.map`, `CopilotQuotaFetcher.convertToQuotaData`, `FactoryDroidQuotaMapper.map` and `GrokQuotaMapper.mapBilling`, and covers persistence round-trips including selections stored before this feature existed.

One production change purely for testability: `CopilotQuotaFetcher.convertToQuotaData(entitlement:)` became `nonisolated static` (it never used `self`).

## Composition with #485

Both branches contain the byte-identical foundation commit `refactor(quota): carry explicit bucket kinds from quota fetchers` (same tree SHA), so it is a no-op for whichever merges second. Trial-merged both orders: the only conflict is one hunk in `Quotio/QuotioApp.swift`; keep this PR's side, which already calls `totalUsagePercent(models: quotaData.models)` as its fallback. #470, #475 and #487 merge cleanly with both.
