### PR TITLE
fix(menubar): render placeholder instead of 101% for no-data quotas

### DIFF
--- a/Quotio/Models/MenuBarSettings.swift
+++ b/Quotio/Models/MenuBarSettings.swift
@@ -161,11 +161,16 @@ enum QuotaDisplayMode: String, Codable, CaseIterable, Identifiable {
         }
     }
     
-    /// Convert a remaining percentage to the display value based on mode
+    /// Convert a remaining percentage to the display value based on mode.
+    /// A negative input is the "no data" sentinel and is propagated as -1 so it can
+    /// never surface as a fake percentage (e.g. 100 - (-1) = 101%). Valid input is
+    /// clamped to 0-100 before conversion.
     func displayValue(from remainingPercent: Double) -> Double {
+        guard remainingPercent >= 0 else { return -1 }
+        let clamped = min(100, max(0, remainingPercent))
         switch self {
-        case .used: return 100 - remainingPercent
-        case .remaining: return remainingPercent
+        case .used: return 100 - clamped
+        case .remaining: return clamped
         }
     }
     

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -2274,15 +2274,7 @@ private struct RingGridLayout: View {
         LazyVGrid(columns: columns, spacing: 10) {
             ForEach(models, id: \.name) { (model: ModelBadgeData) in
                 VStack(spacing: 4) {
-                    ZStack {
-                        RingProgressView(percent: menuDisplayPercent(remainingPercent: model.percentage, displayMode: displayMode), size: ringSize, lineWidth: 4, tint: menuStatusColor(remainingPercent: model.percentage, displayMode: displayMode), showLabel: model.percentage >= 0)
-
-                        if model.percentage < 0 {
-                            Text("—")
-                                .font(.system(size: ringSize * 0.24, weight: .bold))
-                                .foregroundStyle(.secondary)
-                        }
-                    }
+                    RingProgressView(percent: menuDisplayPercent(remainingPercent: model.percentage, displayMode: displayMode), size: ringSize, lineWidth: 4, tint: menuStatusColor(remainingPercent: model.percentage, displayMode: displayMode), showLabel: true)
 
                     Text(model.name)
                         .font(.system(size: 10, weight: .medium, design: .rounded))
@@ -2466,7 +2458,17 @@ private struct MenuModelDetailView: View {
             }
 
             if !model.isStandaloneMetric && displayStyle == .ring {
-                RingProgressView(percent: displayPercent, size: 14, lineWidth: 2, tint: statusColor)
+                if RingProgressView.isUnknown(displayPercent) {
+                    // A 14pt ring has no room for a label, so replace it with the
+                    // same placeholder the other display styles render.
+                    Text("—")
+                        .font(.system(size: 10, weight: .semibold, design: .rounded))
+                        .foregroundStyle(statusColor)
+                        .accessibilityLabel("usage.ring".localized())
+                        .accessibilityValue("quota.noDataYet".localized())
+                } else {
+                    RingProgressView(percent: displayPercent, size: 14, lineWidth: 2, tint: statusColor)
+                }
             }
         }
         .padding(.horizontal, 12)

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -2145,7 +2145,15 @@ private func menuDisplayPercent(remainingPercent: Double, displayMode: QuotaDisp
     displayMode.displayValue(from: remainingPercent)
 }
 
+/// Formatted percentage for menu rows. A negative remaining percentage means
+/// "no data yet" and renders as a placeholder instead of a fake value like 101%.
+private func menuPercentText(remainingPercent: Double, displayMode: QuotaDisplayMode) -> String {
+    guard remainingPercent >= 0 else { return "—" }
+    return "\(Int(menuDisplayPercent(remainingPercent: remainingPercent, displayMode: displayMode)))%"
+}
+
 private func menuStatusColor(remainingPercent: Double, displayMode: QuotaDisplayMode) -> Color {
+    guard remainingPercent >= 0 else { return .secondary }
     let usedPercent = 100 - remainingPercent
     let checkValue = displayMode == .used ? usedPercent : remainingPercent
 
@@ -2230,7 +2238,7 @@ private struct LowestBarLayout: View {
                                     .font(.system(size: 9, design: .rounded))
                                     .foregroundStyle(.tertiary)
                             }
-                            Text("\(Int(menuDisplayPercent(remainingPercent: model.percentage, displayMode: displayMode)))%")
+                            Text(menuPercentText(remainingPercent: model.percentage, displayMode: displayMode))
                                 .font(.system(size: 10, weight: .bold, design: .monospaced))
                                 .foregroundStyle(menuStatusColor(remainingPercent: model.percentage, displayMode: displayMode))
                         }
@@ -2266,7 +2274,15 @@ private struct RingGridLayout: View {
         LazyVGrid(columns: columns, spacing: 10) {
             ForEach(models, id: \.name) { (model: ModelBadgeData) in
                 VStack(spacing: 4) {
-                    RingProgressView(percent: menuDisplayPercent(remainingPercent: model.percentage, displayMode: displayMode), size: ringSize, lineWidth: 4, tint: menuStatusColor(remainingPercent: model.percentage, displayMode: displayMode), showLabel: true)
+                    ZStack {
+                        RingProgressView(percent: menuDisplayPercent(remainingPercent: model.percentage, displayMode: displayMode), size: ringSize, lineWidth: 4, tint: menuStatusColor(remainingPercent: model.percentage, displayMode: displayMode), showLabel: model.percentage >= 0)
+
+                        if model.percentage < 0 {
+                            Text("—")
+                                .font(.system(size: ringSize * 0.24, weight: .bold))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
 
                     Text(model.name)
                         .font(.system(size: 10, weight: .medium, design: .rounded))
@@ -2317,7 +2333,7 @@ private struct CardGridLayout: View {
                                 .font(.system(size: 9, design: .rounded))
                                 .foregroundStyle(.tertiary)
                         }
-                        Text("\(Int(menuDisplayPercent(remainingPercent: model.percentage, displayMode: displayMode)))%")
+                        Text(menuPercentText(remainingPercent: model.percentage, displayMode: displayMode))
                             .font(.system(size: 10, weight: .bold, design: .monospaced))
                             .foregroundStyle(menuStatusColor(remainingPercent: model.percentage, displayMode: displayMode))
                     }
@@ -2381,15 +2397,15 @@ private struct PercentageBadge: View {
     var color: Color {
         menuStatusColor(remainingPercent: percentage, displayMode: settings.quotaDisplayMode)
     }
-    
-    private var displayPercent: Double {
-        menuDisplayPercent(remainingPercent: percentage, displayMode: settings.quotaDisplayMode)
+
+    private var displayText: String {
+        menuPercentText(remainingPercent: percentage, displayMode: settings.quotaDisplayMode)
     }
-    
+
     var body: some View {
         switch style {
         case .pill:
-            Text("\(Int(displayPercent))%")
+            Text(displayText)
                 .font(.system(size: 10, weight: .bold, design: .monospaced))
                 .foregroundStyle(color)
                 .padding(.horizontal, 6)
@@ -2397,7 +2413,7 @@ private struct PercentageBadge: View {
                 .background(color.opacity(0.1))
                 .clipShape(Capsule())
         case .textOnly:
-            Text("\(Int(displayPercent))%")
+            Text(displayText)
                 .font(.system(size: 12, weight: .bold, design: .monospaced))
                 .foregroundStyle(color)
         }
@@ -2436,7 +2452,9 @@ private struct MenuModelDetailView: View {
             }
 
             if !model.isStandaloneMetric && displayStyle != .ring {
-                Text(String(format: "%.0f%% %@", displayPercent, displayMode.suffixKey.localized()))
+                Text(displayPercent >= 0
+                    ? String(format: "%.0f%% %@", displayPercent, displayMode.suffixKey.localized())
+                    : "—")
                     .font(.system(size: 10, weight: .semibold, design: .rounded))
                     .foregroundStyle(statusColor)
             }

--- a/Quotio/Views/Components/QuotaCard.swift
+++ b/Quotio/Views/Components/QuotaCard.swift
@@ -216,7 +216,7 @@ private struct QuotaSection: View {
     @State private var settings = MenuBarSettingsManager.shared
     
     private var progressWidth: Double {
-        remainingPercent / 100
+        min(1, max(0, remainingPercent / 100))
     }
     
     var body: some View {
@@ -232,7 +232,9 @@ private struct QuotaSection: View {
                 Spacer()
                 
                 HStack(spacing: 8) {
-                    Text(verbatim: "\(Int(displayPercent))% \(displayMode.suffixKey.localized())")
+                    Text(verbatim: displayPercent >= 0
+                        ? "\(Int(displayPercent))% \(displayMode.suffixKey.localized())"
+                        : "—")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     

--- a/Quotio/Views/Components/RingProgressView.swift
+++ b/Quotio/Views/Components/RingProgressView.swift
@@ -9,39 +9,80 @@ import SwiftUI
 
 /// Circular progress indicator for quota display
 struct RingProgressView: View {
+    /// Percentage that means "no data available", matching the `-1` quota sentinel.
+    nonisolated static let unknownPercent: Double = -1
+
     let percent: Double
     var size: CGFloat = 32
     var lineWidth: CGFloat = 4
     var tint: Color = .accentColor
     var showLabel: Bool = false
-    
-    private var clamped: Double {
+
+    /// A negative percentage is the "no data yet" sentinel. It must never be
+    /// clamped into a real 0% reading, visually or for VoiceOver.
+    nonisolated static func isUnknown(_ percent: Double) -> Bool {
+        percent < 0
+    }
+
+    /// Center label text: the same `—` placeholder the text/card paths use when
+    /// no data is available.
+    nonisolated static func labelText(for percent: Double) -> String {
+        isUnknown(percent) ? "—" : "\(Int(clamped(percent)))%"
+    }
+
+    /// VoiceOver value. Announces the shared "no usage data" string for unknown
+    /// quotas instead of a fabricated "0 percent".
+    static func accessibilityValueText(for percent: Double) -> String {
+        isUnknown(percent)
+            ? "quota.noDataYet".localized()
+            : String(format: "%lld percent".localized(), Int64(clamped(percent)))
+    }
+
+    nonisolated private static func clamped(_ percent: Double) -> Double {
         min(100, max(0, percent))
     }
-    
+
+    private var isUnknown: Bool {
+        Self.isUnknown(percent)
+    }
+
+    private var clamped: Double {
+        Self.clamped(percent)
+    }
+
     var body: some View {
         ZStack {
             // Background ring
             Circle()
                 .stroke(.quaternary, lineWidth: lineWidth)
-            
-            // Progress ring
-            Circle()
-                .trim(from: 0, to: clamped / 100)
-                .stroke(tint, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
-                .rotationEffect(.degrees(-90))
-                .animation(.smooth(duration: 0.3), value: clamped)
-            
+
+            // Progress ring — omitted when there is no data, so an unknown quota
+            // is not drawn as a real 0% arc.
+            if !isUnknown {
+                Circle()
+                    .trim(from: 0, to: clamped / 100)
+                    .stroke(tint, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                    .animation(.smooth(duration: 0.3), value: clamped)
+            }
+
             // Optional center label
             if showLabel {
-                Text("\(Int(clamped))%")
-                    .font(.system(size: size * 0.24, weight: .bold))
-                    .monospacedDigit()
+                if isUnknown {
+                    Text(Self.labelText(for: percent))
+                        .font(.system(size: size * 0.24, weight: .bold))
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text(Self.labelText(for: percent))
+                        .font(.system(size: size * 0.24, weight: .bold))
+                        .monospacedDigit()
+                }
             }
         }
         .frame(width: size, height: size)
+        .accessibilityElement(children: .ignore)
         .accessibilityLabel("usage.ring".localized())
-        .accessibilityValue(String(format: "%lld percent".localized(), Int64(clamped)))
+        .accessibilityValue(Self.accessibilityValueText(for: percent))
     }
 }
 
@@ -50,6 +91,7 @@ struct RingProgressView: View {
         RingProgressView(percent: 75, tint: .green, showLabel: true)
         RingProgressView(percent: 30, tint: .yellow, showLabel: true)
         RingProgressView(percent: 5, tint: .red, showLabel: true)
+        RingProgressView(percent: RingProgressView.unknownPercent, showLabel: true)
     }
     .padding()
 }

--- a/Quotio/Views/Screens/QuotaScreen.swift
+++ b/Quotio/Views/Screens/QuotaScreen.swift
@@ -259,6 +259,15 @@ fileprivate struct QuotaDisplayHelper {
         let clamped = max(0, min(100, remainingPercent))
         return displayMode == .used ? (100 - clamped) : clamped
     }
+
+    /// Percentage for ring rendering. Unlike `displayPercent(remainingPercent:)`
+    /// this keeps the "no data" sentinel instead of clamping it into a real
+    /// value, so `RingProgressView` can render its unknown state.
+    func ringPercent(remainingPercent: Double) -> Double {
+        remainingPercent < 0
+            ? RingProgressView.unknownPercent
+            : displayPercent(remainingPercent: remainingPercent)
+    }
 }
 
 // MARK: - Provider Segment Button
@@ -1296,16 +1305,16 @@ private struct AntigravityRingLayout: View {
         return Array(repeating: GridItem(.flexible(), spacing: 12), count: count)
     }
     
-    private func displayPercent(for remainingPercent: Double) -> Double {
-        displayHelper.displayPercent(remainingPercent: remainingPercent)
+    private func ringPercent(for remainingPercent: Double) -> Double {
+        displayHelper.ringPercent(remainingPercent: remainingPercent)
     }
-    
+
     var body: some View {
         LazyVGrid(columns: columns, spacing: 12) {
             ForEach(groups) { group in
                 VStack(spacing: 6) {
                     RingProgressView(
-                        percent: displayPercent(for: group.percentage),
+                        percent: ringPercent(for: group.percentage),
                         size: 44,
                         lineWidth: 5,
                         tint: displayHelper.statusColor(remainingPercent: group.percentage),
@@ -1429,16 +1438,16 @@ private struct StandardRingLayout: View {
         return Array(repeating: GridItem(.flexible(), spacing: 12), count: count)
     }
     
-    private func displayPercent(for remainingPercent: Double) -> Double {
-        displayHelper.displayPercent(remainingPercent: remainingPercent)
+    private func ringPercent(for remainingPercent: Double) -> Double {
+        displayHelper.ringPercent(remainingPercent: remainingPercent)
     }
-    
+
     var body: some View {
         LazyVGrid(columns: columns, spacing: 12) {
             ForEach(models) { model in
                 VStack(spacing: 6) {
                     RingProgressView(
-                        percent: displayPercent(for: model.percentage),
+                        percent: ringPercent(for: model.percentage),
                         size: 44,
                         lineWidth: 5,
                         tint: displayHelper.statusColor(remainingPercent: model.percentage),

--- a/QuotioTests/QuotaDisplayModeTests.swift
+++ b/QuotioTests/QuotaDisplayModeTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import Quotio
+
+/// Regression tests for issue #219: a "no data" sentinel of -1 remaining percent
+/// must never be converted into a fake display value (100 - (-1) = 101%).
+@MainActor
+final class QuotaDisplayModeTests: XCTestCase {
+    // MARK: - No-data sentinel propagation
+
+    /// The exact defect from issue #219: an unfetched quota item carries
+    /// remaining = -1, and "used" mode displayed 100 - (-1) = 101%.
+    func testUsedModePropagatesNoDataSentinelInsteadOf101() {
+        XCTAssertEqual(QuotaDisplayMode.used.displayValue(from: -1), -1)
+    }
+
+    func testRemainingModePropagatesNoDataSentinel() {
+        XCTAssertEqual(QuotaDisplayMode.remaining.displayValue(from: -1), -1)
+    }
+
+    func testAnyNegativeInputIsTreatedAsNoData() {
+        XCTAssertEqual(QuotaDisplayMode.used.displayValue(from: -0.5), -1)
+        XCTAssertEqual(QuotaDisplayMode.remaining.displayValue(from: -100), -1)
+    }
+
+    // MARK: - Valid values are unchanged
+
+    func testUsedModeConvertsRemainingToUsed() {
+        XCTAssertEqual(QuotaDisplayMode.used.displayValue(from: 100), 0)
+        XCTAssertEqual(QuotaDisplayMode.used.displayValue(from: 70), 30)
+        XCTAssertEqual(QuotaDisplayMode.used.displayValue(from: 0), 100)
+    }
+
+    func testRemainingModePassesValueThrough() {
+        XCTAssertEqual(QuotaDisplayMode.remaining.displayValue(from: 100), 100)
+        XCTAssertEqual(QuotaDisplayMode.remaining.displayValue(from: 25), 25)
+        XCTAssertEqual(QuotaDisplayMode.remaining.displayValue(from: 0), 0)
+    }
+
+    // MARK: - Out-of-range values are clamped at the display boundary
+
+    func testOverOneHundredRemainingIsClamped() {
+        XCTAssertEqual(QuotaDisplayMode.used.displayValue(from: 150), 0)
+        XCTAssertEqual(QuotaDisplayMode.remaining.displayValue(from: 150), 100)
+    }
+}

--- a/QuotioTests/RingProgressViewTests.swift
+++ b/QuotioTests/RingProgressViewTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import Quotio
+
+/// Regression tests for the ring display paths of issue #219.
+///
+/// The `-1` "no data" sentinel used to be clamped to zero by `RingProgressView`,
+/// so an unknown quota rendered as an empty 0% ring and VoiceOver announced
+/// "0 percent". The ring must expose the same unknown-value contract as the
+/// text/card paths.
+@MainActor
+final class RingProgressViewTests: XCTestCase {
+    // MARK: - Unknown detection
+
+    func testNegativeSentinelIsUnknown() {
+        XCTAssertTrue(RingProgressView.isUnknown(RingProgressView.unknownPercent))
+        XCTAssertTrue(RingProgressView.isUnknown(-1))
+        XCTAssertTrue(RingProgressView.isUnknown(-0.5))
+    }
+
+    func testRealValuesAreNotUnknown() {
+        XCTAssertFalse(RingProgressView.isUnknown(0))
+        XCTAssertFalse(RingProgressView.isUnknown(42))
+        XCTAssertFalse(RingProgressView.isUnknown(100))
+    }
+
+    /// The value the menu bar actually hands to the ring: an unfetched quota
+    /// carries remaining = -1, which `displayValue(from:)` propagates.
+    func testSentinelFromDisplayModeReachesRingAsUnknown() {
+        XCTAssertTrue(RingProgressView.isUnknown(QuotaDisplayMode.used.displayValue(from: -1)))
+        XCTAssertTrue(RingProgressView.isUnknown(QuotaDisplayMode.remaining.displayValue(from: -1)))
+    }
+
+    // MARK: - Visible label
+
+    func testUnknownRendersPlaceholderLabel() {
+        XCTAssertEqual(RingProgressView.labelText(for: RingProgressView.unknownPercent), "—")
+    }
+
+    func testKnownValuesRenderPercentLabel() {
+        XCTAssertEqual(RingProgressView.labelText(for: 0), "0%")
+        XCTAssertEqual(RingProgressView.labelText(for: 42.6), "42%")
+        XCTAssertEqual(RingProgressView.labelText(for: 100), "100%")
+    }
+
+    func testLabelClampsOutOfRangeValues() {
+        XCTAssertEqual(RingProgressView.labelText(for: 150), "100%")
+    }
+
+    // MARK: - Accessibility value
+
+    /// The exact complaint from review: an unknown quota must not be announced
+    /// the same way as a real 0% quota.
+    func testUnknownAccessibilityValueDiffersFromZeroPercent() {
+        let unknown = RingProgressView.accessibilityValueText(for: RingProgressView.unknownPercent)
+        let zero = RingProgressView.accessibilityValueText(for: 0)
+
+        XCTAssertNotEqual(unknown, zero)
+        XCTAssertEqual(unknown, "quota.noDataYet".localized())
+    }
+
+    func testKnownAccessibilityValueAnnouncesPercent() {
+        XCTAssertEqual(
+            RingProgressView.accessibilityValueText(for: 42),
+            String(format: "%lld percent".localized(), Int64(42))
+        )
+    }
+
+    func testAccessibilityValueClampsOutOfRangeValues() {
+        XCTAssertEqual(
+            RingProgressView.accessibilityValueText(for: 150),
+            String(format: "%lld percent".localized(), Int64(100))
+        )
+    }
+}


### PR DESCRIPTION
## Problem

On app open, menu bar quota values briefly show **101%** and, for OpenAI Codex, can stay at 101% even though actual usage is 0 (see the screenshot in #219: the status item shows `101%` while the dropdown for the same Codex account shows Session 0% / Weekly 0%).

## Root cause

Quota values use `remaining = -1` as a "no data yet" sentinel:

- `QuotioApp.quotaItems` initializes `displayPercent = -1` and keeps it when the selected menu bar item's account key cannot be resolved to a fetched quota entry (the Codex case: its quota keys are filename-based, so a stale selection key never matches).
- `MenuBarSettingsManager.totalUsagePercent` returns `-1` when no valid model percentages exist.
- Some fetchers emit `-1` placeholder models (e.g. Trae's `trae-usage` when an account has no active quota buckets — and IDE quotas are persisted in `UserDefaults` and only refreshed by an explicit scan, so the value survives restarts).

In the default "used" display mode, `QuotaDisplayMode.displayValue(from:)` converted that sentinel with `100 - (-1) = 101`, fabricating the 101%. #275/#277 hid the value in the status item view, but the conversion helper still fabricates 101, and the dropdown menu views (`PercentageBadge`, `LowestBarLayout`, `CardGridLayout`, `RingGridLayout`, `MenuModelDetailView` via `menuDisplayPercent`) render it unguarded — a `-1` model still shows as **101%** there today (reproducible with a Trae account that has no active quota buckets, and with any provider whose persisted snapshot carries `-1` while its refresh keeps failing, since `MonitorRefreshCoordinator.refresh` returns the previous snapshot on failure).

## Fix

Handle the sentinel at the display boundary, mirroring the existing `UsageRowV2.isUnknown` pattern from the main window:

- `QuotaDisplayMode.displayValue(from:)` now propagates negative input as `-1` (no data) instead of computing `100 - (-1) = 101`, and clamps valid input to 0–100. This is the single choke point used by the status item, the dropdown, and quota cards, so a fake >100% can no longer be fabricated anywhere.
- Dropdown menu views render `—` in a neutral color for no-data models instead of a fake percentage (`menuPercentText` helper; `menuStatusColor` returns `.secondary` for unknown values so no-data is not painted red).
- `QuotaCard.QuotaSection` gets the same `—` placeholder and a clamped progress width.

No fetcher behavior changes; `-1` remains the internal "unknown" sentinel and now consistently renders as a placeholder.

## Tests

- New `QuotioTests/QuotaDisplayModeTests.swift`:
  - `displayValue(from: -1)` in `.used` mode returned `101` before this change; now returns `-1` (regression test for the reported symptom).
  - Sentinel propagation in both display modes, normal conversions, and out-of-range clamping.
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build` succeeds.
- `xcodebuild test -scheme Quotio -destination 'platform=macOS'` passes (all suites).

Fixes #219
