### PR TITLE
fix(opencode): preserve user settings when auto-configuring opencode.json

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -1857,6 +1857,296 @@
         }
       }
     },
+    "agents.opencode.notConfigured" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Quotio provider found in opencode.json. OpenCode already uses its default providers."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun fournisseur Quotio trouvé dans opencode.json. OpenCode utilise déjà ses fournisseurs par défaut."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không tìm thấy nhà cung cấp Quotio trong opencode.json. OpenCode đang dùng các nhà cung cấp mặc định."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 opencode.json 中未找到 Quotio 提供商。OpenCode 已在使用其默认提供商。"
+          }
+        }
+      }
+    },
+    "agents.opencode.parseError.duplicateKey" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The key \"%@\" appears more than once."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La clé « %@ » apparaît plusieurs fois."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khóa \"%@\" xuất hiện nhiều lần."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "键“%@”出现了多次。"
+          }
+        }
+      }
+    },
+    "agents.opencode.parseError.notObject" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The file is not a JSON object."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le fichier n’est pas un objet JSON."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tệp không phải là một đối tượng JSON."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该文件不是 JSON 对象。"
+          }
+        }
+      }
+    },
+    "agents.opencode.parseError.notUTF8" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The file is not valid UTF-8 text."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le fichier n’est pas un texte UTF-8 valide."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tệp không phải là văn bản UTF-8 hợp lệ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该文件不是有效的 UTF-8 文本。"
+          }
+        }
+      }
+    },
+    "agents.opencode.parseError.providerNotObject" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The \"provider\" field is not a JSON object."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le champ « provider » n’est pas un objet JSON."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trường \"provider\" không phải là một đối tượng JSON."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“provider” 字段不是 JSON 对象。"
+          }
+        }
+      }
+    },
+    "agents.opencode.parseError.syntax" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unexpected character at line %1$@, column %2$@."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caractère inattendu à la ligne %1$@, colonne %2$@."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ký tự không hợp lệ tại dòng %1$@, cột %2$@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %1$@ 行第 %2$@ 列存在意外字符。"
+          }
+        }
+      }
+    },
+    "agents.opencode.parseError.unterminatedComment" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A block comment (/* …) is never closed."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un commentaire de bloc (/* …) n’est jamais fermé."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Một chú thích khối (/* …) chưa được đóng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "块注释（/* …）未闭合。"
+          }
+        }
+      }
+    },
+    "agents.opencode.parseError.unterminatedString" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A text value is missing its closing quote."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une valeur texte n’a pas de guillemet fermant."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Một giá trị văn bản thiếu dấu nháy đóng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文本值缺少结束引号。"
+          }
+        }
+      }
+    },
+    "agents.opencode.parseError.verification" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The edited file did not match the expected result, so nothing was written."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le fichier modifié ne correspond pas au résultat attendu ; rien n’a été écrit."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tệp sau khi chỉnh sửa không khớp với kết quả mong đợi nên không có gì được ghi."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑后的文件与预期结果不符，因此未写入任何内容。"
+          }
+        }
+      }
+    },
+    "agents.opencode.parseFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not parse %1$@: %2$@ The file was left untouched — fix its syntax and try again, or use manual mode."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’analyser %1$@ : %2$@ Le fichier n’a pas été modifié — corrigez sa syntaxe puis réessayez, ou utilisez le mode manuel."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể phân tích %1$@: %2$@ Tệp được giữ nguyên — hãy sửa cú pháp rồi thử lại, hoặc dùng chế độ thủ công."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法解析 %1$@：%2$@ 文件未被修改 — 请修正其语法后重试，或使用手动模式。"
+          }
+        }
+      }
+    },
     "agents.proxyRemovalWarning" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -215,10 +215,10 @@ actor AgentConfigurationService {
         
         guard fileManager.fileExists(atPath: configPath),
               let data = fileManager.contents(atPath: configPath),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+              let json = try? Self.parseOpenCodeJSONObject(data) else {
             return nil
         }
-        
+
         // Check for quotio provider
         guard let providers = json["provider"] as? [String: Any],
               let quotioProvider = providers["quotio"] as? [String: Any],
@@ -752,21 +752,26 @@ actor AgentConfigurationService {
         if mode == .automatic && fileManager.fileExists(atPath: configPath) {
             do {
                 let data = try Data(contentsOf: URL(fileURLWithPath: configPath))
-                var config = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
-                
-                // Create backup
-                let backupPath = "\(configPath).backup.\(Int(Date().timeIntervalSince1970))"
-                try fileManager.copyItem(atPath: configPath, toPath: backupPath)
-                
-                // Remove quotio provider
-                if var providers = config["provider"] as? [String: Any] {
-                    providers.removeValue(forKey: "quotio")
-                    config["provider"] = providers.isEmpty ? nil : providers
+
+                // Remove only the Quotio-managed provider entry, preserving
+                // every other user setting (#176). When there is nothing to
+                // remove, leave the file completely untouched.
+                guard let updatedData = try Self.openCodeJSONRemovingQuotioProvider(existing: data) else {
+                    return .success(
+                        type: .file,
+                        mode: mode,
+                        configPath: configPath,
+                        authPath: nil,
+                        shellConfig: nil,
+                        rawConfigs: [],
+                        instructions: "No Quotio provider found in opencode.json. OpenCode already uses its default providers.",
+                        modelsConfigured: 0
+                    )
                 }
-                
-                let updatedData = try JSONSerialization.data(withJSONObject: config, options: [.prettyPrinted, .sortedKeys])
+
+                _ = try backupIfPresent(configPath)
                 try updatedData.write(to: URL(fileURLWithPath: configPath))
-                
+
                 return .success(
                     type: .file,
                     mode: mode,
@@ -1207,24 +1212,20 @@ actor AgentConfigurationService {
         ]
 
         do {
-            var existingConfig: [String: Any] = [:]
+            let existingData = fileManager.contents(atPath: configPath)
 
-            if fileManager.fileExists(atPath: configPath),
-               let existingData = fileManager.contents(atPath: configPath),
-               let parsed = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] {
-                existingConfig = parsed
+            let jsonData: Data
+            do {
+                jsonData = try Self.mergedOpenCodeJSON(existing: existingData, quotioProvider: quotioProvider)
+            } catch {
+                if mode == .automatic && existingData != nil {
+                    // Never fall back to overwriting a file we could not parse:
+                    // that wipes user settings like `plugin` and other providers (#176).
+                    return .failure(error: "Could not parse existing opencode.json at \(configPath): \(error.localizedDescription). The file was left untouched — fix its syntax and try again, or use manual mode.")
+                }
+                jsonData = try Self.mergedOpenCodeJSON(existing: nil, quotioProvider: quotioProvider)
             }
-
-            if existingConfig["$schema"] == nil {
-                existingConfig["$schema"] = "https://opencode.ai/config.json"
-            }
-
-            var providers = existingConfig["provider"] as? [String: Any] ?? [:]
-            providers["quotio"] = quotioProvider
-            existingConfig["provider"] = providers
-
-            let jsonData = try JSONSerialization.data(withJSONObject: existingConfig, options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
-            let jsonString = String(data: jsonData, encoding: .utf8) ?? "{}"
+            let jsonString = String(decoding: jsonData, as: UTF8.self)
 
             let rawConfigs = [
                 RawConfigOutput(
@@ -1239,11 +1240,7 @@ actor AgentConfigurationService {
             if mode == .automatic {
                 try fileManager.createDirectory(atPath: configDir, withIntermediateDirectories: true)
 
-                var backupPath: String? = nil
-                if fileManager.fileExists(atPath: configPath) {
-                    backupPath = "\(configPath).backup.\(Int(Date().timeIntervalSince1970))"
-                    try? fileManager.copyItem(atPath: configPath, toPath: backupPath!)
-                }
+                let backupPath = try backupIfPresent(configPath)
 
                 try jsonData.write(to: URL(fileURLWithPath: configPath))
 
@@ -1329,7 +1326,136 @@ actor AgentConfigurationService {
 
         return modelConfig
     }
-    
+
+    // MARK: - OpenCode JSON(C) helpers
+
+    /// Parses opencode.json content into a JSON object. OpenCode configs are
+    /// JSONC (comments and trailing commas are allowed), so a strict parse is
+    /// attempted first and, on failure, the content is re-parsed after a
+    /// comment/trailing-comma stripping pre-pass. Throws when the content is
+    /// not a JSON object even after that pre-pass.
+    nonisolated static func parseOpenCodeJSONObject(_ data: Data) throws -> [String: Any] {
+        if let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] {
+            return object
+        }
+        let sanitized = strippingJSONCSyntax(from: String(decoding: data, as: UTF8.self))
+        guard let object = try JSONSerialization.jsonObject(with: Data(sanitized.utf8)) as? [String: Any] else {
+            throw CocoaError(.propertyListReadCorrupt)
+        }
+        return object
+    }
+
+    /// Merges the Quotio provider entry into existing opencode.json content,
+    /// preserving every other field (plugin, mcp, other providers, ...).
+    /// Throws when `existing` cannot be parsed even with the JSONC pre-pass —
+    /// callers must not fall back to overwriting the file in that case (#176).
+    /// Note: the object is re-serialized, so JSONC comments in the existing
+    /// file are not carried into the rewritten output (the pre-write backup
+    /// keeps the original).
+    nonisolated static func mergedOpenCodeJSON(existing: Data?, quotioProvider: [String: Any]) throws -> Data {
+        var object: [String: Any] = [:]
+        if let existing {
+            object = try parseOpenCodeJSONObject(existing)
+        }
+        if object["$schema"] == nil {
+            object["$schema"] = "https://opencode.ai/config.json"
+        }
+        var providers = object["provider"] as? [String: Any] ?? [:]
+        providers["quotio"] = quotioProvider
+        object["provider"] = providers
+        return try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
+    }
+
+    /// Removes only the Quotio-managed provider entry from opencode.json
+    /// content, preserving all other fields. Returns nil when there is nothing
+    /// to remove so callers can leave the file untouched. Throws when
+    /// `existing` cannot be parsed even with the JSONC pre-pass.
+    nonisolated static func openCodeJSONRemovingQuotioProvider(existing: Data) throws -> Data? {
+        var object = try parseOpenCodeJSONObject(existing)
+        guard var providers = object["provider"] as? [String: Any], providers["quotio"] != nil else {
+            return nil
+        }
+        providers.removeValue(forKey: "quotio")
+        if providers.isEmpty {
+            object.removeValue(forKey: "provider")
+        } else {
+            object["provider"] = providers
+        }
+        return try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
+    }
+
+    /// Strips `//` and `/* */` comments and trailing commas from JSONC text.
+    /// String literals (including escapes) are left untouched, so values like
+    /// "https://opencode.ai/config.json" survive intact.
+    nonisolated static func strippingJSONCSyntax(from text: String) -> String {
+        let chars = Array(text)
+        var withoutComments: [Character] = []
+        var i = 0
+        var inString = false
+        while i < chars.count {
+            let c = chars[i]
+            if inString {
+                withoutComments.append(c)
+                if c == "\\", i + 1 < chars.count {
+                    withoutComments.append(chars[i + 1])
+                    i += 2
+                    continue
+                }
+                if c == "\"" { inString = false }
+                i += 1
+            } else if c == "\"" {
+                inString = true
+                withoutComments.append(c)
+                i += 1
+            } else if c == "/", i + 1 < chars.count, chars[i + 1] == "/" {
+                while i < chars.count, chars[i] != "\n" { i += 1 }
+            } else if c == "/", i + 1 < chars.count, chars[i + 1] == "*" {
+                i += 2
+                while i + 1 < chars.count, !(chars[i] == "*" && chars[i + 1] == "/") { i += 1 }
+                i = min(i + 2, chars.count)
+            } else {
+                withoutComments.append(c)
+                i += 1
+            }
+        }
+
+        // Second string-aware pass: drop commas whose next non-whitespace
+        // character closes an object or array (trailing commas).
+        var result: [Character] = []
+        i = 0
+        inString = false
+        while i < withoutComments.count {
+            let c = withoutComments[i]
+            if inString {
+                result.append(c)
+                if c == "\\", i + 1 < withoutComments.count {
+                    result.append(withoutComments[i + 1])
+                    i += 2
+                    continue
+                }
+                if c == "\"" { inString = false }
+                i += 1
+            } else if c == "\"" {
+                inString = true
+                result.append(c)
+                i += 1
+            } else if c == "," {
+                var j = i + 1
+                while j < withoutComments.count, withoutComments[j].isWhitespace { j += 1 }
+                if j < withoutComments.count, withoutComments[j] == "}" || withoutComments[j] == "]" {
+                    i += 1
+                } else {
+                    result.append(c)
+                    i += 1
+                }
+            } else {
+                result.append(c)
+                i += 1
+            }
+        }
+        return String(result)
+    }
+
     private func generateFactoryDroidConfig(config: AgentConfiguration, mode: ConfigurationMode, availableModels: [AvailableModel]) -> AgentConfigResult {
         let home = fileManager.homeDirectoryForCurrentUser.path
         let configDir = "\(home)/.factory"

--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -215,7 +215,7 @@ actor AgentConfigurationService {
         
         guard fileManager.fileExists(atPath: configPath),
               let data = fileManager.contents(atPath: configPath),
-              let json = try? Self.parseOpenCodeJSONObject(data) else {
+              let json = try? OpenCodeConfigEditor.parseObject(data) else {
             return nil
         }
 
@@ -754,9 +754,9 @@ actor AgentConfigurationService {
                 let data = try Data(contentsOf: URL(fileURLWithPath: configPath))
 
                 // Remove only the Quotio-managed provider entry, preserving
-                // every other user setting (#176). When there is nothing to
-                // remove, leave the file completely untouched.
-                guard let updatedData = try Self.openCodeJSONRemovingQuotioProvider(existing: data) else {
+                // every other user setting — comments included (#176). When
+                // there is nothing to remove, leave the file untouched.
+                guard let updatedData = try OpenCodeConfigEditor.removingProviders(existing: data, keys: ["quotio"]) else {
                     return .success(
                         type: .file,
                         mode: mode,
@@ -764,7 +764,7 @@ actor AgentConfigurationService {
                         authPath: nil,
                         shellConfig: nil,
                         rawConfigs: [],
-                        instructions: "No Quotio provider found in opencode.json. OpenCode already uses its default providers.",
+                        instructions: "agents.opencode.notConfigured".localizedStatic(),
                         modelsConfigured: 0
                     )
                 }
@@ -1216,14 +1216,24 @@ actor AgentConfigurationService {
 
             let jsonData: Data
             do {
-                jsonData = try Self.mergedOpenCodeJSON(existing: existingData, quotioProvider: quotioProvider)
+                jsonData = try OpenCodeConfigEditor.merging(
+                    existing: existingData,
+                    providers: ["quotio": quotioProvider]
+                )
             } catch {
                 if mode == .automatic && existingData != nil {
                     // Never fall back to overwriting a file we could not parse:
                     // that wipes user settings like `plugin` and other providers (#176).
-                    return .failure(error: "Could not parse existing opencode.json at \(configPath): \(error.localizedDescription). The file was left untouched — fix its syntax and try again, or use manual mode.")
+                    return .failure(error: String(
+                        format: "agents.opencode.parseFailed".localizedStatic(),
+                        configPath,
+                        error.localizedDescription
+                    ))
                 }
-                jsonData = try Self.mergedOpenCodeJSON(existing: nil, quotioProvider: quotioProvider)
+                jsonData = try OpenCodeConfigEditor.merging(
+                    existing: nil,
+                    providers: ["quotio": quotioProvider]
+                )
             }
             let jsonString = String(decoding: jsonData, as: UTF8.self)
 
@@ -1325,135 +1335,6 @@ actor AgentConfigurationService {
         }
 
         return modelConfig
-    }
-
-    // MARK: - OpenCode JSON(C) helpers
-
-    /// Parses opencode.json content into a JSON object. OpenCode configs are
-    /// JSONC (comments and trailing commas are allowed), so a strict parse is
-    /// attempted first and, on failure, the content is re-parsed after a
-    /// comment/trailing-comma stripping pre-pass. Throws when the content is
-    /// not a JSON object even after that pre-pass.
-    nonisolated static func parseOpenCodeJSONObject(_ data: Data) throws -> [String: Any] {
-        if let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] {
-            return object
-        }
-        let sanitized = strippingJSONCSyntax(from: String(decoding: data, as: UTF8.self))
-        guard let object = try JSONSerialization.jsonObject(with: Data(sanitized.utf8)) as? [String: Any] else {
-            throw CocoaError(.propertyListReadCorrupt)
-        }
-        return object
-    }
-
-    /// Merges the Quotio provider entry into existing opencode.json content,
-    /// preserving every other field (plugin, mcp, other providers, ...).
-    /// Throws when `existing` cannot be parsed even with the JSONC pre-pass —
-    /// callers must not fall back to overwriting the file in that case (#176).
-    /// Note: the object is re-serialized, so JSONC comments in the existing
-    /// file are not carried into the rewritten output (the pre-write backup
-    /// keeps the original).
-    nonisolated static func mergedOpenCodeJSON(existing: Data?, quotioProvider: [String: Any]) throws -> Data {
-        var object: [String: Any] = [:]
-        if let existing {
-            object = try parseOpenCodeJSONObject(existing)
-        }
-        if object["$schema"] == nil {
-            object["$schema"] = "https://opencode.ai/config.json"
-        }
-        var providers = object["provider"] as? [String: Any] ?? [:]
-        providers["quotio"] = quotioProvider
-        object["provider"] = providers
-        return try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
-    }
-
-    /// Removes only the Quotio-managed provider entry from opencode.json
-    /// content, preserving all other fields. Returns nil when there is nothing
-    /// to remove so callers can leave the file untouched. Throws when
-    /// `existing` cannot be parsed even with the JSONC pre-pass.
-    nonisolated static func openCodeJSONRemovingQuotioProvider(existing: Data) throws -> Data? {
-        var object = try parseOpenCodeJSONObject(existing)
-        guard var providers = object["provider"] as? [String: Any], providers["quotio"] != nil else {
-            return nil
-        }
-        providers.removeValue(forKey: "quotio")
-        if providers.isEmpty {
-            object.removeValue(forKey: "provider")
-        } else {
-            object["provider"] = providers
-        }
-        return try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
-    }
-
-    /// Strips `//` and `/* */` comments and trailing commas from JSONC text.
-    /// String literals (including escapes) are left untouched, so values like
-    /// "https://opencode.ai/config.json" survive intact.
-    nonisolated static func strippingJSONCSyntax(from text: String) -> String {
-        let chars = Array(text)
-        var withoutComments: [Character] = []
-        var i = 0
-        var inString = false
-        while i < chars.count {
-            let c = chars[i]
-            if inString {
-                withoutComments.append(c)
-                if c == "\\", i + 1 < chars.count {
-                    withoutComments.append(chars[i + 1])
-                    i += 2
-                    continue
-                }
-                if c == "\"" { inString = false }
-                i += 1
-            } else if c == "\"" {
-                inString = true
-                withoutComments.append(c)
-                i += 1
-            } else if c == "/", i + 1 < chars.count, chars[i + 1] == "/" {
-                while i < chars.count, chars[i] != "\n" { i += 1 }
-            } else if c == "/", i + 1 < chars.count, chars[i + 1] == "*" {
-                i += 2
-                while i + 1 < chars.count, !(chars[i] == "*" && chars[i + 1] == "/") { i += 1 }
-                i = min(i + 2, chars.count)
-            } else {
-                withoutComments.append(c)
-                i += 1
-            }
-        }
-
-        // Second string-aware pass: drop commas whose next non-whitespace
-        // character closes an object or array (trailing commas).
-        var result: [Character] = []
-        i = 0
-        inString = false
-        while i < withoutComments.count {
-            let c = withoutComments[i]
-            if inString {
-                result.append(c)
-                if c == "\\", i + 1 < withoutComments.count {
-                    result.append(withoutComments[i + 1])
-                    i += 2
-                    continue
-                }
-                if c == "\"" { inString = false }
-                i += 1
-            } else if c == "\"" {
-                inString = true
-                result.append(c)
-                i += 1
-            } else if c == "," {
-                var j = i + 1
-                while j < withoutComments.count, withoutComments[j].isWhitespace { j += 1 }
-                if j < withoutComments.count, withoutComments[j] == "}" || withoutComments[j] == "]" {
-                    i += 1
-                } else {
-                    result.append(c)
-                    i += 1
-                }
-            } else {
-                result.append(c)
-                i += 1
-            }
-        }
-        return String(result)
     }
 
     private func generateFactoryDroidConfig(config: AgentConfiguration, mode: ConfigurationMode, availableModels: [AvailableModel]) -> AgentConfigResult {

--- a/Quotio/Services/OpenCodeConfigEditor.swift
+++ b/Quotio/Services/OpenCodeConfigEditor.swift
@@ -1,0 +1,762 @@
+import Foundation
+
+/// Reasons an opencode.json document is refused. Every case means "do not
+/// write": the caller must leave the user's file exactly as it was (#176).
+nonisolated enum OpenCodeConfigError: LocalizedError, Equatable {
+    /// The file is not decodable as UTF-8 text.
+    case notUTF8
+    /// A `/* … */` comment is never closed.
+    case unterminatedBlockComment
+    /// A string literal is never closed.
+    case unterminatedString
+    /// The document is not well-formed JSONC at the given 1-based line/column.
+    case invalidSyntax(line: Int, column: Int)
+    /// The top level of the document is not a JSON object.
+    case rootNotObject
+    /// A key we need to address unambiguously occurs more than once.
+    case duplicateKey(String)
+    /// `provider` exists but is not a JSON object, so it cannot be merged into.
+    case providerNotObject
+    /// The spliced document did not reparse into the expected value.
+    case verificationFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .notUTF8:
+            return "agents.opencode.parseError.notUTF8".localizedStatic()
+        case .unterminatedBlockComment:
+            return "agents.opencode.parseError.unterminatedComment".localizedStatic()
+        case .unterminatedString:
+            return "agents.opencode.parseError.unterminatedString".localizedStatic()
+        case let .invalidSyntax(line, column):
+            return String(
+                format: "agents.opencode.parseError.syntax".localizedStatic(),
+                String(line),
+                String(column)
+            )
+        case .rootNotObject:
+            return "agents.opencode.parseError.notObject".localizedStatic()
+        case let .duplicateKey(key):
+            return String(format: "agents.opencode.parseError.duplicateKey".localizedStatic(), key)
+        case .providerNotObject:
+            return "agents.opencode.parseError.providerNotObject".localizedStatic()
+        case .verificationFailed:
+            return "agents.opencode.parseError.verification".localizedStatic()
+        }
+    }
+}
+
+/// Field-scoped, comment-preserving editor for opencode.json.
+///
+/// OpenCode reads its config as JSONC (comments and trailing commas allowed).
+/// Issue #176 requires that automatic configuration only touch the Quotio-owned
+/// entries under `provider`; everything else — `plugin`, `mcp`, other providers,
+/// key order, indentation and comments — must survive verbatim. So instead of
+/// reparsing and reserializing the whole document, this editor locates the exact
+/// character range of the managed member in the original text and splices it.
+///
+/// Every operation is fail-closed: if the document cannot be parsed, is
+/// ambiguous, or the spliced result does not reparse into the value we intended,
+/// the operation throws and the caller leaves the file untouched.
+nonisolated enum OpenCodeConfigEditor {
+
+    static let schemaURL = "https://opencode.ai/config.json"
+
+    // MARK: - Public API
+
+    /// Inserts or replaces the given provider entries under `provider`,
+    /// preserving all other content of `existing` byte for byte.
+    ///
+    /// `$schema` is added only when creating a brand-new document; an existing
+    /// file that does not declare it is left as the user wrote it.
+    /// - Parameter existing: current file contents, or nil/empty for a new file.
+    /// - Returns: the full new file contents.
+    static func merging(existing: Data?, providers: [String: Any]) throws -> Data {
+        if providers.isEmpty, let existing, !existing.isEmpty {
+            return existing
+        }
+        guard let existing, !existing.isEmpty else {
+            return try freshDocument(providers: providers)
+        }
+        let (bom, text) = try decoded(existing)
+        guard text.contains(where: { !$0.isWhitespace }) else {
+            return try freshDocument(providers: providers)
+        }
+
+        let scalars = Array(text.unicodeScalars)
+        let root = try parseDocument(scalars)
+
+        var expected = try parsedObject(text)
+        var expectedProviders = expected["provider"] as? [String: Any] ?? [:]
+        for (key, value) in providers {
+            expectedProviders[key] = value
+        }
+        expected["provider"] = expectedProviders
+
+        var edits: [Edit] = []
+        let unit = indentUnit(scalars, root: root)
+
+        if let providerMember = try uniqueMember(named: "provider", in: root, scalars: scalars) {
+            guard case let .object(providerObject) = providerMember.value else {
+                throw OpenCodeConfigError.providerNotObject
+            }
+            let memberIndent = lineIndent(scalars, before: providerMember.start)
+            let entryIndent = memberIndent + unit
+            var newEntries: [String] = []
+            for key in providers.keys.sorted() {
+                let value = providers[key]!
+                if let existingEntry = try uniqueMember(named: key, in: providerObject, scalars: scalars) {
+                    // Replace only the value: the key token, the comments around
+                    // it and every sibling member stay exactly as the user wrote
+                    // them.
+                    let valueIndent = lineIndent(scalars, before: existingEntry.start)
+                    edits.append(Edit(
+                        range: existingEntry.value.range,
+                        replacement: rendered(value, indent: valueIndent)
+                    ))
+                } else {
+                    newEntries.append(memberText(key: key, value: value, indent: entryIndent))
+                }
+            }
+            if !newEntries.isEmpty {
+                edits.append(contentsOf: insertion(
+                    of: newEntries.joined(separator: ",\n" + entryIndent),
+                    into: providerObject,
+                    scalars: scalars,
+                    indent: entryIndent,
+                    closeIndent: memberIndent
+                ))
+            }
+        } else {
+            let rootIndent = root.members.first.map { lineIndent(scalars, before: $0.start) } ?? unit
+            let entryIndent = rootIndent + unit
+            let entries = providers.keys.sorted().map {
+                memberText(key: $0, value: providers[$0]!, indent: entryIndent)
+            }
+            let body = "{\n" + entryIndent
+                + entries.joined(separator: ",\n" + entryIndent)
+                + "\n" + rootIndent + "}"
+            edits.append(contentsOf: insertion(
+                of: "\"provider\": " + body,
+                into: root,
+                scalars: scalars,
+                indent: rootIndent,
+                closeIndent: ""
+            ))
+        }
+
+        return try applyVerified(edits, to: scalars, bom: bom, expecting: expected)
+    }
+
+    /// Removes the given provider entries, preserving all other content.
+    ///
+    /// - Returns: the new file contents, or nil when none of `keys` is present
+    ///   so the caller can leave the file completely untouched.
+    static func removingProviders(existing: Data, keys: [String]) throws -> Data? {
+        guard !existing.isEmpty else { return nil }
+        let (bom, text) = try decoded(existing)
+        let scalars = Array(text.unicodeScalars)
+        let root = try parseDocument(scalars)
+
+        guard let providerMember = try uniqueMember(named: "provider", in: root, scalars: scalars),
+              case let .object(providerObject) = providerMember.value else {
+            // No `provider` object at all (or it is not an object): nothing that
+            // belongs to Quotio can live there, so leave the file alone.
+            return nil
+        }
+
+        var present: [Member] = []
+        for key in keys.sorted() {
+            if let member = try uniqueMember(named: key, in: providerObject, scalars: scalars) {
+                present.append(member)
+            }
+        }
+        guard !present.isEmpty else { return nil }
+
+        var expected = try parsedObject(text)
+        var expectedProviders = expected["provider"] as? [String: Any] ?? [:]
+        for key in keys { expectedProviders.removeValue(forKey: key) }
+        if expectedProviders.isEmpty {
+            expected.removeValue(forKey: "provider")
+        } else {
+            expected["provider"] = expectedProviders
+        }
+
+        let edits: [Edit]
+        if present.count == providerObject.members.count {
+            // Every remaining provider is ours: drop the whole `provider` member
+            // rather than leaving an empty object behind.
+            edits = [Edit(range: deletionRange(of: providerMember, scalars: scalars), replacement: "")]
+        } else {
+            edits = present.map {
+                Edit(range: deletionRange(of: $0, scalars: scalars), replacement: "")
+            }
+        }
+
+        return try applyVerified(edits, to: scalars, bom: bom, expecting: expected)
+    }
+
+    /// Parses opencode.json content into a JSON object.
+    ///
+    /// A strict `JSONSerialization` parse is attempted first; on failure the
+    /// content is reparsed after a JSONC pre-pass that removes comments and
+    /// trailing commas. The pre-pass never invents validity: it throws on
+    /// unterminated comments/strings and replaces each removed comment with a
+    /// space so adjacent tokens cannot fuse into a new, valid token.
+    static func parseObject(_ data: Data) throws -> [String: Any] {
+        if let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] {
+            return object
+        }
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw OpenCodeConfigError.notUTF8
+        }
+        return try parsedObject(text)
+    }
+
+    /// Removes `//` and `/* */` comments and trailing commas from JSONC text.
+    ///
+    /// String literals (including escapes) are left untouched, so values such as
+    /// `"https://opencode.ai/config.json"` survive intact. Each removed comment
+    /// is replaced by a single space so that removing it can never join two
+    /// tokens into one — `1/* x */2` becomes `1 2` (invalid), never `12`.
+    /// Throws on unterminated block comments and unterminated strings instead of
+    /// silently discarding the rest of the input.
+    static func strippingJSONCSyntax(from text: String) throws -> String {
+        let s = Array(text.unicodeScalars)
+        var withoutComments: [Unicode.Scalar] = []
+        withoutComments.reserveCapacity(s.count)
+        var i = 0
+        var inString = false
+        while i < s.count {
+            let c = s[i]
+            if inString {
+                withoutComments.append(c)
+                if c == "\\" {
+                    guard i + 1 < s.count else { throw OpenCodeConfigError.unterminatedString }
+                    withoutComments.append(s[i + 1])
+                    i += 2
+                    continue
+                }
+                if c == "\"" { inString = false }
+                i += 1
+            } else if c == "\"" {
+                inString = true
+                withoutComments.append(c)
+                i += 1
+            } else if c == "/", i + 1 < s.count, s[i + 1] == "/" {
+                while i < s.count, s[i] != "\n", s[i] != "\r" { i += 1 }
+                withoutComments.append(" ")
+            } else if c == "/", i + 1 < s.count, s[i + 1] == "*" {
+                var j = i + 2
+                while j + 1 < s.count, !(s[j] == "*" && s[j + 1] == "/") { j += 1 }
+                guard j + 1 < s.count else { throw OpenCodeConfigError.unterminatedBlockComment }
+                i = j + 2
+                withoutComments.append(" ")
+            } else {
+                withoutComments.append(c)
+                i += 1
+            }
+        }
+        guard !inString else { throw OpenCodeConfigError.unterminatedString }
+
+        // Second string-aware pass: drop commas whose next non-whitespace
+        // character closes an object or array (trailing commas).
+        var result: [Unicode.Scalar] = []
+        result.reserveCapacity(withoutComments.count)
+        i = 0
+        inString = false
+        while i < withoutComments.count {
+            let c = withoutComments[i]
+            if inString {
+                result.append(c)
+                if c == "\\", i + 1 < withoutComments.count {
+                    result.append(withoutComments[i + 1])
+                    i += 2
+                    continue
+                }
+                if c == "\"" { inString = false }
+                i += 1
+            } else if c == "\"" {
+                inString = true
+                result.append(c)
+                i += 1
+            } else if c == "," {
+                var j = i + 1
+                while j < withoutComments.count, isWhitespace(withoutComments[j]) { j += 1 }
+                if j < withoutComments.count, withoutComments[j] == "}" || withoutComments[j] == "]" {
+                    i += 1
+                } else {
+                    result.append(c)
+                    i += 1
+                }
+            } else {
+                result.append(c)
+                i += 1
+            }
+        }
+        return String(String.UnicodeScalarView(result))
+    }
+
+    // MARK: - Document model
+
+    struct Member {
+        let key: String
+        /// Index of the opening quote of the key token.
+        let start: Int
+        let value: Node
+    }
+
+    struct ObjectSpan {
+        let range: Range<Int>
+        let openBrace: Int
+        let closeBrace: Int
+        let members: [Member]
+        /// Index of a trailing comma after the last member, when present.
+        let trailingComma: Int?
+    }
+
+    indirect enum Node {
+        case object(ObjectSpan)
+        case other(Range<Int>)
+
+        var range: Range<Int> {
+            switch self {
+            case let .object(span): return span.range
+            case let .other(range): return range
+            }
+        }
+    }
+
+    // MARK: - Splicing
+
+    private struct Edit {
+        let range: Range<Int>
+        let replacement: String
+    }
+
+    /// Decodes file contents as UTF-8. `String(data:encoding:)` swallows a
+    /// leading byte order mark, so it is returned separately and restored on
+    /// write — the file must come back byte-identical outside `provider`.
+    private static func decoded(_ data: Data) throws -> (bom: String, text: String) {
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw OpenCodeConfigError.notUTF8
+        }
+        let hasBOM = data.count >= 3 && data[data.startIndex] == 0xEF
+            && data[data.index(data.startIndex, offsetBy: 1)] == 0xBB
+            && data[data.index(data.startIndex, offsetBy: 2)] == 0xBF
+        return (hasBOM && !text.hasPrefix("\u{FEFF}") ? "\u{FEFF}" : "", text)
+    }
+
+    private static func applyVerified(
+        _ edits: [Edit],
+        to scalars: [Unicode.Scalar],
+        bom: String,
+        expecting expected: [String: Any]
+    ) throws -> Data {
+        // Match the document's line endings. Inserted text is generated by this
+        // type and JSON-escapes any newline inside a value, so no user data can
+        // be rewritten by this substitution.
+        let usesCRLF = scalars.indices.contains { $0 + 1 < scalars.count && scalars[$0] == "\r" && scalars[$0 + 1] == "\n" }
+
+        var output = scalars
+        var limit = scalars.count
+        for edit in edits.sorted(by: { $0.range.lowerBound > $1.range.lowerBound }) {
+            guard edit.range.upperBound <= limit else { throw OpenCodeConfigError.verificationFailed }
+            limit = edit.range.lowerBound
+            let replacement = usesCRLF
+                ? edit.replacement.replacingOccurrences(of: "\n", with: "\r\n")
+                : edit.replacement
+            output.replaceSubrange(edit.range, with: Array(replacement.unicodeScalars))
+        }
+        let text = String(String.UnicodeScalarView(output))
+
+        // Fail closed: only hand back content that reparses into exactly the
+        // value we intended. Anything else means the splice was wrong and the
+        // user's file must not be overwritten.
+        let actual = try parsedObject(text)
+        guard NSDictionary(dictionary: actual).isEqual(to: expected) else {
+            throw OpenCodeConfigError.verificationFailed
+        }
+        return Data((bom + text).utf8)
+    }
+
+    private static func insertion(
+        of memberText: String,
+        into object: ObjectSpan,
+        scalars: [Unicode.Scalar],
+        indent: String,
+        closeIndent: String
+    ) -> [Edit] {
+        guard let last = object.members.last else {
+            let interior = (object.openBrace + 1)..<object.closeBrace
+            let interiorIsBlank = interior.allSatisfy { isWhitespace(scalars[$0]) }
+            if interiorIsBlank {
+                return [Edit(
+                    range: interior,
+                    replacement: "\n" + indent + memberText + "\n" + closeIndent
+                )]
+            }
+            return [Edit(
+                range: (object.openBrace + 1)..<(object.openBrace + 1),
+                replacement: "\n" + indent + memberText
+            )]
+        }
+
+        let anchor = object.trailingComma.map { $0 + 1 } ?? last.value.range.upperBound
+        let needsComma = object.trailingComma == nil
+
+        // Step over a same-line `// …` comment so the new member starts on its
+        // own line instead of being swallowed by that comment.
+        var cursor = anchor
+        while cursor < scalars.count, scalars[cursor] == " " || scalars[cursor] == "\t" { cursor += 1 }
+        let hasTrailingLineComment = cursor + 1 < scalars.count
+            && scalars[cursor] == "/" && scalars[cursor + 1] == "/"
+        if hasTrailingLineComment {
+            while cursor < scalars.count, scalars[cursor] != "\n", scalars[cursor] != "\r" { cursor += 1 }
+        } else {
+            cursor = anchor
+        }
+
+        let member = "\n" + indent + memberText
+        guard hasTrailingLineComment else {
+            return [Edit(range: anchor..<anchor, replacement: (needsComma ? "," : "") + member)]
+        }
+        // The separating comma goes directly after the last value so it can
+        // never land inside the trailing comment; the member goes after it.
+        var edits: [Edit] = []
+        if needsComma {
+            edits.append(Edit(range: anchor..<anchor, replacement: ","))
+        }
+        edits.append(Edit(range: cursor..<cursor, replacement: member))
+        return edits
+    }
+
+    /// Character range to delete so that `member` disappears together with one
+    /// adjacent comma and, when it occupied a line of its own, that line.
+    private static func deletionRange(
+        of member: Member,
+        scalars: [Unicode.Scalar]
+    ) -> Range<Int> {
+        var start = member.start
+        var end = member.value.range.upperBound
+
+        var forward = end
+        while forward < scalars.count, isWhitespace(scalars[forward]) { forward += 1 }
+        if forward < scalars.count, scalars[forward] == "," {
+            end = forward + 1
+        } else {
+            var back = start - 1
+            while back >= 0, isWhitespace(scalars[back]) { back -= 1 }
+            if back >= 0, scalars[back] == "," {
+                start = back
+            }
+        }
+
+        // Swallow the surrounding blank line, but only horizontal whitespace —
+        // never a comment, which may belong to the user.
+        var lineStart = start
+        while lineStart > 0, scalars[lineStart - 1] == " " || scalars[lineStart - 1] == "\t" { lineStart -= 1 }
+        var lineEnd = end
+        while lineEnd < scalars.count, scalars[lineEnd] == " " || scalars[lineEnd] == "\t" { lineEnd += 1 }
+        let startsLine = lineStart == 0 || scalars[lineStart - 1] == "\n" || scalars[lineStart - 1] == "\r"
+        if startsLine, lineEnd < scalars.count {
+            if scalars[lineEnd] == "\r", lineEnd + 1 < scalars.count, scalars[lineEnd + 1] == "\n" {
+                return lineStart..<(lineEnd + 2)
+            }
+            if scalars[lineEnd] == "\n" || scalars[lineEnd] == "\r" {
+                return lineStart..<(lineEnd + 1)
+            }
+        }
+        return start..<end
+    }
+
+    // MARK: - Rendering
+
+    private static func freshDocument(providers: [String: Any]) throws -> Data {
+        var object: [String: Any] = ["$schema": schemaURL]
+        var entries: [String: Any] = [:]
+        for (key, value) in providers { entries[key] = value }
+        object["provider"] = entries
+        return try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        )
+    }
+
+    private static func memberText(key: String, value: Any, indent: String) -> String {
+        jsonString(key) + ": " + rendered(value, indent: indent)
+    }
+
+    /// Serializes `value` and re-indents its continuation lines to `indent`.
+    private static func rendered(_ value: Any, indent: String) -> String {
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: value,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        ) else {
+            return "null"
+        }
+        let text = String(decoding: data, as: UTF8.self)
+        return text
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .enumerated()
+            .map { $0.offset == 0 ? String($0.element) : indent + $0.element }
+            .joined(separator: "\n")
+    }
+
+    private static func jsonString(_ value: String) -> String {
+        var out = "\""
+        for scalar in value.unicodeScalars {
+            switch scalar {
+            case "\"": out += "\\\""
+            case "\\": out += "\\\\"
+            case "\n": out += "\\n"
+            case "\r": out += "\\r"
+            case "\t": out += "\\t"
+            default:
+                if scalar.value < 0x20 {
+                    out += String(format: "\\u%04x", scalar.value)
+                } else {
+                    out.unicodeScalars.append(scalar)
+                }
+            }
+        }
+        return out + "\""
+    }
+
+    // MARK: - Layout helpers
+
+    /// Leading horizontal whitespace of the line `index` sits on, or "" when the
+    /// member does not start its line.
+    private static func lineIndent(_ scalars: [Unicode.Scalar], before index: Int) -> String {
+        var i = index
+        while i > 0, scalars[i - 1] == " " || scalars[i - 1] == "\t" { i -= 1 }
+        guard i == 0 || scalars[i - 1] == "\n" || scalars[i - 1] == "\r" else { return "" }
+        return String(String.UnicodeScalarView(scalars[i..<index]))
+    }
+
+    /// Indentation step used by the document, defaulting to two spaces.
+    private static func indentUnit(_ scalars: [Unicode.Scalar], root: ObjectSpan) -> String {
+        for member in root.members {
+            let indent = lineIndent(scalars, before: member.start)
+            if !indent.isEmpty { return indent }
+        }
+        return "  "
+    }
+
+    // MARK: - Parsing
+
+    private static func parsedObject(_ text: String) throws -> [String: Any] {
+        let sanitized = try strippingJSONCSyntax(from: text)
+        guard let object = try JSONSerialization.jsonObject(with: Data(sanitized.utf8)) as? [String: Any] else {
+            throw OpenCodeConfigError.rootNotObject
+        }
+        return object
+    }
+
+    private static func uniqueMember(
+        named name: String,
+        in object: ObjectSpan,
+        scalars: [Unicode.Scalar]
+    ) throws -> Member? {
+        let matches = object.members.filter { $0.key == name }
+        guard matches.count <= 1 else { throw OpenCodeConfigError.duplicateKey(name) }
+        return matches.first
+    }
+
+    private static func isWhitespace(_ scalar: Unicode.Scalar) -> Bool {
+        scalar == " " || scalar == "\t" || scalar == "\n" || scalar == "\r"
+    }
+
+    /// Parses the whole document and returns the root object span. Throws unless
+    /// the document is a single well-formed JSONC object optionally surrounded
+    /// by whitespace and comments.
+    static func parseDocument(_ scalars: [Unicode.Scalar]) throws -> ObjectSpan {
+        var parser = Parser(scalars: scalars)
+        // A UTF-8 BOM is preserved in the output but ignored while parsing.
+        if parser.index < scalars.count, scalars[parser.index] == "\u{FEFF}" { parser.index += 1 }
+        let node = try parser.parseValue()
+        try parser.skipTrivia()
+        guard parser.index == scalars.count else { throw parser.syntaxError() }
+        guard case let .object(span) = node else { throw OpenCodeConfigError.rootNotObject }
+        return span
+    }
+
+    private struct Parser {
+        let scalars: [Unicode.Scalar]
+        var index = 0
+
+        func syntaxError() -> OpenCodeConfigError {
+            var line = 1
+            var column = 1
+            var i = 0
+            while i < index, i < scalars.count {
+                if scalars[i] == "\n" {
+                    line += 1
+                    column = 1
+                } else {
+                    column += 1
+                }
+                i += 1
+            }
+            return .invalidSyntax(line: line, column: column)
+        }
+
+        mutating func skipTrivia() throws {
+            while index < scalars.count {
+                let c = scalars[index]
+                if isWhitespace(c) {
+                    index += 1
+                    continue
+                }
+                if c == "/", index + 1 < scalars.count {
+                    if scalars[index + 1] == "/" {
+                        index += 2
+                        while index < scalars.count, scalars[index] != "\n", scalars[index] != "\r" {
+                            index += 1
+                        }
+                        continue
+                    }
+                    if scalars[index + 1] == "*" {
+                        var j = index + 2
+                        while j + 1 < scalars.count, !(scalars[j] == "*" && scalars[j + 1] == "/") { j += 1 }
+                        guard j + 1 < scalars.count else { throw OpenCodeConfigError.unterminatedBlockComment }
+                        index = j + 2
+                        continue
+                    }
+                }
+                return
+            }
+        }
+
+        mutating func expect(_ scalar: Unicode.Scalar) throws {
+            guard index < scalars.count, scalars[index] == scalar else { throw syntaxError() }
+            index += 1
+        }
+
+        mutating func parseValue() throws -> Node {
+            try skipTrivia()
+            guard index < scalars.count else { throw syntaxError() }
+            let start = index
+            switch scalars[index] {
+            case "{":
+                return .object(try parseObjectSpan())
+            case "[":
+                try parseArray()
+                return .other(start..<index)
+            case "\"":
+                _ = try parseString()
+                return .other(start..<index)
+            default:
+                try parseLiteral()
+                return .other(start..<index)
+            }
+        }
+
+        mutating func parseObjectSpan() throws -> ObjectSpan {
+            let start = index
+            try expect("{")
+            var members: [Member] = []
+            var trailingComma: Int?
+            while true {
+                try skipTrivia()
+                guard index < scalars.count else { throw syntaxError() }
+                if scalars[index] == "}" {
+                    let close = index
+                    index += 1
+                    return ObjectSpan(
+                        range: start..<index,
+                        openBrace: start,
+                        closeBrace: close,
+                        members: members,
+                        trailingComma: trailingComma
+                    )
+                }
+                guard scalars[index] == "\"" else { throw syntaxError() }
+                let keyStart = index
+                let key = try parseString()
+                try skipTrivia()
+                try expect(":")
+                let value = try parseValue()
+                members.append(Member(key: key, start: keyStart, value: value))
+                trailingComma = nil
+                try skipTrivia()
+                guard index < scalars.count else { throw syntaxError() }
+                if scalars[index] == "," {
+                    trailingComma = index
+                    index += 1
+                    continue
+                }
+                guard scalars[index] == "}" else { throw syntaxError() }
+            }
+        }
+
+        mutating func parseArray() throws {
+            try expect("[")
+            while true {
+                try skipTrivia()
+                guard index < scalars.count else { throw syntaxError() }
+                if scalars[index] == "]" {
+                    index += 1
+                    return
+                }
+                _ = try parseValue()
+                try skipTrivia()
+                guard index < scalars.count else { throw syntaxError() }
+                if scalars[index] == "," {
+                    index += 1
+                    continue
+                }
+                guard scalars[index] == "]" else { throw syntaxError() }
+            }
+        }
+
+        @discardableResult
+        mutating func parseString() throws -> String {
+            try expect("\"")
+            var out = String.UnicodeScalarView()
+            while index < scalars.count {
+                let c = scalars[index]
+                if c == "\\" {
+                    guard index + 1 < scalars.count else { throw OpenCodeConfigError.unterminatedString }
+                    out.append(c)
+                    out.append(scalars[index + 1])
+                    index += 2
+                    continue
+                }
+                if c == "\"" {
+                    index += 1
+                    return unescaped(String(out))
+                }
+                if c == "\n" || c == "\r" { throw OpenCodeConfigError.unterminatedString }
+                out.append(c)
+                index += 1
+            }
+            throw OpenCodeConfigError.unterminatedString
+        }
+
+        /// Decodes the escape sequences of an already-delimited JSON string body.
+        /// Only used for member keys, which we compare against ASCII literals.
+        private func unescaped(_ raw: String) -> String {
+            guard raw.contains("\\") else { return raw }
+            let quoted = "\"\(raw)\""
+            if let data = quoted.data(using: .utf8),
+               let value = try? JSONSerialization.jsonObject(
+                   with: data,
+                   options: [.fragmentsAllowed]
+               ) as? String {
+                return value
+            }
+            return raw
+        }
+
+        mutating func parseLiteral() throws {
+            let start = index
+            while index < scalars.count {
+                let c = scalars[index]
+                if isWhitespace(c) || c == "," || c == "}" || c == "]" || c == "/" { break }
+                index += 1
+            }
+            guard index > start else { throw syntaxError() }
+        }
+    }
+}

