### PR TITLE
feat(stats): persist traffic statistics across proxy restarts

### DIFF
--- a/Quotio/Services/Proxy/CLIProxyManager.swift
+++ b/Quotio/Services/Proxy/CLIProxyManager.swift
@@ -17,6 +17,12 @@ final class CLIProxyManager {
     /// This solves the stale connection issue by forcing "Connection: close" on all requests
     let proxyBridge = ProxyBridge()
     
+    /// Closes the persistent traffic-statistics session whenever this manager
+    /// tears the proxy down, so CLIProxyAPI's in-memory counters restarting from
+    /// zero does not discard what the previous process served.
+    /// Driven from stop(), stopAndWait(), restartProxyIfRunning(), promote() and rollback().
+    @ObservationIgnored let usageSessionRecorder = ProxyUsageSessionRecorder()
+
     /// When enabled: clients connect to userPort, ProxyBridge forwards to internalPort
     /// When disabled: clients connect directly to userPort where CLIProxyAPI runs
     var useBridgeMode: Bool {
@@ -258,6 +264,12 @@ final class CLIProxyManager {
 
         Task {
             NSLog("[CLIProxyManager] Restarting proxy to apply configuration changes...")
+            // Fold a final usage snapshot before the process goes down.
+            // Reentrancy: this Task body runs after the guard above, so the
+            // running state is re-read here rather than reused from it.
+            if proxyStatus.running {
+                await usageSessionRecorder.proxyWillStop()
+            }
             stop()
             // Wait 0.5s for ports to clear
             try? await Task.sleep(nanoseconds: 500_000_000)
@@ -956,6 +968,11 @@ final class CLIProxyManager {
     }
     
     func stop() {
+        // Close the traffic-statistics session for the process being torn down.
+        // This path is synchronous, so no final counter sample can be fetched;
+        // callers that can await run proxyWillStop() first, which folds one.
+        usageSessionRecorder.proxyDidStop()
+
         terminateAuthProcess()
         stopHealthMonitor()
         cancelCrashRestart()
@@ -1009,6 +1026,13 @@ final class CLIProxyManager {
     /// Used by recovery paths that immediately restart, so the detached cleanup in stop()
     /// cannot race with and kill the newly started process by port.
     func stopAndWait() async {
+        // Fold a final usage snapshot and close the statistics session before
+        // the process is signalled. Deliberately the first statement: it
+        // suspends, so every piece of state captured below is read afterwards.
+        if proxyStatus.running {
+            await usageSessionRecorder.proxyWillStop()
+        }
+
         terminateAuthProcess()
         stopHealthMonitor()
         cancelCrashRestart()
@@ -1974,13 +1998,20 @@ extension CLIProxyManager {
             testConfigPath = nil
         }
         testManagementKey = nil
-        
+
+        // Fold a final usage snapshot before the old binary is torn down, so an
+        // upgrade does not reset the dashboard traffic statistics (issue #359).
+        // Reentrancy: this suspends, so `wasRunning` is read after it, not before.
+        if proxyStatus.running {
+            await usageSessionRecorder.proxyWillStop()
+        }
+
         // Stop the current active proxy if running
         let wasRunning = proxyStatus.running
         if wasRunning {
             stop()
         }
-        
+
         // Update the current symlink
         try storageManager.setCurrentVersion(version, source: source)
         activeVersion = version
@@ -2002,7 +2033,13 @@ extension CLIProxyManager {
         }
         
         managerState = .rollingBack
-        
+
+        // Fold a final usage snapshot before the process goes down.
+        // Reentrancy: this suspends, so `wasRunning` is read after it, not before.
+        if proxyStatus.running {
+            await usageSessionRecorder.proxyWillStop()
+        }
+
         // Stop current proxy
         let wasRunning = proxyStatus.running
         if wasRunning {

--- a/Quotio/Services/UsageStatsAggregator.swift
+++ b/Quotio/Services/UsageStatsAggregator.swift
@@ -1,0 +1,214 @@
+//
+//  UsageStatsAggregator.swift
+//  Quotio - Persistent Traffic Statistics
+//
+//  CLIProxyAPI keeps its /v0/management/usage counters in memory, so every
+//  proxy restart (or CLIProxyAPI upgrade) resets them to zero. This service
+//  accumulates those counters on the Quotio side and persists them to disk,
+//  so the dashboard traffic statistics survive proxy restarts and upgrades.
+//
+
+import Foundation
+
+// MARK: - Persisted Totals
+
+/// Fixed-size aggregate usage counters (no per-request entries, so the
+/// persisted file never grows with traffic).
+nonisolated struct UsageTotals: Codable, Sendable, Equatable {
+    var totalRequests: Int
+    var successCount: Int
+    var failureCount: Int
+    var totalTokens: Int
+    var inputTokens: Int
+    var outputTokens: Int
+
+    static let zero = UsageTotals(
+        totalRequests: 0,
+        successCount: 0,
+        failureCount: 0,
+        totalTokens: 0,
+        inputTokens: 0,
+        outputTokens: 0
+    )
+
+    init(
+        totalRequests: Int,
+        successCount: Int,
+        failureCount: Int,
+        totalTokens: Int,
+        inputTokens: Int,
+        outputTokens: Int
+    ) {
+        self.totalRequests = totalRequests
+        self.successCount = successCount
+        self.failureCount = failureCount
+        self.totalTokens = totalTokens
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+    }
+
+    /// Snapshot the counters reported by CLIProxyAPI.
+    init(stats: UsageStats) {
+        let usage = stats.usage
+        self.init(
+            totalRequests: usage?.totalRequests ?? 0,
+            successCount: usage?.successCount ?? 0,
+            failureCount: usage?.failureCount ?? 0,
+            totalTokens: usage?.totalTokens ?? 0,
+            inputTokens: usage?.inputTokens ?? 0,
+            outputTokens: usage?.outputTokens ?? 0
+        )
+    }
+
+    static func + (lhs: UsageTotals, rhs: UsageTotals) -> UsageTotals {
+        UsageTotals(
+            totalRequests: lhs.totalRequests + rhs.totalRequests,
+            successCount: lhs.successCount + rhs.successCount,
+            failureCount: lhs.failureCount + rhs.failureCount,
+            totalTokens: lhs.totalTokens + rhs.totalTokens,
+            inputTokens: lhs.inputTokens + rhs.inputTokens,
+            outputTokens: lhs.outputTokens + rhs.outputTokens
+        )
+    }
+
+    var isZero: Bool {
+        self == .zero
+    }
+
+    /// Convert to the DTO the dashboard already consumes.
+    var asUsageStats: UsageStats {
+        UsageStats(
+            usage: UsageData(
+                totalRequests: totalRequests,
+                successCount: successCount,
+                failureCount: failureCount,
+                totalTokens: totalTokens,
+                inputTokens: inputTokens,
+                outputTokens: outputTokens
+            ),
+            failedRequests: failureCount
+        )
+    }
+}
+
+/// On-disk container for accumulated usage statistics.
+nonisolated struct UsageTotalsStore: Codable, Sendable, Equatable {
+    /// Version for migration support
+    var version: Int
+
+    /// Totals folded in from previous proxy sessions.
+    var baseline: UsageTotals
+
+    /// Latest raw counter sample from the current proxy session.
+    var lastSample: UsageTotals
+
+    static let currentVersion = 1
+
+    static var empty: UsageTotalsStore {
+        UsageTotalsStore(version: currentVersion, baseline: .zero, lastSample: .zero)
+    }
+
+    var cumulative: UsageTotals {
+        baseline + lastSample
+    }
+}
+
+// MARK: - Aggregator
+
+/// Accumulates CLIProxyAPI usage counters across proxy restarts and persists
+/// them to Application Support so traffic statistics are retained.
+@MainActor
+@Observable
+final class UsageStatsAggregator {
+
+    static let shared = UsageStatsAggregator()
+
+    // MARK: - Properties
+
+    private(set) var store: UsageTotalsStore = .empty
+
+    /// Storage file URL
+    private let storageURL: URL
+
+    // MARK: - Initialization
+
+    init(storageURL: URL? = nil) {
+        self.storageURL = storageURL ?? Self.defaultStorageURL()
+        loadFromDisk()
+    }
+
+    private static func defaultStorageURL() -> URL {
+        guard let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            fatalError("Application Support directory not found")
+        }
+        let quotioDir = appSupport.appendingPathComponent("Quotio")
+        try? FileManager.default.createDirectory(at: quotioDir, withIntermediateDirectories: true)
+        return quotioDir.appendingPathComponent("usage-stats.json")
+    }
+
+    // MARK: - Public Methods
+
+    /// Record a fresh counter sample from CLIProxyAPI and return the
+    /// cumulative statistics to display.
+    ///
+    /// When the proxy restarts (manual restart or CLIProxyAPI upgrade) its
+    /// in-memory counters start over from zero. A sample whose request count
+    /// is lower than the previous one signals that reset, so the previous
+    /// session's totals are folded into the persistent baseline before the
+    /// new sample is stored.
+    @discardableResult
+    func record(_ sample: UsageStats) -> UsageStats {
+        let sampleTotals = UsageTotals(stats: sample)
+
+        if sampleTotals.totalRequests < store.lastSample.totalRequests {
+            // Proxy counters reset: preserve the finished session's totals.
+            store.baseline = store.baseline + store.lastSample
+        }
+        store.lastSample = sampleTotals
+        saveToDisk()
+
+        return store.cumulative.asUsageStats
+    }
+
+    /// Cumulative statistics restored from disk, or nil when nothing has been
+    /// recorded yet (fresh install keeps showing the empty dashboard).
+    func restoredStats() -> UsageStats? {
+        let cumulative = store.cumulative
+        return cumulative.isZero ? nil : cumulative.asUsageStats
+    }
+
+    /// Clear all accumulated statistics.
+    func reset() {
+        store = .empty
+        saveToDisk()
+    }
+
+    // MARK: - Persistence
+
+    private func loadFromDisk() {
+        guard FileManager.default.fileExists(atPath: storageURL.path) else {
+            return
+        }
+
+        do {
+            let data = try Data(contentsOf: storageURL)
+            store = try JSONDecoder().decode(UsageTotalsStore.self, from: data)
+        } catch {
+            NSLog("[UsageStatsAggregator] Failed to load usage totals: \(error)")
+            // If decoding fails due to corruption or format mismatch, start fresh
+            try? FileManager.default.removeItem(at: storageURL)
+            store = .empty
+        }
+    }
+
+    private func saveToDisk() {
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(store)
+            try data.write(to: storageURL, options: .atomic)
+        } catch {
+            NSLog("[UsageStatsAggregator] Failed to save usage totals: \(error)")
+        }
+    }
+}

--- a/Quotio/Services/UsageStatsAggregator.swift
+++ b/Quotio/Services/UsageStatsAggregator.swift
@@ -7,8 +7,49 @@
 //  accumulates those counters on the Quotio side and persists them to disk,
 //  so the dashboard traffic statistics survive proxy restarts and upgrades.
 //
+//  Correctness relies on two mechanisms, in this order:
+//
+//  1. Explicit session boundaries driven by the managed proxy lifecycle.
+//     `CLIProxyManager` owns a `ProxyUsageSessionRecorder` and calls it on
+//     every managed teardown path (stop, config restart, upgrade promote,
+//     rollback, health recovery). Where the path can await, a final counter
+//     sample is fetched and folded first, so requests served between the last
+//     poll and the shutdown are not lost.
+//  2. A counter-decrease fallback inside `record(_:source:)`, which only
+//     covers restarts Quotio did not perform (proxy crash, external kill,
+//     power loss). That fallback is inherently lossy and is not what the
+//     managed paths depend on.
+//
 
 import Foundation
+
+// MARK: - Proxy Identity
+
+/// Identifies which proxy a set of usage counters belongs to.
+///
+/// Persisted totals are scoped by this value, so counters from the local
+/// managed proxy are never merged into a remote CLIProxyAPI instance's totals
+/// (and two different remote servers never share a bucket either).
+nonisolated enum UsageStatsSource: Sendable, Equatable, Hashable {
+    /// The CLIProxyAPI process Quotio starts and manages on this machine.
+    case localProxy
+
+    /// A remote CLIProxyAPI instance, identified by its management base URL.
+    case remote(endpoint: String)
+
+    /// Stable key used for on-disk storage.
+    var storageKey: String {
+        switch self {
+        case .localProxy:
+            return "local"
+        case .remote(let endpoint):
+            let normalized = endpoint
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            return "remote:\(normalized)"
+        }
+    }
+}
 
 // MARK: - Persisted Totals
 
@@ -71,6 +112,22 @@ nonisolated struct UsageTotals: Codable, Sendable, Equatable {
         )
     }
 
+    /// Component-wise maximum with another sample from the *same* proxy session.
+    ///
+    /// CLIProxyAPI counters only ever grow within a session, so taking the
+    /// maximum keeps whichever sample is newer without ever double counting.
+    /// Used when a final shutdown snapshot and a concurrent poll race.
+    func mergingSameSession(_ other: UsageTotals) -> UsageTotals {
+        UsageTotals(
+            totalRequests: max(totalRequests, other.totalRequests),
+            successCount: max(successCount, other.successCount),
+            failureCount: max(failureCount, other.failureCount),
+            totalTokens: max(totalTokens, other.totalTokens),
+            inputTokens: max(inputTokens, other.inputTokens),
+            outputTokens: max(outputTokens, other.outputTokens)
+        )
+    }
+
     var isZero: Bool {
         self == .zero
     }
@@ -91,26 +148,51 @@ nonisolated struct UsageTotals: Codable, Sendable, Equatable {
     }
 }
 
-/// On-disk container for accumulated usage statistics.
-nonisolated struct UsageTotalsStore: Codable, Sendable, Equatable {
-    /// Version for migration support
-    var version: Int
-
-    /// Totals folded in from previous proxy sessions.
+/// Accumulated state for a single proxy identity.
+nonisolated struct UsageSessionState: Codable, Sendable, Equatable {
+    /// Totals folded in from proxy sessions that have already ended.
     var baseline: UsageTotals
 
-    /// Latest raw counter sample from the current proxy session.
+    /// Latest raw counter sample from the proxy session currently in progress.
+    /// Zero once the session has been closed by the lifecycle hook.
     var lastSample: UsageTotals
 
-    static let currentVersion = 1
-
-    static var empty: UsageTotalsStore {
-        UsageTotalsStore(version: currentVersion, baseline: .zero, lastSample: .zero)
-    }
+    static let empty = UsageSessionState(baseline: .zero, lastSample: .zero)
 
     var cumulative: UsageTotals {
         baseline + lastSample
     }
+}
+
+/// On-disk container for accumulated usage statistics, scoped per proxy identity.
+nonisolated struct UsageTotalsStore: Codable, Sendable, Equatable {
+    /// Version for migration support
+    var version: Int
+
+    /// State keyed by `UsageStatsSource.storageKey`.
+    var sources: [String: UsageSessionState]
+
+    static let currentVersion = 2
+
+    static var empty: UsageTotalsStore {
+        UsageTotalsStore(version: currentVersion, sources: [:])
+    }
+
+    func state(for source: UsageStatsSource) -> UsageSessionState {
+        sources[source.storageKey] ?? .empty
+    }
+
+    mutating func setState(_ state: UsageSessionState, for source: UsageStatsSource) {
+        sources[source.storageKey] = state
+    }
+}
+
+/// Version 1 layout: one unscoped bucket. Migrated onto `.localProxy`, which is
+/// the only proxy the previous implementation could meaningfully have tracked.
+private struct LegacyUsageTotalsStoreV1: Decodable {
+    var version: Int
+    var baseline: UsageTotals
+    var lastSample: UsageTotals
 }
 
 // MARK: - Aggregator
@@ -146,38 +228,71 @@ final class UsageStatsAggregator {
         return quotioDir.appendingPathComponent("usage-stats.json")
     }
 
-    // MARK: - Public Methods
+    // MARK: - Sampling
 
-    /// Record a fresh counter sample from CLIProxyAPI and return the
-    /// cumulative statistics to display.
+    /// Record a fresh counter sample from `source` and return the cumulative
+    /// statistics to display for that source.
     ///
-    /// When the proxy restarts (manual restart or CLIProxyAPI upgrade) its
-    /// in-memory counters start over from zero. A sample whose request count
-    /// is lower than the previous one signals that reset, so the previous
-    /// session's totals are folded into the persistent baseline before the
-    /// new sample is stored.
+    /// Restarts Quotio performs itself are handled by `endSession(source:)`,
+    /// which is driven from the proxy lifecycle before the process goes down.
+    /// The counter-decrease check below is only a fallback for restarts Quotio
+    /// did not perform (crash, external kill, machine power loss); it cannot
+    /// recover traffic served between the last poll and such a restart.
     @discardableResult
-    func record(_ sample: UsageStats) -> UsageStats {
+    func record(_ sample: UsageStats, source: UsageStatsSource) -> UsageStats {
+        var state = store.state(for: source)
         let sampleTotals = UsageTotals(stats: sample)
 
-        if sampleTotals.totalRequests < store.lastSample.totalRequests {
-            // Proxy counters reset: preserve the finished session's totals.
-            store.baseline = store.baseline + store.lastSample
+        if sampleTotals.totalRequests < state.lastSample.totalRequests {
+            // Counters went backwards without a managed teardown: preserve
+            // whatever the finished session had reported.
+            state.baseline = state.baseline + state.lastSample
         }
-        store.lastSample = sampleTotals
+        state.lastSample = sampleTotals
+
+        store.setState(state, for: source)
         saveToDisk()
 
-        return store.cumulative.asUsageStats
+        return state.cumulative.asUsageStats
     }
 
-    /// Cumulative statistics restored from disk, or nil when nothing has been
-    /// recorded yet (fresh install keeps showing the empty dashboard).
-    func restoredStats() -> UsageStats? {
-        let cumulative = store.cumulative
+    /// Fold a final counter sample taken immediately before a managed shutdown.
+    ///
+    /// Callers reach this after an `await`, so the state is re-read here rather
+    /// than captured beforehand, and the sample is merged component-wise with
+    /// whatever the auto-refresh loop may have recorded in the meantime instead
+    /// of overwriting it.
+    func foldFinalSample(_ sample: UsageStats, source: UsageStatsSource) {
+        var state = store.state(for: source)
+        state.lastSample = state.lastSample.mergingSameSession(UsageTotals(stats: sample))
+        store.setState(state, for: source)
+        saveToDisk()
+    }
+
+    /// Close the current proxy session for `source`: the session's counters are
+    /// folded into the persistent baseline, so the next process may start from
+    /// zero (or from any value at all) without discarding what was served.
+    ///
+    /// Idempotent — closing an already closed session is a no-op.
+    func endSession(source: UsageStatsSource) {
+        var state = store.state(for: source)
+        guard !state.lastSample.isZero else { return }
+
+        state.baseline = state.baseline + state.lastSample
+        state.lastSample = .zero
+        store.setState(state, for: source)
+        saveToDisk()
+    }
+
+    /// Cumulative statistics restored from disk for `source`, or nil when
+    /// nothing has been recorded yet (fresh install keeps showing the empty
+    /// dashboard).
+    func restoredStats(for source: UsageStatsSource) -> UsageStats? {
+        let cumulative = store.state(for: source).cumulative
         return cumulative.isZero ? nil : cumulative.asUsageStats
     }
 
-    /// Clear all accumulated statistics.
+    /// Clear all accumulated statistics for every source.
     func reset() {
         store = .empty
         saveToDisk()
@@ -192,7 +307,23 @@ final class UsageStatsAggregator {
 
         do {
             let data = try Data(contentsOf: storageURL)
-            store = try JSONDecoder().decode(UsageTotalsStore.self, from: data)
+            let decoder = JSONDecoder()
+
+            if let current = try? decoder.decode(UsageTotalsStore.self, from: data),
+               current.version >= UsageTotalsStore.currentVersion {
+                store = current
+                return
+            }
+
+            // Migrate the single-bucket v1 file onto the local proxy.
+            let legacy = try decoder.decode(LegacyUsageTotalsStoreV1.self, from: data)
+            var migrated = UsageTotalsStore.empty
+            migrated.setState(
+                UsageSessionState(baseline: legacy.baseline, lastSample: legacy.lastSample),
+                for: .localProxy
+            )
+            store = migrated
+            saveToDisk()
         } catch {
             NSLog("[UsageStatsAggregator] Failed to load usage totals: \(error)")
             // If decoding fails due to corruption or format mismatch, start fresh
@@ -210,5 +341,52 @@ final class UsageStatsAggregator {
         } catch {
             NSLog("[UsageStatsAggregator] Failed to save usage totals: \(error)")
         }
+    }
+}
+
+// MARK: - Proxy Lifecycle Bridge
+
+/// Bridges the managed CLIProxyAPI lifecycle to persistent usage statistics.
+///
+/// `CLIProxyManager` owns one instance and drives it from every managed
+/// teardown path, so a stop / restart / upgrade closes the statistics session
+/// explicitly instead of it being inferred later from a counter decrease.
+///
+/// Only `.localProxy` is handled here: `CLIProxyManager` manages exactly one
+/// proxy, the local one. A remote CLIProxyAPI instance has no lifecycle Quotio
+/// can observe, so its bucket falls back to the counter-decrease heuristic.
+@MainActor
+final class ProxyUsageSessionRecorder {
+
+    /// Fetches one last `/v0/management/usage` sample from the proxy that is
+    /// about to go down. Installed by `QuotaViewModel`, which owns the
+    /// management API client. Returns nil when the proxy is already unreachable.
+    typealias FinalSampleProvider = @MainActor () async -> UsageStats?
+
+    private let aggregator: UsageStatsAggregator
+
+    var finalSampleProvider: FinalSampleProvider?
+
+    init(aggregator: UsageStatsAggregator = .shared) {
+        self.aggregator = aggregator
+    }
+
+    /// Called before the managed proxy process is signalled, on teardown paths
+    /// that can await. Folds a final counter sample so requests served since
+    /// the last poll survive, then closes the session.
+    func proxyWillStop() async {
+        if let provider = finalSampleProvider, let sample = await provider() {
+            aggregator.foldFinalSample(sample, source: .localProxy)
+        }
+        aggregator.endSession(source: .localProxy)
+    }
+
+    /// Called as the managed proxy process goes down, including from the
+    /// synchronous `stop()` path where no final sample can be fetched.
+    ///
+    /// Idempotent: a session already closed by `proxyWillStop()` is untouched,
+    /// so paths that call both still fold exactly once.
+    func proxyDidStop() {
+        aggregator.endSession(source: .localProxy)
     }
 }

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -41,6 +41,9 @@ final class QuotaViewModel {
     
     /// Request tracker for monitoring API requests through ProxyBridge
     let requestTracker = RequestTracker.shared
+
+    /// Persists cumulative traffic statistics across proxy restarts/upgrades
+    @ObservationIgnored private let usageAggregator = UsageStatsAggregator.shared
     
     /// Tunnel manager for Cloudflare Tunnel integration
     let tunnelManager = TunnelManager.shared
@@ -281,6 +284,7 @@ final class QuotaViewModel {
 
     init() {
         self.proxyManager = CLIProxyManager.shared
+        self.usageStats = usageAggregator.restoredStats()
         loadPersistedIDEQuotas()
         setupRefreshCadenceCallback()
         setupWarmupCallback()
@@ -1518,7 +1522,10 @@ final class QuotaViewModel {
             self.authFiles = newAuthFiles
 
             do {
-                self.usageStats = try await client.fetchUsageStats()
+                // Fold the proxy's in-memory counters into the persisted
+                // aggregate so statistics survive proxy restarts/upgrades.
+                let sample = try await client.fetchUsageStats()
+                self.usageStats = usageAggregator.record(sample)
             } catch APIError.httpError(404) {
                 self.usageStats = nil
                 Log.quota("Usage stats endpoint is not supported by this CLIProxyAPI version")

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -282,9 +282,33 @@ final class QuotaViewModel {
         notifyQuotaDataChanged()
     }
 
+    /// Which persisted usage bucket the currently configured proxy writes to.
+    /// The local managed proxy, and each distinct remote server, keep separate
+    /// totals so switching between them never merges unrelated counters.
+    private var usageStatsSource: UsageStatsSource {
+        if modeManager.isRemoteProxyMode, let config = modeManager.remoteConfig {
+            return .remote(endpoint: config.managementBaseURL)
+        }
+        return .localProxy
+    }
+
+    /// Let CLIProxyManager fold a final counter sample before it tears the
+    /// managed proxy down, so requests served since the last poll are kept.
+    /// The mode is re-checked inside the closure because it is invoked later,
+    /// during shutdown, not at wiring time.
+    private func setupUsageSessionRecorder() {
+        proxyManager.usageSessionRecorder.finalSampleProvider = { [weak self] in
+            guard let self,
+                  !self.modeManager.isRemoteProxyMode,
+                  let client = self.apiClient else { return nil }
+            return try? await client.fetchUsageStats()
+        }
+    }
+
     init() {
         self.proxyManager = CLIProxyManager.shared
-        self.usageStats = usageAggregator.restoredStats()
+        self.usageStats = usageAggregator.restoredStats(for: usageStatsSource)
+        setupUsageSessionRecorder()
         loadPersistedIDEQuotas()
         setupRefreshCadenceCallback()
         setupWarmupCallback()
@@ -378,6 +402,12 @@ final class QuotaViewModel {
     // MARK: - Mode-Aware Initialization
 
     func initialize() async {
+        // Every mode switch routes through here, so re-scope the displayed
+        // traffic statistics to the proxy this mode targets. Without this a
+        // switch would keep showing the previous proxy's totals until (and
+        // unless) the first refresh against the new one succeeds.
+        usageStats = usageAggregator.restoredStats(for: usageStatsSource)
+
         if modeManager.isRemoteProxyMode {
             await initializeRemoteMode()
         } else if modeManager.isMonitorMode {
@@ -1506,7 +1536,13 @@ final class QuotaViewModel {
     
     func refreshData(refreshQuotas: Bool = true) async {
         guard let client = apiClient else { return }
-        
+
+        // Resolve the statistics bucket together with the client it belongs to.
+        // Reentrancy: a mode switch during the awaits below swaps `apiClient`,
+        // so re-reading the source afterwards would file this client's counters
+        // under a different proxy.
+        let usageSource = usageStatsSource
+
         do {
             // Serialize requests to avoid connection contention (issue #37)
             // This reduces pressure on the connection pool
@@ -1525,7 +1561,7 @@ final class QuotaViewModel {
                 // Fold the proxy's in-memory counters into the persisted
                 // aggregate so statistics survive proxy restarts/upgrades.
                 let sample = try await client.fetchUsageStats()
-                self.usageStats = usageAggregator.record(sample)
+                self.usageStats = usageAggregator.record(sample, source: usageSource)
             } catch APIError.httpError(404) {
                 self.usageStats = nil
                 Log.quota("Usage stats endpoint is not supported by this CLIProxyAPI version")

--- a/QuotioTests/UsageStatsAggregatorTests.swift
+++ b/QuotioTests/UsageStatsAggregatorTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import Quotio
+
+@MainActor
+final class UsageStatsAggregatorTests: XCTestCase {
+
+    private var storageURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        storageURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("usage-stats-tests-\(UUID().uuidString).json")
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: storageURL)
+        storageURL = nil
+        super.tearDown()
+    }
+
+    private func makeStats(
+        totalRequests: Int,
+        successCount: Int,
+        failureCount: Int,
+        totalTokens: Int,
+        inputTokens: Int,
+        outputTokens: Int
+    ) -> UsageStats {
+        UsageStats(
+            usage: UsageData(
+                totalRequests: totalRequests,
+                successCount: successCount,
+                failureCount: failureCount,
+                totalTokens: totalTokens,
+                inputTokens: inputTokens,
+                outputTokens: outputTokens
+            ),
+            failedRequests: failureCount
+        )
+    }
+
+    // MARK: - Accumulation
+
+    func testMonotonicSamplesAreNotDoubleCounted() {
+        let aggregator = UsageStatsAggregator(storageURL: storageURL)
+
+        _ = aggregator.record(makeStats(totalRequests: 10, successCount: 9, failureCount: 1, totalTokens: 1000, inputTokens: 600, outputTokens: 400))
+        _ = aggregator.record(makeStats(totalRequests: 15, successCount: 13, failureCount: 2, totalTokens: 1500, inputTokens: 900, outputTokens: 600))
+        let result = aggregator.record(makeStats(totalRequests: 20, successCount: 17, failureCount: 3, totalTokens: 2000, inputTokens: 1200, outputTokens: 800))
+
+        XCTAssertEqual(result.usage?.totalRequests, 20)
+        XCTAssertEqual(result.usage?.successCount, 17)
+        XCTAssertEqual(result.usage?.failureCount, 3)
+        XCTAssertEqual(result.usage?.totalTokens, 2000)
+        XCTAssertEqual(result.usage?.inputTokens, 1200)
+        XCTAssertEqual(result.usage?.outputTokens, 800)
+    }
+
+    func testProxyRestartFoldsPreviousSessionIntoBaseline() {
+        let aggregator = UsageStatsAggregator(storageURL: storageURL)
+
+        // First proxy session
+        _ = aggregator.record(makeStats(totalRequests: 100, successCount: 90, failureCount: 10, totalTokens: 5000, inputTokens: 3000, outputTokens: 2000))
+
+        // Proxy restarted (or CLIProxyAPI upgraded): counters start over
+        let afterRestart = aggregator.record(makeStats(totalRequests: 5, successCount: 5, failureCount: 0, totalTokens: 250, inputTokens: 150, outputTokens: 100))
+
+        XCTAssertEqual(afterRestart.usage?.totalRequests, 105)
+        XCTAssertEqual(afterRestart.usage?.successCount, 95)
+        XCTAssertEqual(afterRestart.usage?.failureCount, 10)
+        XCTAssertEqual(afterRestart.usage?.totalTokens, 5250)
+        XCTAssertEqual(afterRestart.usage?.inputTokens, 3150)
+        XCTAssertEqual(afterRestart.usage?.outputTokens, 2100)
+        XCTAssertEqual(afterRestart.failedRequests, 10)
+    }
+
+    func testRestartToZeroSampleKeepsPreviousTotals() {
+        let aggregator = UsageStatsAggregator(storageURL: storageURL)
+
+        _ = aggregator.record(makeStats(totalRequests: 42, successCount: 40, failureCount: 2, totalTokens: 900, inputTokens: 500, outputTokens: 400))
+
+        // Fresh proxy, no traffic yet
+        let afterRestart = aggregator.record(makeStats(totalRequests: 0, successCount: 0, failureCount: 0, totalTokens: 0, inputTokens: 0, outputTokens: 0))
+
+        XCTAssertEqual(afterRestart.usage?.totalRequests, 42)
+        XCTAssertEqual(afterRestart.usage?.totalTokens, 900)
+    }
+
+    // MARK: - Persistence across app relaunch
+
+    func testTotalsSurviveAppRelaunch() {
+        let first = UsageStatsAggregator(storageURL: storageURL)
+        _ = first.record(makeStats(totalRequests: 100, successCount: 90, failureCount: 10, totalTokens: 5000, inputTokens: 3000, outputTokens: 2000))
+
+        // Simulate app relaunch: new aggregator instance reads the same file
+        let second = UsageStatsAggregator(storageURL: storageURL)
+        let restored = second.restoredStats()
+        XCTAssertEqual(restored?.usage?.totalRequests, 100)
+        XCTAssertEqual(restored?.usage?.totalTokens, 5000)
+
+        // Proxy also restarted while the app was closed: counters reset
+        let afterRestart = second.record(makeStats(totalRequests: 3, successCount: 3, failureCount: 0, totalTokens: 90, inputTokens: 60, outputTokens: 30))
+        XCTAssertEqual(afterRestart.usage?.totalRequests, 103)
+        XCTAssertEqual(afterRestart.usage?.totalTokens, 5090)
+    }
+
+    func testRestoredStatsIsNilForFreshInstall() {
+        let aggregator = UsageStatsAggregator(storageURL: storageURL)
+        XCTAssertNil(aggregator.restoredStats())
+    }
+
+    // MARK: - Bounded storage
+
+    func testPersistedFileStaysBoundedAggregatesOnly() throws {
+        let aggregator = UsageStatsAggregator(storageURL: storageURL)
+
+        for i in 1...500 {
+            _ = aggregator.record(makeStats(totalRequests: i, successCount: i, failureCount: 0, totalTokens: i * 100, inputTokens: i * 60, outputTokens: i * 40))
+        }
+
+        let data = try Data(contentsOf: storageURL)
+        // Fixed-size aggregate counters only, never per-request entries
+        let decoded = try JSONDecoder().decode(UsageTotalsStore.self, from: data)
+        XCTAssertEqual(decoded.lastSample.totalRequests, 500)
+        XCTAssertLessThan(data.count, 2048, "usage-stats.json must stay a small fixed-size aggregate file")
+    }
+
+    // MARK: - Corruption handling
+
+    func testCorruptFileStartsFresh() throws {
+        try Data("not json {{{".utf8).write(to: storageURL)
+
+        let aggregator = UsageStatsAggregator(storageURL: storageURL)
+        XCTAssertNil(aggregator.restoredStats())
+
+        // Aggregation still works after recovery
+        let result = aggregator.record(makeStats(totalRequests: 7, successCount: 7, failureCount: 0, totalTokens: 70, inputTokens: 40, outputTokens: 30))
+        XCTAssertEqual(result.usage?.totalRequests, 7)
+    }
+
+    // MARK: - Reset
+
+    func testResetClearsTotalsAndPersists() {
+        let aggregator = UsageStatsAggregator(storageURL: storageURL)
+        _ = aggregator.record(makeStats(totalRequests: 12, successCount: 12, failureCount: 0, totalTokens: 300, inputTokens: 200, outputTokens: 100))
+
+        aggregator.reset()
+        XCTAssertNil(aggregator.restoredStats())
+
+        let relaunched = UsageStatsAggregator(storageURL: storageURL)
+        XCTAssertNil(relaunched.restoredStats())
+    }
+}

--- a/QuotioTests/UsageStatsAggregatorTests.swift
+++ b/QuotioTests/UsageStatsAggregatorTests.swift
@@ -20,11 +20,11 @@ final class UsageStatsAggregatorTests: XCTestCase {
 
     private func makeStats(
         totalRequests: Int,
-        successCount: Int,
-        failureCount: Int,
-        totalTokens: Int,
-        inputTokens: Int,
-        outputTokens: Int
+        successCount: Int = 0,
+        failureCount: Int = 0,
+        totalTokens: Int = 0,
+        inputTokens: Int = 0,
+        outputTokens: Int = 0
     ) -> UsageStats {
         UsageStats(
             usage: UsageData(
@@ -44,9 +44,9 @@ final class UsageStatsAggregatorTests: XCTestCase {
     func testMonotonicSamplesAreNotDoubleCounted() {
         let aggregator = UsageStatsAggregator(storageURL: storageURL)
 
-        _ = aggregator.record(makeStats(totalRequests: 10, successCount: 9, failureCount: 1, totalTokens: 1000, inputTokens: 600, outputTokens: 400))
-        _ = aggregator.record(makeStats(totalRequests: 15, successCount: 13, failureCount: 2, totalTokens: 1500, inputTokens: 900, outputTokens: 600))
-        let result = aggregator.record(makeStats(totalRequests: 20, successCount: 17, failureCount: 3, totalTokens: 2000, inputTokens: 1200, outputTokens: 800))
+        _ = aggregator.record(makeStats(totalRequests: 10, successCount: 9, failureCount: 1, totalTokens: 1000, inputTokens: 600, outputTokens: 400), source: .localProxy)
+        _ = aggregator.record(makeStats(totalRequests: 15, successCount: 13, failureCount: 2, totalTokens: 1500, inputTokens: 900, outputTokens: 600), source: .localProxy)
+        let result = aggregator.record(makeStats(totalRequests: 20, successCount: 17, failureCount: 3, totalTokens: 2000, inputTokens: 1200, outputTokens: 800), source: .localProxy)
 
         XCTAssertEqual(result.usage?.totalRequests, 20)
         XCTAssertEqual(result.usage?.successCount, 17)
@@ -56,14 +56,15 @@ final class UsageStatsAggregatorTests: XCTestCase {
         XCTAssertEqual(result.usage?.outputTokens, 800)
     }
 
-    func testProxyRestartFoldsPreviousSessionIntoBaseline() {
+    /// Fallback path for restarts Quotio did not perform (crash / external kill),
+    /// where the only signal is the counters going backwards.
+    func testUnmanagedRestartFoldsPreviousSessionIntoBaseline() {
         let aggregator = UsageStatsAggregator(storageURL: storageURL)
 
-        // First proxy session
-        _ = aggregator.record(makeStats(totalRequests: 100, successCount: 90, failureCount: 10, totalTokens: 5000, inputTokens: 3000, outputTokens: 2000))
+        _ = aggregator.record(makeStats(totalRequests: 100, successCount: 90, failureCount: 10, totalTokens: 5000, inputTokens: 3000, outputTokens: 2000), source: .localProxy)
 
-        // Proxy restarted (or CLIProxyAPI upgraded): counters start over
-        let afterRestart = aggregator.record(makeStats(totalRequests: 5, successCount: 5, failureCount: 0, totalTokens: 250, inputTokens: 150, outputTokens: 100))
+        // Proxy died and came back on its own: counters start over.
+        let afterRestart = aggregator.record(makeStats(totalRequests: 5, successCount: 5, failureCount: 0, totalTokens: 250, inputTokens: 150, outputTokens: 100), source: .localProxy)
 
         XCTAssertEqual(afterRestart.usage?.totalRequests, 105)
         XCTAssertEqual(afterRestart.usage?.successCount, 95)
@@ -77,36 +78,218 @@ final class UsageStatsAggregatorTests: XCTestCase {
     func testRestartToZeroSampleKeepsPreviousTotals() {
         let aggregator = UsageStatsAggregator(storageURL: storageURL)
 
-        _ = aggregator.record(makeStats(totalRequests: 42, successCount: 40, failureCount: 2, totalTokens: 900, inputTokens: 500, outputTokens: 400))
+        _ = aggregator.record(makeStats(totalRequests: 42, successCount: 40, failureCount: 2, totalTokens: 900, inputTokens: 500, outputTokens: 400), source: .localProxy)
 
         // Fresh proxy, no traffic yet
-        let afterRestart = aggregator.record(makeStats(totalRequests: 0, successCount: 0, failureCount: 0, totalTokens: 0, inputTokens: 0, outputTokens: 0))
+        let afterRestart = aggregator.record(makeStats(totalRequests: 0), source: .localProxy)
 
         XCTAssertEqual(afterRestart.usage?.totalRequests, 42)
         XCTAssertEqual(afterRestart.usage?.totalTokens, 900)
+    }
+
+    // MARK: - Managed lifecycle session boundary (review blocker 1)
+
+    /// Reviewer scenario 1: last poll stored 100, nine more requests complete,
+    /// then the proxy restarts and the first new sample is 1.
+    /// The final snapshot taken at teardown must make this 110, not 101.
+    func testManagedRestartFoldsFinalSnapshotTakenAtTeardown() async {
+        let aggregator = UsageStatsAggregator(storageURL: storageURL)
+        let recorder = ProxyUsageSessionRecorder(aggregator: aggregator)
+
+        _ = aggregator.record(makeStats(totalRequests: 100, successCount: 100, totalTokens: 1000), source: .localProxy)
+
+        // Nine more requests are served without an intervening poll; the
+        // shutdown snapshot is the only place they can still be observed.
+        let finalSample = makeStats(totalRequests: 109, successCount: 109, totalTokens: 1090)
+        recorder.finalSampleProvider = { finalSample }
+
+        // Managed teardown: CLIProxyManager awaits this before signalling the
+        // process, then calls proxyDidStop() from stop().
+        await recorder.proxyWillStop()
+        recorder.proxyDidStop()
+
+        let afterRestart = aggregator.record(makeStats(totalRequests: 1, successCount: 1, totalTokens: 10), source: .localProxy)
+
+        XCTAssertEqual(afterRestart.usage?.totalRequests, 110)
+        XCTAssertEqual(afterRestart.usage?.successCount, 110)
+        XCTAssertEqual(afterRestart.usage?.totalTokens, 1100)
+    }
+
+    /// Reviewer scenario 2: last poll stored 5, and the restarted proxy is
+    /// already at 10 by the next poll, so no counter decrease is ever observed.
+    /// The explicit session boundary must keep the first five.
+    func testManagedRestartRetainsTotalsWhenNoDecreaseIsEverObserved() async {
+        let aggregator = UsageStatsAggregator(storageURL: storageURL)
+        let recorder = ProxyUsageSessionRecorder(aggregator: aggregator)
+
+        _ = aggregator.record(makeStats(totalRequests: 5, successCount: 5, totalTokens: 50), source: .localProxy)
+
+        // Proxy already unreachable at teardown: no final sample available.
+        recorder.finalSampleProvider = { nil }
+        await recorder.proxyWillStop()
+        recorder.proxyDidStop()
+
+        // Next poll only ever sees a value larger than the previous one.
+        let afterRestart = aggregator.record(makeStats(totalRequests: 10, successCount: 10, totalTokens: 100), source: .localProxy)
+
+        XCTAssertEqual(afterRestart.usage?.totalRequests, 15)
+        XCTAssertEqual(afterRestart.usage?.successCount, 15)
+        XCTAssertEqual(afterRestart.usage?.totalTokens, 150)
+    }
+
+    /// stop() calls proxyDidStop() on every teardown, including on paths that
+    /// already awaited proxyWillStop(). Folding must happen exactly once.
+    func testSessionBoundaryIsIdempotent() async {
+        let aggregator = UsageStatsAggregator(storageURL: storageURL)
+        let recorder = ProxyUsageSessionRecorder(aggregator: aggregator)
+
+        _ = aggregator.record(makeStats(totalRequests: 30, totalTokens: 300), source: .localProxy)
+
+        recorder.finalSampleProvider = { nil }
+        await recorder.proxyWillStop()
+        recorder.proxyDidStop()
+        recorder.proxyDidStop()
+        await recorder.proxyWillStop()
+
+        XCTAssertEqual(aggregator.restoredStats(for: .localProxy)?.usage?.totalRequests, 30)
+        XCTAssertEqual(aggregator.restoredStats(for: .localProxy)?.usage?.totalTokens, 300)
+    }
+
+    /// The final snapshot is fetched across an await, so the auto-refresh loop
+    /// can record a newer sample in between. Merging must not double count, and
+    /// must not discard whichever sample is newer.
+    func testConcurrentPollDuringFinalSnapshotIsMergedNotDoubleCounted() async {
+        let aggregator = UsageStatsAggregator(storageURL: storageURL)
+        let recorder = ProxyUsageSessionRecorder(aggregator: aggregator)
+
+        _ = aggregator.record(makeStats(totalRequests: 100, totalTokens: 1000), source: .localProxy)
+
+        let concurrentSample = makeStats(totalRequests: 112, totalTokens: 1120)
+        let shutdownSample = makeStats(totalRequests: 109, totalTokens: 1090)
+
+        // While the final fetch is suspended, a scheduled refresh records 112;
+        // the shutdown fetch itself observed a slightly older value.
+        recorder.finalSampleProvider = { [aggregator] in
+            _ = aggregator.record(concurrentSample, source: .localProxy)
+            return shutdownSample
+        }
+
+        await recorder.proxyWillStop()
+
+        XCTAssertEqual(aggregator.restoredStats(for: .localProxy)?.usage?.totalRequests, 112)
+        XCTAssertEqual(aggregator.restoredStats(for: .localProxy)?.usage?.totalTokens, 1120)
+    }
+
+    // MARK: - Source scoping (review blocker 2)
+
+    func testLocalAndRemoteTotalsAreNeverMerged() {
+        let aggregator = UsageStatsAggregator(storageURL: storageURL)
+        let remote = UsageStatsSource.remote(endpoint: "https://proxy.example.com:8317/v0/management")
+
+        let local = aggregator.record(makeStats(totalRequests: 100, totalTokens: 1000), source: .localProxy)
+        XCTAssertEqual(local.usage?.totalRequests, 100)
+
+        // Switching to a remote endpoint reporting 20 must show 20, not 120.
+        let afterSwitch = aggregator.record(makeStats(totalRequests: 20, totalTokens: 200), source: remote)
+        XCTAssertEqual(afterSwitch.usage?.totalRequests, 20)
+        XCTAssertEqual(afterSwitch.usage?.totalTokens, 200)
+
+        // Switching back to the still-running local proxy must show 100, not 200.
+        let backToLocal = aggregator.record(makeStats(totalRequests: 100, totalTokens: 1000), source: .localProxy)
+        XCTAssertEqual(backToLocal.usage?.totalRequests, 100)
+        XCTAssertEqual(backToLocal.usage?.totalTokens, 1000)
+    }
+
+    func testDistinctRemoteServersKeepSeparateTotals() {
+        let aggregator = UsageStatsAggregator(storageURL: storageURL)
+        let first = UsageStatsSource.remote(endpoint: "https://a.example.com/v0/management")
+        let second = UsageStatsSource.remote(endpoint: "https://b.example.com/v0/management")
+
+        _ = aggregator.record(makeStats(totalRequests: 500), source: first)
+        let onSecond = aggregator.record(makeStats(totalRequests: 7), source: second)
+
+        XCTAssertEqual(onSecond.usage?.totalRequests, 7)
+        XCTAssertEqual(aggregator.restoredStats(for: first)?.usage?.totalRequests, 500)
+    }
+
+    func testMixedSourceTotalsStaySeparateAcrossRelaunch() {
+        let remote = UsageStatsSource.remote(endpoint: "https://proxy.example.com/v0/management")
+
+        let first = UsageStatsAggregator(storageURL: storageURL)
+        _ = first.record(makeStats(totalRequests: 100), source: .localProxy)
+        _ = first.record(makeStats(totalRequests: 20), source: remote)
+
+        let relaunched = UsageStatsAggregator(storageURL: storageURL)
+        XCTAssertEqual(relaunched.restoredStats(for: .localProxy)?.usage?.totalRequests, 100)
+        XCTAssertEqual(relaunched.restoredStats(for: remote)?.usage?.totalRequests, 20)
+    }
+
+    /// The proxy lifecycle only ever closes the local proxy's session; a remote
+    /// server's bucket must be untouched by a local stop/restart.
+    func testLifecycleBoundaryOnlyClosesLocalProxySession() async {
+        let aggregator = UsageStatsAggregator(storageURL: storageURL)
+        let recorder = ProxyUsageSessionRecorder(aggregator: aggregator)
+        let remote = UsageStatsSource.remote(endpoint: "https://proxy.example.com/v0/management")
+
+        _ = aggregator.record(makeStats(totalRequests: 8), source: remote)
+
+        recorder.finalSampleProvider = { nil }
+        await recorder.proxyWillStop()
+
+        XCTAssertEqual(aggregator.store.state(for: remote).lastSample.totalRequests, 8)
+        XCTAssertEqual(aggregator.store.state(for: remote).baseline.totalRequests, 0)
+    }
+
+    func testRemoteEndpointKeyIsNormalized() {
+        XCTAssertEqual(
+            UsageStatsSource.remote(endpoint: " https://Proxy.Example.com/v0/management ").storageKey,
+            UsageStatsSource.remote(endpoint: "https://proxy.example.com/v0/management").storageKey
+        )
+        XCTAssertNotEqual(
+            UsageStatsSource.remote(endpoint: "https://proxy.example.com/v0/management").storageKey,
+            UsageStatsSource.localProxy.storageKey
+        )
     }
 
     // MARK: - Persistence across app relaunch
 
     func testTotalsSurviveAppRelaunch() {
         let first = UsageStatsAggregator(storageURL: storageURL)
-        _ = first.record(makeStats(totalRequests: 100, successCount: 90, failureCount: 10, totalTokens: 5000, inputTokens: 3000, outputTokens: 2000))
+        _ = first.record(makeStats(totalRequests: 100, successCount: 90, failureCount: 10, totalTokens: 5000, inputTokens: 3000, outputTokens: 2000), source: .localProxy)
 
         // Simulate app relaunch: new aggregator instance reads the same file
         let second = UsageStatsAggregator(storageURL: storageURL)
-        let restored = second.restoredStats()
+        let restored = second.restoredStats(for: .localProxy)
         XCTAssertEqual(restored?.usage?.totalRequests, 100)
         XCTAssertEqual(restored?.usage?.totalTokens, 5000)
 
         // Proxy also restarted while the app was closed: counters reset
-        let afterRestart = second.record(makeStats(totalRequests: 3, successCount: 3, failureCount: 0, totalTokens: 90, inputTokens: 60, outputTokens: 30))
+        let afterRestart = second.record(makeStats(totalRequests: 3, successCount: 3, failureCount: 0, totalTokens: 90, inputTokens: 60, outputTokens: 30), source: .localProxy)
         XCTAssertEqual(afterRestart.usage?.totalRequests, 103)
         XCTAssertEqual(afterRestart.usage?.totalTokens, 5090)
     }
 
     func testRestoredStatsIsNilForFreshInstall() {
         let aggregator = UsageStatsAggregator(storageURL: storageURL)
-        XCTAssertNil(aggregator.restoredStats())
+        XCTAssertNil(aggregator.restoredStats(for: .localProxy))
+    }
+
+    func testVersion1FileMigratesOntoLocalProxy() throws {
+        let legacy = """
+        {"version":1,\
+        "baseline":{"totalRequests":40,"successCount":38,"failureCount":2,"totalTokens":400,"inputTokens":250,"outputTokens":150},\
+        "lastSample":{"totalRequests":10,"successCount":10,"failureCount":0,"totalTokens":100,"inputTokens":60,"outputTokens":40}}
+        """
+        try Data(legacy.utf8).write(to: storageURL)
+
+        let aggregator = UsageStatsAggregator(storageURL: storageURL)
+        XCTAssertEqual(aggregator.restoredStats(for: .localProxy)?.usage?.totalRequests, 50)
+        XCTAssertEqual(aggregator.restoredStats(for: .localProxy)?.usage?.totalTokens, 500)
+
+        // The migrated file is rewritten in the current format.
+        let reloaded = UsageStatsAggregator(storageURL: storageURL)
+        XCTAssertEqual(reloaded.store.version, UsageTotalsStore.currentVersion)
+        XCTAssertEqual(reloaded.restoredStats(for: .localProxy)?.usage?.totalRequests, 50)
     }
 
     // MARK: - Bounded storage
@@ -115,13 +298,13 @@ final class UsageStatsAggregatorTests: XCTestCase {
         let aggregator = UsageStatsAggregator(storageURL: storageURL)
 
         for i in 1...500 {
-            _ = aggregator.record(makeStats(totalRequests: i, successCount: i, failureCount: 0, totalTokens: i * 100, inputTokens: i * 60, outputTokens: i * 40))
+            _ = aggregator.record(makeStats(totalRequests: i, successCount: i, failureCount: 0, totalTokens: i * 100, inputTokens: i * 60, outputTokens: i * 40), source: .localProxy)
         }
 
         let data = try Data(contentsOf: storageURL)
         // Fixed-size aggregate counters only, never per-request entries
         let decoded = try JSONDecoder().decode(UsageTotalsStore.self, from: data)
-        XCTAssertEqual(decoded.lastSample.totalRequests, 500)
+        XCTAssertEqual(decoded.state(for: .localProxy).lastSample.totalRequests, 500)
         XCTAssertLessThan(data.count, 2048, "usage-stats.json must stay a small fixed-size aggregate file")
     }
 
@@ -131,10 +314,10 @@ final class UsageStatsAggregatorTests: XCTestCase {
         try Data("not json {{{".utf8).write(to: storageURL)
 
         let aggregator = UsageStatsAggregator(storageURL: storageURL)
-        XCTAssertNil(aggregator.restoredStats())
+        XCTAssertNil(aggregator.restoredStats(for: .localProxy))
 
         // Aggregation still works after recovery
-        let result = aggregator.record(makeStats(totalRequests: 7, successCount: 7, failureCount: 0, totalTokens: 70, inputTokens: 40, outputTokens: 30))
+        let result = aggregator.record(makeStats(totalRequests: 7, successCount: 7, failureCount: 0, totalTokens: 70, inputTokens: 40, outputTokens: 30), source: .localProxy)
         XCTAssertEqual(result.usage?.totalRequests, 7)
     }
 
@@ -142,12 +325,16 @@ final class UsageStatsAggregatorTests: XCTestCase {
 
     func testResetClearsTotalsAndPersists() {
         let aggregator = UsageStatsAggregator(storageURL: storageURL)
-        _ = aggregator.record(makeStats(totalRequests: 12, successCount: 12, failureCount: 0, totalTokens: 300, inputTokens: 200, outputTokens: 100))
+        let remote = UsageStatsSource.remote(endpoint: "https://proxy.example.com/v0/management")
+        _ = aggregator.record(makeStats(totalRequests: 12, successCount: 12, failureCount: 0, totalTokens: 300, inputTokens: 200, outputTokens: 100), source: .localProxy)
+        _ = aggregator.record(makeStats(totalRequests: 4), source: remote)
 
         aggregator.reset()
-        XCTAssertNil(aggregator.restoredStats())
+        XCTAssertNil(aggregator.restoredStats(for: .localProxy))
+        XCTAssertNil(aggregator.restoredStats(for: remote))
 
         let relaunched = UsageStatsAggregator(storageURL: storageURL)
-        XCTAssertNil(relaunched.restoredStats())
+        XCTAssertNil(relaunched.restoredStats(for: .localProxy))
+        XCTAssertNil(relaunched.restoredStats(for: remote))
     }
 }


### PR DESCRIPTION
## Problem

Every proxy restart — including the restart that happens during a CLIProxyAPI upgrade — resets the dashboard traffic statistics (requests, tokens, success rate) to zero, and there is no way to retain them.

## Root cause

The dashboard KPI cards read `QuotaViewModel.usageStats`, which is fetched verbatim from CLIProxyAPI's `GET /v0/management/usage` endpoint (`ManagementAPIClient.fetchUsageStats()`). Those counters live **in memory inside the CLIProxyAPI process**, so any proxy restart or binary upgrade starts them over from zero. Quotio never persisted them.

(`RequestTracker` / `request-history.json` is a separate per-request log capped at 50 entries and does not back these KPIs.)

## Design

`UsageStatsAggregator` accumulates the proxy's counters on the Quotio side and persists them. Correctness rests on an **explicit session boundary driven by the proxy lifecycle**, not on inferring a restart from a counter decrease.

### 1. Session boundary from the managed lifecycle

`CLIProxyManager` owns a `ProxyUsageSessionRecorder` and drives it from every path on which it tears the managed proxy down:

| Lifecycle path | `CLIProxyManager.swift` | Hook |
| --- | --- | --- |
| `stop()` — user toggle, mode switch (`QuotaViewModel.stopProxy()`, `SettingsScreen`) | `stop()` | `proxyDidStop()` (synchronous path, no final fetch possible) |
| `stopAndWait()` — health recovery (`QuotaViewModel.attemptProxyRecovery()`) | `stopAndWait()` | `await proxyWillStop()` |
| Config-change restart — port, host, allow-remote, logging, routing strategy, proxy URL | `restartProxyIfRunning()` | `await proxyWillStop()` then `stop()` |
| **Upgrade** — `performManagedUpgrade(to:)` → promote new binary | `promote(version:source:)` | `await proxyWillStop()` then `stop()` |
| Rollback | `rollback()` | `await proxyWillStop()` then `stop()` |

`proxyWillStop()` takes a **final `/v0/management/usage` snapshot** from the process that is about to go down (the fetch closure is installed by `QuotaViewModel`, which owns the management client), folds it, and closes the session: the session's counters move into the persistent baseline and the live sample is zeroed. The next process may then start from zero — or from any value at all — without discarding what the previous one served. `proxyDidStop()` closes the session without a fetch and is idempotent, so paths that run both still fold exactly once.

### 2. Per-proxy scoping

Persisted state is keyed by `UsageStatsSource`: `.localProxy` for the managed proxy, `.remote(endpoint:)` keyed on the normalized management base URL. Local totals and each remote server's totals are separate buckets that are never added together, so switching modes — or changing the configured remote server — no longer mixes unrelated counters, on screen or on disk. `QuotaViewModel.initialize()` re-scopes the displayed totals on every mode switch. Version 1 files migrate onto the local bucket.

### 3. Counter-decrease fallback

The original "new sample is lower than the last one" check is retained, but **only** as a fallback for restarts Quotio does not perform. It is not what the managed paths depend on.

## Honest limitation

Retention is exact for restarts Quotio performs, and best-effort otherwise:

- **Managed stop / config restart / upgrade / rollback / health recovery** — exact. A final snapshot is folded before the process is signalled, so requests served between the last poll and the shutdown are counted.
- **`stop()` from the synchronous path** — the session is closed correctly, but no final snapshot is fetched, so requests served since the last poll (up to one refresh interval) are not counted.
- **Proxy dies without Quotio's involvement** — crash, external `kill`, machine sleep or power loss, or `terminateProxyOnShutdown()` at app quit. Quotio gets no chance to snapshot, so whatever the proxy served since the last poll is genuinely unrecoverable. The counter-decrease fallback preserves everything up to that last poll; it cannot recover what came after. This PR does not claim perfect retention for these cases.

## Retention / storage behavior

- The persisted file holds **fixed-size aggregate counters only** (no per-request entries), so it never grows with traffic — no rotation needed (a test asserts it stays under 2 KB after 500 samples). One small entry per proxy identity.
- A corrupt/unreadable file is discarded and the aggregator starts fresh, mirroring `RequestTracker`'s recovery behavior.
- Fresh installs behave exactly as before (`restoredStats(for:)` returns nil until traffic exists); the 404 fallback for older CLIProxyAPI versions without the usage endpoint is unchanged. No UI changes.
- `reset()` clears every source's totals (persisted immediately).

## Concurrency

Everything runs on `@MainActor`. Both suspension points are handled explicitly:

- `refreshData()` resolves the `UsageStatsSource` **together with** the `apiClient` it belongs to, before the awaits, so a mode switch mid-refresh cannot file one proxy's counters under another.
- `proxyWillStop()` awaits the final fetch, then re-reads the stored sample and merges component-wise (counters only grow within a session), so a poll that lands during the suspension is neither lost nor double-counted.
- In `stopAndWait()`, `promote()`, `rollback()` and `restartProxyIfRunning()`, the hook is awaited **before** `proxyStatus.running` / process state is captured, never after.

## Tests

`QuotioTests/UsageStatsAggregatorTests.swift` — both reviewer scenarios are covered by name:

- `testManagedRestartFoldsFinalSnapshotTakenAtTeardown` — last poll 100, nine more requests, managed restart, first new sample 1 → **110**
- `testManagedRestartRetainsTotalsWhenNoDecreaseIsEverObserved` — last poll 5, restarted proxy already at 10 by the next poll (no decrease ever observed) → **15**
- `testSessionBoundaryIsIdempotent` — `proxyWillStop()` + repeated `proxyDidStop()` fold exactly once
- `testConcurrentPollDuringFinalSnapshotIsMergedNotDoubleCounted` — refresh landing during the shutdown fetch
- `testLocalAndRemoteTotalsAreNeverMerged` — local 100 → remote 20 shows **20**; back to local 100 shows **100**
- `testDistinctRemoteServersKeepSeparateTotals`, `testMixedSourceTotalsStaySeparateAcrossRelaunch`, `testLifecycleBoundaryOnlyClosesLocalProxySession`, `testRemoteEndpointKeyIsNormalized`
- `testVersion1FileMigratesOntoLocalProxy`
- plus the original coverage: unmanaged-restart fallback, monotonic samples, app relaunch, bounded file, corrupt file, reset

## Verification

- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build` — **BUILD SUCCEEDED**
- `xcodebuild test -project Quotio.xcodeproj -scheme Quotio -destination 'platform=macOS'` — **TEST SUCCEEDED**, 84 passed / 0 failed

Closes #359