--- a/QuotioTests/OpenCodeConfigTests.swift
+++ b/QuotioTests/OpenCodeConfigTests.swift
@@ -1,0 +1,243 @@
+import XCTest
+@testable import Quotio
+
+final class OpenCodeConfigTests: XCTestCase {
+
+    private let quotioProvider: [String: Any] = [
+        "models": ["claude-sonnet-4-5": ["name": "Claude Sonnet 4 5"]],
+        "name": "Quotio",
+        "npm": "@ai-sdk/anthropic",
+        "options": [
+            "apiKey": "quotio-local-test",
+            "baseURL": "http://127.0.0.1:8317/v1",
+            "litellmProxy": true
+        ]
+    ]
+
+    private func jsonObject(_ data: Data) throws -> [String: Any] {
+        try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    // MARK: - mergedOpenCodeJSON
+
+    func testMergePreservesUserFieldsAndSetsQuotioProvider() throws {
+        let existing = try JSONSerialization.data(withJSONObject: [
+            "$schema": "https://opencode.ai/config.json",
+            "plugin": [
+                "opencode-antigravity-auth@1.2.8",
+                "opencode-openai-codex-auth"
+            ],
+            "theme": "dark",
+            "provider": [
+                "myrouter": [
+                    "npm": "@ai-sdk/openai-compatible",
+                    "options": ["baseURL": "https://example.com/v1"]
+                ]
+            ]
+        ])
+
+        let merged = try AgentConfigurationService.mergedOpenCodeJSON(
+            existing: existing,
+            quotioProvider: quotioProvider
+        )
+        let object = try jsonObject(merged)
+
+        XCTAssertEqual(object["$schema"] as? String, "https://opencode.ai/config.json")
+        XCTAssertEqual(object["theme"] as? String, "dark")
+        XCTAssertEqual(object["plugin"] as? [String], [
+            "opencode-antigravity-auth@1.2.8",
+            "opencode-openai-codex-auth"
+        ])
+
+        let providers = try XCTUnwrap(object["provider"] as? [String: Any])
+        XCTAssertNotNil(providers["myrouter"], "Existing custom provider must survive the merge")
+        let quotio = try XCTUnwrap(providers["quotio"] as? [String: Any])
+        let options = try XCTUnwrap(quotio["options"] as? [String: Any])
+        XCTAssertEqual(options["apiKey"] as? String, "quotio-local-test")
+    }
+
+    func testMergeParsesJSONCWithCommentsAndTrailingCommas() throws {
+        let jsonc = """
+        {
+          // user plugins
+          "plugin": [
+            "opencode-antigravity-auth@1.2.8",
+            // "oh-my-opencode",
+            "opencode-openai-codex-auth",
+          ],
+          /* block comment */
+          "theme": "dark",
+        }
+        """
+
+        let merged = try AgentConfigurationService.mergedOpenCodeJSON(
+            existing: Data(jsonc.utf8),
+            quotioProvider: quotioProvider
+        )
+        let object = try jsonObject(merged)
+
+        XCTAssertEqual(object["plugin"] as? [String], [
+            "opencode-antigravity-auth@1.2.8",
+            "opencode-openai-codex-auth"
+        ])
+        XCTAssertEqual(object["theme"] as? String, "dark")
+        XCTAssertNotNil((object["provider"] as? [String: Any])?["quotio"])
+    }
+
+    func testMergeWithoutExistingFileProducesSchemaAndProviderOnly() throws {
+        let merged = try AgentConfigurationService.mergedOpenCodeJSON(
+            existing: nil,
+            quotioProvider: quotioProvider
+        )
+        let object = try jsonObject(merged)
+
+        XCTAssertEqual(object.count, 2)
+        XCTAssertEqual(object["$schema"] as? String, "https://opencode.ai/config.json")
+        XCTAssertNotNil((object["provider"] as? [String: Any])?["quotio"])
+    }
+
+    func testMergeThrowsOnUnparseableExistingContent() {
+        let corrupt = Data("{ definitely not json".utf8)
+        XCTAssertThrowsError(
+            try AgentConfigurationService.mergedOpenCodeJSON(
+                existing: corrupt,
+                quotioProvider: quotioProvider
+            )
+        )
+    }
+
+    func testMergeOverwritesStaleQuotioEntryOnly() throws {
+        let existing = try JSONSerialization.data(withJSONObject: [
+            "plugin": ["some-plugin"],
+            "provider": [
+                "quotio": ["options": ["apiKey": "stale-key"]],
+                "other": ["npm": "@ai-sdk/openai-compatible"]
+            ]
+        ])
+
+        let merged = try AgentConfigurationService.mergedOpenCodeJSON(
+            existing: existing,
+            quotioProvider: quotioProvider
+        )
+        let object = try jsonObject(merged)
+
+        XCTAssertEqual(object["plugin"] as? [String], ["some-plugin"])
+        let providers = try XCTUnwrap(object["provider"] as? [String: Any])
+        XCTAssertNotNil(providers["other"])
+        let quotio = try XCTUnwrap(providers["quotio"] as? [String: Any])
+        let options = try XCTUnwrap(quotio["options"] as? [String: Any])
+        XCTAssertEqual(options["apiKey"] as? String, "quotio-local-test")
+    }
+
+    // MARK: - openCodeJSONRemovingQuotioProvider
+
+    func testRemoveDeletesOnlyQuotioProvider() throws {
+        let existing = try JSONSerialization.data(withJSONObject: [
+            "plugin": ["opencode-antigravity-auth@1.2.8"],
+            "theme": "dark",
+            "provider": [
+                "quotio": ["name": "Quotio"],
+                "myrouter": ["npm": "@ai-sdk/openai-compatible"]
+            ]
+        ])
+
+        let updated = try XCTUnwrap(
+            AgentConfigurationService.openCodeJSONRemovingQuotioProvider(existing: existing)
+        )
+        let object = try jsonObject(updated)
+
+        XCTAssertEqual(object["plugin"] as? [String], ["opencode-antigravity-auth@1.2.8"])
+        XCTAssertEqual(object["theme"] as? String, "dark")
+        let providers = try XCTUnwrap(object["provider"] as? [String: Any])
+        XCTAssertNil(providers["quotio"])
+        XCTAssertNotNil(providers["myrouter"])
+    }
+
+    func testRemoveDropsEmptyProviderObject() throws {
+        let existing = try JSONSerialization.data(withJSONObject: [
+            "theme": "dark",
+            "provider": ["quotio": ["name": "Quotio"]]
+        ])
+
+        let updated = try XCTUnwrap(
+            AgentConfigurationService.openCodeJSONRemovingQuotioProvider(existing: existing)
+        )
+        let object = try jsonObject(updated)
+
+        XCTAssertEqual(object["theme"] as? String, "dark")
+        XCTAssertNil(object["provider"])
+    }
+
+    func testRemoveReturnsNilWhenNothingToRemove() throws {
+        let existing = try JSONSerialization.data(withJSONObject: [
+            "plugin": ["some-plugin"],
+            "provider": ["myrouter": ["npm": "@ai-sdk/openai-compatible"]]
+        ])
+
+        XCTAssertNil(
+            try AgentConfigurationService.openCodeJSONRemovingQuotioProvider(existing: existing)
+        )
+    }
+
+    func testRemoveParsesJSONCInput() throws {
+        let jsonc = """
+        {
+          "plugin": ["some-plugin"], // keep me
+          "provider": {
+            "quotio": { "name": "Quotio" },
+          },
+        }
+        """
+
+        let updated = try XCTUnwrap(
+            AgentConfigurationService.openCodeJSONRemovingQuotioProvider(existing: Data(jsonc.utf8))
+        )
+        let object = try jsonObject(updated)
+
+        XCTAssertEqual(object["plugin"] as? [String], ["some-plugin"])
+        XCTAssertNil(object["provider"])
+    }
+
+    func testRemoveThrowsOnUnparseableContent() {
+        let corrupt = Data("not json at all".utf8)
+        XCTAssertThrowsError(
+            try AgentConfigurationService.openCodeJSONRemovingQuotioProvider(existing: corrupt)
+        )
+    }
+
+    // MARK: - strippingJSONCSyntax
+
+    func testStrippingLeavesStringContentsUntouched() throws {
+        let jsonc = """
+        {
+          "$schema": "https://opencode.ai/config.json", // schema URL has //
+          "note": "a /* not a comment */ b",
+          "escaped": "quote \\" then // still in string",
+        }
+        """
+
+        let stripped = AgentConfigurationService.strippingJSONCSyntax(from: jsonc)
+        let object = try jsonObject(Data(stripped.utf8))
+
+        XCTAssertEqual(object["$schema"] as? String, "https://opencode.ai/config.json")
+        XCTAssertEqual(object["note"] as? String, "a /* not a comment */ b")
+        XCTAssertEqual(object["escaped"] as? String, "quote \" then // still in string")
+    }
+
+    func testStrippingHandlesNestedTrailingCommas() throws {
+        let jsonc = """
+        {
+          "a": [1, 2, 3,],
+          "b": { "c": [ { "d": 1, }, ], },
+        }
+        """
+
+        let stripped = AgentConfigurationService.strippingJSONCSyntax(from: jsonc)
+        let object = try jsonObject(Data(stripped.utf8))
+
+        XCTAssertEqual(object["a"] as? [Int], [1, 2, 3])
+        let b = try XCTUnwrap(object["b"] as? [String: Any])
+        let c = try XCTUnwrap(b["c"] as? [[String: Any]])
+        XCTAssertEqual(c.first?["d"] as? Int, 1)
+    }
+}

--- a/QuotioTests/OpenCodeConfigTests.swift
+++ b/QuotioTests/OpenCodeConfigTests.swift
@@ -18,210 +18,299 @@ final class OpenCodeConfigTests: XCTestCase {
         try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 
-    // MARK: - mergedOpenCodeJSON
-
-    func testMergePreservesUserFieldsAndSetsQuotioProvider() throws {
-        let existing = try JSONSerialization.data(withJSONObject: [
-            "$schema": "https://opencode.ai/config.json",
-            "plugin": [
-                "opencode-antigravity-auth@1.2.8",
-                "opencode-openai-codex-auth"
-            ],
-            "theme": "dark",
-            "provider": [
-                "myrouter": [
-                    "npm": "@ai-sdk/openai-compatible",
-                    "options": ["baseURL": "https://example.com/v1"]
-                ]
-            ]
-        ])
-
-        let merged = try AgentConfigurationService.mergedOpenCodeJSON(
-            existing: existing,
-            quotioProvider: quotioProvider
+    private func merged(_ source: String) throws -> String {
+        let data = try OpenCodeConfigEditor.merging(
+            existing: Data(source.utf8),
+            providers: ["quotio": quotioProvider]
         )
-        let object = try jsonObject(merged)
+        return String(decoding: data, as: UTF8.self)
+    }
 
-        XCTAssertEqual(object["$schema"] as? String, "https://opencode.ai/config.json")
-        XCTAssertEqual(object["theme"] as? String, "dark")
-        XCTAssertEqual(object["plugin"] as? [String], [
-            "opencode-antigravity-auth@1.2.8",
-            "opencode-openai-codex-auth"
-        ])
+    /// The reporter's config from #176: comments, a commented-out plugin line,
+    /// unrelated top-level keys, nested objects and arrays, another provider.
+    private let reporterConfig = """
+    {
+      "$schema": "https://opencode.ai/config.json",
+      // plugins are load-bearing, do not touch
+      "plugin": [
+        "opencode-antigravity-auth@1.2.8",
+        // "oh-my-opencode",
+        "opencode-openai-codex-auth"
+      ],
+      "theme": "opencode",
+      "keybinds": { "leader": "ctrl+x", "app_exit": "ctrl+c" },
+      "mcp": {
+        "local-tools": {
+          "type": "local",
+          "command": ["bun", "x", "my-mcp-server"],
+          "enabled": true
+        }
+      },
+      "provider": {
+        /* my own router */
+        "myrouter": {
+          "npm": "@ai-sdk/openai-compatible",
+          "options": { "baseURL": "https://example.com/v1" }
+        }
+      }
+    }
+    """
 
+    // MARK: - Round-trip fidelity (#176)
+
+    func testMergeThenRemoveRestoresTheOriginalByteForByte() throws {
+        let mergedText = try merged(reporterConfig)
+        let restored = try XCTUnwrap(
+            OpenCodeConfigEditor.removingProviders(existing: Data(mergedText.utf8), keys: ["quotio"])
+        )
+        XCTAssertEqual(String(decoding: restored, as: UTF8.self), reporterConfig)
+    }
+
+    func testMergeKeepsEverythingOutsideProviderQuotioVerbatim() throws {
+        let mergedText = try merged(reporterConfig)
+
+        // Everything before the `provider` object is untouched, including the
+        // commented-out plugin line the reporter lost.
+        let providerMarker = try XCTUnwrap(reporterConfig.range(of: "  \"provider\": {"))
+        XCTAssertTrue(
+            mergedText.hasPrefix(String(reporterConfig[..<providerMarker.lowerBound])),
+            "Content above provider must survive verbatim"
+        )
+        XCTAssertTrue(mergedText.contains("// \"oh-my-opencode\","))
+        XCTAssertTrue(mergedText.contains("// plugins are load-bearing, do not touch"))
+        XCTAssertTrue(mergedText.contains("/* my own router */"))
+        XCTAssertTrue(mergedText.contains("\"command\": [\"bun\", \"x\", \"my-mcp-server\"],"))
+        XCTAssertTrue(mergedText.contains("\"keybinds\": { \"leader\": \"ctrl+x\", \"app_exit\": \"ctrl+c\" },"))
+        XCTAssertTrue(mergedText.hasSuffix("}"))
+
+        let object = try jsonObject(Data(
+            OpenCodeConfigEditor.strippingJSONCSyntax(from: mergedText).utf8
+        ))
         let providers = try XCTUnwrap(object["provider"] as? [String: Any])
-        XCTAssertNotNil(providers["myrouter"], "Existing custom provider must survive the merge")
+        XCTAssertNotNil(providers["myrouter"])
         let quotio = try XCTUnwrap(providers["quotio"] as? [String: Any])
         let options = try XCTUnwrap(quotio["options"] as? [String: Any])
         XCTAssertEqual(options["apiKey"] as? String, "quotio-local-test")
     }
 
-    func testMergeParsesJSONCWithCommentsAndTrailingCommas() throws {
-        let jsonc = """
+    func testReconfiguringTwiceIsIdempotent() throws {
+        let once = try merged(reporterConfig)
+        XCTAssertEqual(try merged(once), once)
+    }
+
+    func testMergeDoesNotAddSchemaToAnExistingFileThatOmitsIt() throws {
+        let source = """
         {
-          // user plugins
-          "plugin": [
-            "opencode-antigravity-auth@1.2.8",
-            // "oh-my-opencode",
-            "opencode-openai-codex-auth",
-          ],
-          /* block comment */
-          "theme": "dark",
+          "theme": "system"
         }
         """
+        let mergedText = try merged(source)
+        XCTAssertFalse(mergedText.contains("$schema"))
+        XCTAssertTrue(mergedText.contains("\"theme\": \"system\","))
+    }
 
-        let merged = try AgentConfigurationService.mergedOpenCodeJSON(
-            existing: Data(jsonc.utf8),
-            quotioProvider: quotioProvider
-        )
-        let object = try jsonObject(merged)
+    func testMergeReplacesOnlyTheQuotioValueOnReconfigure() throws {
+        let source = """
+        {
+          "provider": {
+            // Quotio-managed, edited by the app
+            "quotio": { "options": { "apiKey": "stale" } },
+            "other": { "npm": "@ai-sdk/openai-compatible" }
+          }
+        }
+        """
+        let mergedText = try merged(source)
+        XCTAssertTrue(mergedText.contains("// Quotio-managed, edited by the app"))
+        XCTAssertTrue(mergedText.contains("\"other\": { \"npm\": \"@ai-sdk/openai-compatible\" }"))
+        XCTAssertFalse(mergedText.contains("stale"))
+        XCTAssertTrue(mergedText.contains("quotio-local-test"))
+    }
 
-        XCTAssertEqual(object["plugin"] as? [String], [
-            "opencode-antigravity-auth@1.2.8",
-            "opencode-openai-codex-auth"
-        ])
-        XCTAssertEqual(object["theme"] as? String, "dark")
+    func testMergeInsertsProviderWhenAbsent() throws {
+        let source = """
+        {
+          "theme": "system", // trailing comment on the last member
+          "plugin": ["a"]
+        }
+        """
+        let mergedText = try merged(source)
+        XCTAssertTrue(mergedText.contains("// trailing comment on the last member"))
+        let object = try jsonObject(Data(
+            OpenCodeConfigEditor.strippingJSONCSyntax(from: mergedText).utf8
+        ))
+        XCTAssertEqual(object["plugin"] as? [String], ["a"])
+        XCTAssertNotNil((object["provider"] as? [String: Any])?["quotio"])
+    }
+
+    func testMergeIntoEmptyProviderObject() throws {
+        let source = """
+        {
+          "provider": {}
+        }
+        """
+        let object = try jsonObject(Data(
+            OpenCodeConfigEditor.strippingJSONCSyntax(from: try merged(source)).utf8
+        ))
+        XCTAssertNotNil((object["provider"] as? [String: Any])?["quotio"])
+    }
+
+    func testMergeKeepsExistingTrailingCommaInsteadOfDoublingIt() throws {
+        let source = """
+        {
+          "provider": {
+            "other": { "npm": "x" },
+          },
+        }
+        """
+        let mergedText = try merged(source)
+        XCTAssertFalse(mergedText.contains(",,"))
+        let object = try jsonObject(Data(
+            OpenCodeConfigEditor.strippingJSONCSyntax(from: mergedText).utf8
+        ))
+        let providers = try XCTUnwrap(object["provider"] as? [String: Any])
+        XCTAssertNotNil(providers["other"])
+        XCTAssertNotNil(providers["quotio"])
+    }
+
+    func testMergePreservesCRLFAndByteOrderMark() throws {
+        let source = "\u{FEFF}{\r\n  // keep\r\n  \"theme\": \"system\"\r\n}"
+        let mergedText = try merged(source)
+        XCTAssertTrue(mergedText.hasPrefix("\u{FEFF}{\r\n  // keep\r\n"))
+        let object = try jsonObject(Data(
+            OpenCodeConfigEditor.strippingJSONCSyntax(from: mergedText).utf8
+        ))
+        XCTAssertEqual(object["theme"] as? String, "system")
         XCTAssertNotNil((object["provider"] as? [String: Any])?["quotio"])
     }
 
     func testMergeWithoutExistingFileProducesSchemaAndProviderOnly() throws {
-        let merged = try AgentConfigurationService.mergedOpenCodeJSON(
-            existing: nil,
-            quotioProvider: quotioProvider
+        let object = try jsonObject(
+            try OpenCodeConfigEditor.merging(existing: nil, providers: ["quotio": quotioProvider])
         )
-        let object = try jsonObject(merged)
-
         XCTAssertEqual(object.count, 2)
         XCTAssertEqual(object["$schema"] as? String, "https://opencode.ai/config.json")
         XCTAssertNotNil((object["provider"] as? [String: Any])?["quotio"])
     }
 
-    func testMergeThrowsOnUnparseableExistingContent() {
-        let corrupt = Data("{ definitely not json".utf8)
+    func testMergeTreatsWhitespaceOnlyFileAsNew() throws {
+        let object = try jsonObject(
+            try OpenCodeConfigEditor.merging(existing: Data("\n\n  ".utf8), providers: ["quotio": quotioProvider])
+        )
+        XCTAssertEqual(object["$schema"] as? String, "https://opencode.ai/config.json")
+    }
+
+    // MARK: - Refusals: the parser must never manufacture validity
+
+    private func assertMergeRefuses(
+        _ source: String,
+        _ expected: OpenCodeConfigError? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
         XCTAssertThrowsError(
-            try AgentConfigurationService.mergedOpenCodeJSON(
-                existing: corrupt,
-                quotioProvider: quotioProvider
-            )
-        )
-    }
-
-    func testMergeOverwritesStaleQuotioEntryOnly() throws {
-        let existing = try JSONSerialization.data(withJSONObject: [
-            "plugin": ["some-plugin"],
-            "provider": [
-                "quotio": ["options": ["apiKey": "stale-key"]],
-                "other": ["npm": "@ai-sdk/openai-compatible"]
-            ]
-        ])
-
-        let merged = try AgentConfigurationService.mergedOpenCodeJSON(
-            existing: existing,
-            quotioProvider: quotioProvider
-        )
-        let object = try jsonObject(merged)
-
-        XCTAssertEqual(object["plugin"] as? [String], ["some-plugin"])
-        let providers = try XCTUnwrap(object["provider"] as? [String: Any])
-        XCTAssertNotNil(providers["other"])
-        let quotio = try XCTUnwrap(providers["quotio"] as? [String: Any])
-        let options = try XCTUnwrap(quotio["options"] as? [String: Any])
-        XCTAssertEqual(options["apiKey"] as? String, "quotio-local-test")
-    }
-
-    // MARK: - openCodeJSONRemovingQuotioProvider
-
-    func testRemoveDeletesOnlyQuotioProvider() throws {
-        let existing = try JSONSerialization.data(withJSONObject: [
-            "plugin": ["opencode-antigravity-auth@1.2.8"],
-            "theme": "dark",
-            "provider": [
-                "quotio": ["name": "Quotio"],
-                "myrouter": ["npm": "@ai-sdk/openai-compatible"]
-            ]
-        ])
-
-        let updated = try XCTUnwrap(
-            AgentConfigurationService.openCodeJSONRemovingQuotioProvider(existing: existing)
-        )
-        let object = try jsonObject(updated)
-
-        XCTAssertEqual(object["plugin"] as? [String], ["opencode-antigravity-auth@1.2.8"])
-        XCTAssertEqual(object["theme"] as? String, "dark")
-        let providers = try XCTUnwrap(object["provider"] as? [String: Any])
-        XCTAssertNil(providers["quotio"])
-        XCTAssertNotNil(providers["myrouter"])
-    }
-
-    func testRemoveDropsEmptyProviderObject() throws {
-        let existing = try JSONSerialization.data(withJSONObject: [
-            "theme": "dark",
-            "provider": ["quotio": ["name": "Quotio"]]
-        ])
-
-        let updated = try XCTUnwrap(
-            AgentConfigurationService.openCodeJSONRemovingQuotioProvider(existing: existing)
-        )
-        let object = try jsonObject(updated)
-
-        XCTAssertEqual(object["theme"] as? String, "dark")
-        XCTAssertNil(object["provider"])
-    }
-
-    func testRemoveReturnsNilWhenNothingToRemove() throws {
-        let existing = try JSONSerialization.data(withJSONObject: [
-            "plugin": ["some-plugin"],
-            "provider": ["myrouter": ["npm": "@ai-sdk/openai-compatible"]]
-        ])
-
-        XCTAssertNil(
-            try AgentConfigurationService.openCodeJSONRemovingQuotioProvider(existing: existing)
-        )
-    }
-
-    func testRemoveParsesJSONCInput() throws {
-        let jsonc = """
-        {
-          "plugin": ["some-plugin"], // keep me
-          "provider": {
-            "quotio": { "name": "Quotio" },
-          },
+            try OpenCodeConfigEditor.merging(
+                existing: Data(source.utf8),
+                providers: ["quotio": quotioProvider]
+            ),
+            file: file,
+            line: line
+        ) { error in
+            if let expected {
+                XCTAssertEqual(error as? OpenCodeConfigError, expected, file: file, line: line)
+            }
         }
-        """
-
-        let updated = try XCTUnwrap(
-            AgentConfigurationService.openCodeJSONRemovingQuotioProvider(existing: Data(jsonc.utf8))
-        )
-        let object = try jsonObject(updated)
-
-        XCTAssertEqual(object["plugin"] as? [String], ["some-plugin"])
-        XCTAssertNil(object["provider"])
     }
 
-    func testRemoveThrowsOnUnparseableContent() {
-        let corrupt = Data("not json at all".utf8)
-        XCTAssertThrowsError(
-            try AgentConfigurationService.openCodeJSONRemovingQuotioProvider(existing: corrupt)
-        )
+    /// Reviewer's case 1: stripping a closed block comment must not fuse the
+    /// tokens on either side into a new, valid token.
+    func testBlockCommentRemovalPreservesTokenBoundary() throws {
+        let stripped = try OpenCodeConfigEditor.strippingJSONCSyntax(from: "[{\"value\": 1/* x */2}]")
+        XCTAssertEqual(stripped, "[{\"value\": 1 2}]")
+        XCTAssertThrowsError(try OpenCodeConfigEditor.parseObject(Data("{\"value\": 1/* x */2}".utf8)))
+        assertMergeRefuses("{\"value\": 1/* x */2}")
     }
 
-    // MARK: - strippingJSONCSyntax
-
-    func testStrippingLeavesStringContentsUntouched() throws {
-        let jsonc = """
+    /// Reviewer's case 2: a valid document followed by an unterminated block
+    /// comment must not be accepted by silently discarding the rest.
+    func testUnterminatedBlockCommentIsRejected() {
+        let source = """
         {
-          "$schema": "https://opencode.ai/config.json", // schema URL has //
+          "theme": "system"
+        }
+        /* oops, never closed
+        """
+        XCTAssertThrowsError(try OpenCodeConfigEditor.parseObject(Data(source.utf8))) { error in
+            XCTAssertEqual(error as? OpenCodeConfigError, .unterminatedBlockComment)
+        }
+        assertMergeRefuses(source, .unterminatedBlockComment)
+        assertMergeRefuses("{ /* never closed \"theme\": \"system\" }", .unterminatedBlockComment)
+    }
+
+    func testUnterminatedStringIsRejected() {
+        assertMergeRefuses("{\n  \"theme\": \"system\n}", .unterminatedString)
+        assertMergeRefuses("{\n  \"theme\": \"system", .unterminatedString)
+    }
+
+    /// JSONC has no nested block comments: the first `*/` closes, leaving stray
+    /// `*/` that must be reported instead of silently dropped.
+    func testNestedBlockCommentIsRejected() {
+        assertMergeRefuses("{ /* outer /* inner */ */ \"theme\": \"system\" }")
+    }
+
+    func testTrailingContentAfterRootIsRejected() {
+        assertMergeRefuses("{\"theme\": \"system\"} {\"theme\": \"other\"}")
+    }
+
+    func testRootThatIsNotAnObjectIsRejected() {
+        assertMergeRefuses("[{\"theme\": \"system\"}]", .rootNotObject)
+    }
+
+    func testDuplicateProviderKeyIsRejected() {
+        assertMergeRefuses(
+            "{\"provider\": {\"a\": {}}, \"provider\": {\"b\": {}}}",
+            .duplicateKey("provider")
+        )
+    }
+
+    func testNonObjectProviderIsRejected() {
+        assertMergeRefuses("{\"provider\": \"nope\"}", .providerNotObject)
+        assertMergeRefuses("{\"provider\": null}", .providerNotObject)
+    }
+
+    func testNonUTF8InputIsRejected() {
+        XCTAssertThrowsError(
+            try OpenCodeConfigEditor.merging(
+                existing: Data([0x7B, 0xFF, 0xFE, 0x7D]),
+                providers: ["quotio": quotioProvider]
+            )
+        ) { error in
+            XCTAssertEqual(error as? OpenCodeConfigError, .notUTF8)
+        }
+    }
+
+    func testMissingCommaBetweenMembersIsRejected() {
+        assertMergeRefuses("{\n  \"a\": 1\n  \"b\": 2\n}")
+    }
+
+    // MARK: - Comment/comma markers that live inside string literals
+
+    func testCommentMarkersInsideStringsAreNotComments() throws {
+        let source = """
+        {
+          "$schema": "https://opencode.ai/config.json",
           "note": "a /* not a comment */ b",
           "escaped": "quote \\" then // still in string",
+          "commaish": "value, }"
         }
         """
-
-        let stripped = AgentConfigurationService.strippingJSONCSyntax(from: jsonc)
-        let object = try jsonObject(Data(stripped.utf8))
-
+        let mergedText = try merged(source)
+        let object = try jsonObject(Data(
+            OpenCodeConfigEditor.strippingJSONCSyntax(from: mergedText).utf8
+        ))
         XCTAssertEqual(object["$schema"] as? String, "https://opencode.ai/config.json")
         XCTAssertEqual(object["note"] as? String, "a /* not a comment */ b")
         XCTAssertEqual(object["escaped"] as? String, "quote \" then // still in string")
+        XCTAssertEqual(object["commaish"] as? String, "value, }")
     }
 
     func testStrippingHandlesNestedTrailingCommas() throws {
@@ -231,13 +320,84 @@ final class OpenCodeConfigTests: XCTestCase {
           "b": { "c": [ { "d": 1, }, ], },
         }
         """
-
-        let stripped = AgentConfigurationService.strippingJSONCSyntax(from: jsonc)
-        let object = try jsonObject(Data(stripped.utf8))
-
+        let object = try jsonObject(Data(
+            OpenCodeConfigEditor.strippingJSONCSyntax(from: jsonc).utf8
+        ))
         XCTAssertEqual(object["a"] as? [Int], [1, 2, 3])
         let b = try XCTUnwrap(object["b"] as? [String: Any])
         let c = try XCTUnwrap(b["c"] as? [[String: Any]])
         XCTAssertEqual(c.first?["d"] as? Int, 1)
+    }
+
+    // MARK: - Removal (default-config path)
+
+    func testRemoveDeletesOnlyQuotioAndKeepsComments() throws {
+        let source = """
+        {
+          // top comment
+          "plugin": ["opencode-antigravity-auth@1.2.8"],
+          "provider": {
+            "quotio": { "name": "Quotio" },
+            /* mine */
+            "myrouter": { "npm": "@ai-sdk/openai-compatible" }
+          }
+        }
+        """
+        let updated = try XCTUnwrap(
+            OpenCodeConfigEditor.removingProviders(existing: Data(source.utf8), keys: ["quotio"])
+        )
+        let text = String(decoding: updated, as: UTF8.self)
+        XCTAssertEqual(text, """
+        {
+          // top comment
+          "plugin": ["opencode-antigravity-auth@1.2.8"],
+          "provider": {
+            /* mine */
+            "myrouter": { "npm": "@ai-sdk/openai-compatible" }
+          }
+        }
+        """)
+    }
+
+    func testRemoveDropsTheWholeProviderMemberWhenQuotioWasItsOnlyEntry() throws {
+        let source = """
+        {
+          "theme": "dark",
+          "provider": {
+            "quotio": { "name": "Quotio" }
+          }
+        }
+        """
+        let updated = try XCTUnwrap(
+            OpenCodeConfigEditor.removingProviders(existing: Data(source.utf8), keys: ["quotio"])
+        )
+        XCTAssertEqual(String(decoding: updated, as: UTF8.self), """
+        {
+          "theme": "dark"
+        }
+        """)
+    }
+
+    func testRemoveReturnsNilWhenNothingToRemove() throws {
+        let source = """
+        {
+          "provider": { "myrouter": { "npm": "@ai-sdk/openai-compatible" } }
+        }
+        """
+        XCTAssertNil(
+            try OpenCodeConfigEditor.removingProviders(existing: Data(source.utf8), keys: ["quotio"])
+        )
+        XCTAssertNil(
+            try OpenCodeConfigEditor.removingProviders(existing: Data("{}".utf8), keys: ["quotio"])
+        )
+    }
+
+    func testRemoveRefusesUnparseableContent() {
+        XCTAssertThrowsError(
+            try OpenCodeConfigEditor.removingProviders(
+                existing: Data("not json at all".utf8),
+                keys: ["quotio"]
+            )
+        )
     }
 }


### PR DESCRIPTION
## Root cause

Applying auto-configure for OpenCode wiped user settings (`plugin`, other `provider` entries) from `~/.config/opencode/opencode.json`.

`generateOpenCodeConfig` does try to merge into the existing file, but it parses it with a strict `JSONSerialization` call wrapped in `try?`:

```swift
if fileManager.fileExists(atPath: configPath),
   let existingData = fileManager.contents(atPath: configPath),
   let parsed = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any] {
    existingConfig = parsed
}
```

OpenCode's config is JSONC — comments and trailing commas are valid (the reporter's file contains `// "oh-my-opencode"`). Strict parsing fails on such a file, the failure is swallowed, `existingConfig` stays `{}`, and the subsequent write replaces the whole file with just `$schema` + `provider.quotio`, destroying everything the user had.

## Fix

A new `Quotio/Services/OpenCodeConfigEditor.swift` performs a **field-scoped, text-preserving edit** instead of reparsing and reserializing the document:

- **Only `provider.quotio` is rewritten.** The editor parses the file structurally, locates the exact character range of the managed member, and splices it. Everything else — `plugin`, `mcp`, other providers, comments, key order, indentation, line endings, a UTF-8 BOM — comes back byte-identical. Reconfiguring twice is idempotent.
- **`$schema` is only added to a brand-new file.** An existing file that omits it is left as the user wrote it.
- **The revert path is symmetric**: it deletes only the `quotio` member (dropping `provider` when that was its last entry), and returns "nothing to do" — leaving the file completely untouched — when there is no quotio entry.
- **The parser is fail-closed.** It never manufactures validity: comment removal substitutes a space so adjacent tokens cannot fuse, unterminated block comments and strings are rejected rather than truncating the input, and missing commas, trailing content after the root, duplicate `provider` keys, a non-object `provider`, a non-object root and non-UTF-8 bytes are all refused.
- **Every splice is verified before it is returned**: the result is reparsed and compared against the value we intended to produce. A mismatch throws, and nothing is written.
- In automatic mode, a refusal surfaces a localized error and leaves `opencode.json` untouched. Manual mode still shows a quotio-only snippet to merge by hand (nothing is written).
- The read/detection path uses the same tolerant parser, so Quotio detects its provider inside a commented config.
- A timestamped backup is still written before any modification, via the existing `backupIfPresent` helper.

## Parse-or-refuse decision table

| Input | Decision |
| --- | --- |
| Strict JSON | parse |
| `//` and `/* */` comments, trailing commas | parse, preserved in place on write |
| Comment markers inside string literals (`"a /* not a comment */ b"`, `"…// still in string"`) | parse — string literals are never scanned for comments |
| Comma/brace characters inside string literals (`"value, }"`) | parse |
| CRLF line endings, UTF-8 BOM | parse; both preserved on write |
| Unterminated block comment (anywhere, including after an otherwise valid document) | **refuse** |
| Nested block comment `/* a /* b */ */` | **refuse** (JSONC has no nesting; the stray `*/` is a syntax error) |
| Unterminated string literal | **refuse** |
| Closed block comment between two tokens (`1/* x */2`) | **refuse** — the comment becomes a space, so the tokens stay separate and the document is invalid |
| Missing comma between members | **refuse** |
| Trailing content after the root value | **refuse** |
| Root is not a JSON object | **refuse** |
| Duplicate `provider` key at the root, or duplicate managed key inside `provider` | **refuse** (ambiguous target) |
| `provider` present but not an object (including `null`) | **refuse** (merging would replace user content) |
| File is not valid UTF-8 | **refuse** |
| Spliced result does not reparse into the expected value | **refuse** |
| Missing, empty, or whitespace-only file | write a fresh config (`$schema` + `provider.quotio`) |

Every "refuse" row means the same thing: `opencode.json` is left exactly as it was, and automatic mode reports a localized error.

## Localization

New user-facing strings use the established `localizedStatic()` / `String(format:)` pattern and are added textually to `Localizable.xcstrings` for `en`, `fr`, `vi`, `zh-Hans`: `agents.opencode.notConfigured`, `agents.opencode.parseFailed` (path + reason placeholders) and `agents.opencode.parseError.*` (one per refusal reason).

## Tests

`QuotioTests/OpenCodeConfigTests.swift` — 27 tests, including:

- **Round-trip fidelity**: on a config with unrelated top-level keys, nested objects, arrays, another provider and three comments, `merge` then `remove` reproduces the original **byte for byte**; a separate test asserts the source above `provider` is unchanged and the comments (including the reporter's commented-out plugin line) are still present.
- Reconfiguring twice is idempotent; reconfiguring an existing entry replaces only its value.
- `$schema` is not injected into an existing file that omits it.
- Insertion when `provider` is absent, when it is `{}`, when the last member already has a trailing comma, and when the last member carries a trailing `//` comment.
- CRLF + BOM preservation.
- One refusal test per row of the table above.

Verification:
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build` — **BUILD SUCCEEDED**
- `xcodebuild test -project Quotio.xcodeproj -scheme Quotio -destination 'platform=macOS'` — **TEST SUCCEEDED**, 93 passed / 0 failed

Fixes #176
