### PR TITLE
feat(providers): custom HTTP headers for OpenAI/Claude/Codex-compatible custom providers

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -4200,6 +4200,64 @@
         }
       }
     },
+    "customProviders.error.headerNameDuplicate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duplicate custom header names are not allowed"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les noms d'en-têtes personnalisés en double ne sont pas autorisés"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không được phép trùng tên header tùy chỉnh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义标头名称不能重复"
+          }
+        }
+      }
+    },
+    "customProviders.error.headerNameInvalid" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom header names may only contain letters, digits, and the characters !#$%&'*+-.^_`|~"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les noms d'en-têtes personnalisés ne peuvent contenir que des lettres, des chiffres et les caractères !#$%&'*+-.^_`|~"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tên header tùy chỉnh chỉ được chứa chữ cái, chữ số và các ký tự !#$%&'*+-.^_`|~"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义标头名称只能包含字母、数字以及字符 !#$%&'*+-.^_`|~"
+          }
+        }
+      }
+    },
     "customProviders.fetchModels" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -4258,6 +4258,35 @@
         }
       }
     },
+    "customProviders.error.headerValueInvalid" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom header values must be printable ASCII, without line breaks or control characters"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les valeurs d'en-têtes personnalisés doivent être en ASCII imprimable, sans saut de ligne ni caractère de contrôle"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giá trị header tùy chỉnh phải là ký tự ASCII in được, không có ký tự xuống dòng hoặc ký tự điều khiển"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义标头值必须为可打印的 ASCII 字符，不能包含换行符或控制字符"
+          }
+        }
+      }
+    },
     "customProviders.fetchModels" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Models/CustomProviderModels.swift
+++ b/Quotio/Models/CustomProviderModels.swift
@@ -152,12 +152,16 @@ enum CustomProviderType: String, CaseIterable, Codable, Identifiable, Sendable {
         }
     }
 
-    /// Whether this provider type supports custom headers
+    /// Whether this provider type supports custom headers.
+    /// CLIProxyAPI accepts a `headers` map for `openai-compatibility` providers (provider level)
+    /// and for `claude-api-key`, `gemini-api-key`, and `codex-api-key` entries (per key).
+    /// GLM and ClinePass are excluded: `glm-api-key` has no documented headers support,
+    /// and ClinePass is a managed service with fixed authentication.
     var supportsCustomHeaders: Bool {
         switch self {
-        case .geminiCompatibility:
+        case .openaiCompatibility, .claudeCompatibility, .geminiCompatibility, .codexCompatibility:
             return true
-        case .openaiCompatibility, .claudeCompatibility, .codexCompatibility, .glmCompatibility, .clinePass:
+        case .glmCompatibility, .clinePass:
             return false
         }
     }
@@ -223,20 +227,30 @@ struct ModelMapping: Codable, Identifiable, Hashable, Sendable {
 
 // MARK: - Custom Header
 
-/// A custom HTTP header for Gemini-compatible providers
+/// A custom HTTP header sent with requests to the upstream provider
 struct CustomHeader: Codable, Identifiable, Hashable, Sendable {
     let id: UUID
     var key: String
     var value: String
-    
+
     init(id: UUID = UUID(), key: String, value: String) {
         self.id = id
         self.key = key
         self.value = value
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case id, key, value
+    }
+
+    /// Non-alphanumeric characters allowed in an HTTP header field name (RFC 7230 token)
+    private static let validNameSpecials = Set("!#$%&'*+-.^_`|~")
+
+    /// Whether the given string is a valid HTTP header field name (RFC 7230 token: ASCII letters, digits, and select punctuation)
+    static func isValidName(_ name: String) -> Bool {
+        !name.isEmpty && name.allSatisfy { character in
+            character.isASCII && (character.isLetter || character.isNumber || validNameSpecials.contains(character))
+        }
     }
 }
 
@@ -251,7 +265,7 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
     var prefix: String?
     var apiKeys: [CustomAPIKeyEntry]
     var models: [ModelMapping]
-    var headers: [CustomHeader]  // Only used for Gemini-compatible
+    var headers: [CustomHeader]  // Custom HTTP headers (types where supportsCustomHeaders is true)
     var limitToSelectedModels: Bool
     var isEnabled: Bool
     var createdAt: Date
@@ -363,7 +377,25 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
         if type == .clinePass, models.isEmpty {
             errors.append("clinepass.error.modelsRequired".localizedStatic())
         }
-        
+
+        if type.supportsCustomHeaders {
+            var seenHeaderNames = Set<String>()
+            var reportedInvalidName = false
+            var reportedDuplicateName = false
+            for header in headers {
+                let name = header.key.trimmingCharacters(in: .whitespaces)
+                guard !name.isEmpty else { continue }
+                if !CustomHeader.isValidName(name), !reportedInvalidName {
+                    errors.append("customProviders.error.headerNameInvalid".localizedStatic())
+                    reportedInvalidName = true
+                }
+                if !seenHeaderNames.insert(name.lowercased()).inserted, !reportedDuplicateName {
+                    errors.append("customProviders.error.headerNameDuplicate".localizedStatic())
+                    reportedDuplicateName = true
+                }
+            }
+        }
+
         return errors
     }
     
@@ -394,6 +426,35 @@ extension CustomProvider {
         }
     }
 
+    /// Headers that are safe to emit into the YAML config:
+    /// non-empty, RFC 7230 token names only (invalid names are rejected by validation)
+    private var emittableHeaders: [CustomHeader] {
+        headers.compactMap { header in
+            let name = header.key.trimmingCharacters(in: .whitespaces)
+            guard CustomHeader.isValidName(name) else { return nil }
+            return CustomHeader(id: header.id, key: name, value: header.value)
+        }
+    }
+
+    /// Render the custom headers map at the given indentation level (in spaces)
+    private func headersYAML(indent: Int) -> String {
+        let entries = emittableHeaders
+        guard !entries.isEmpty else { return "" }
+
+        let pad = String(repeating: " ", count: indent)
+        var yaml = "\(pad)headers:\n"
+        for header in entries {
+            yaml += "\(pad)  \"\(Self.escapedYAMLString(header.key))\": \"\(Self.escapedYAMLString(header.value))\"\n"
+        }
+        return yaml
+    }
+
+    private static func escapedYAMLString(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
     private func generateOpenAICompatibilityYAML() -> String {
         var yaml = "  - name: \"\(escapedName)\"\n"
         yaml += "    base-url: \"\(baseURL)\"\n"
@@ -401,6 +462,9 @@ extension CustomProvider {
         if let prefix = prefix, !prefix.isEmpty {
             yaml += "    prefix: \"\(prefix)\"\n"
         }
+
+        // Provider-level custom headers (CLIProxyAPI OpenAICompatibility.Headers)
+        yaml += headersYAML(indent: 4)
 
         if !apiKeys.isEmpty {
             yaml += "    api-key-entries:\n"
@@ -437,10 +501,13 @@ extension CustomProvider {
                 yaml += "    prefix: \"\(prefix)\"\n"
             }
 
+            // Per-key custom headers (CLIProxyAPI ClaudeKey.Headers)
+            yaml += headersYAML(indent: 4)
+
             if let proxyURL = key.proxyURL, !proxyURL.isEmpty {
                 yaml += "    proxy-url: \"\(proxyURL)\"\n"
             }
-            
+
             if !models.isEmpty {
                 yaml += "    models:\n"
                 for model in models {
@@ -451,7 +518,7 @@ extension CustomProvider {
         }
         return yaml
     }
-    
+
     private func generateGeminiCompatibilityYAML() -> String {
         var yaml = ""
         for key in apiKeys {
@@ -466,20 +533,16 @@ extension CustomProvider {
                 yaml += "    prefix: \"\(prefix)\"\n"
             }
 
-            if !headers.isEmpty {
-                yaml += "    headers:\n"
-                for header in headers {
-                    yaml += "      \(header.key): \"\(header.value)\"\n"
-                }
-            }
-            
+            // Per-key custom headers (CLIProxyAPI GeminiKey.Headers)
+            yaml += headersYAML(indent: 4)
+
             if let proxyURL = key.proxyURL, !proxyURL.isEmpty {
                 yaml += "    proxy-url: \"\(proxyURL)\"\n"
             }
         }
         return yaml
     }
-    
+
     private func generateCodexCompatibilityYAML() -> String {
         var yaml = ""
         for key in apiKeys {
@@ -489,6 +552,9 @@ extension CustomProvider {
             if let prefix = prefix, !prefix.isEmpty {
                 yaml += "    prefix: \"\(prefix)\"\n"
             }
+
+            // Per-key custom headers (CLIProxyAPI CodexKey.Headers)
+            yaml += headersYAML(indent: 4)
 
             if let proxyURL = key.proxyURL, !proxyURL.isEmpty {
                 yaml += "    proxy-url: \"\(proxyURL)\"\n"

--- a/Quotio/Models/CustomProviderModels.swift
+++ b/Quotio/Models/CustomProviderModels.swift
@@ -246,10 +246,91 @@ struct CustomHeader: Codable, Identifiable, Hashable, Sendable {
     /// Non-alphanumeric characters allowed in an HTTP header field name (RFC 7230 token)
     private static let validNameSpecials = Set("!#$%&'*+-.^_`|~")
 
+    /// RFC 7230 optional whitespace: the only characters stripped when normalizing.
+    /// Deliberately narrower than `CharacterSet.whitespaces` (which also covers
+    /// U+00A0 and friends) so normalization never silently rewrites a value that
+    /// validation would otherwise reject.
+    private static let optionalWhitespace = CharacterSet(charactersIn: " \t")
+
     /// Whether the given string is a valid HTTP header field name (RFC 7230 token: ASCII letters, digits, and select punctuation)
     static func isValidName(_ name: String) -> Bool {
         !name.isEmpty && name.allSatisfy { character in
             character.isASCII && (character.isLetter || character.isNumber || validNameSpecials.contains(character))
+        }
+    }
+
+    /// Whether the given string is a valid HTTP header field value (RFC 7230 `field-value`:
+    /// horizontal tab, space, and visible US-ASCII).
+    ///
+    /// CR/LF and other control characters must be rejected rather than escaped: CFNetwork
+    /// either drops such a header or folds it into the previous one, Go's outbound HTTP
+    /// stack refuses to send it, and a literal newline inside a YAML scalar is folded into
+    /// a space when CLIProxyAPI parses the config back — silently changing the secret.
+    /// Non-ASCII is rejected because its wire encoding is not interoperable (RFC 9110 §5.5).
+    static func isValidValue(_ value: String) -> Bool {
+        value.unicodeScalars.allSatisfy { scalar in
+            scalar.value == 0x09 || (scalar.value >= 0x20 && scalar.value <= 0x7E)
+        }
+    }
+
+    /// This header in canonical form: surrounding RFC 7230 optional whitespace removed
+    /// from both the name and the value.
+    var normalized: CustomHeader {
+        CustomHeader(
+            id: id,
+            key: key.trimmingCharacters(in: Self.optionalWhitespace),
+            value: value.trimmingCharacters(in: Self.optionalWhitespace)
+        )
+    }
+
+    /// The canonical representation of an editor-entered header list: every entry
+    /// normalized, entries without a name dropped.
+    ///
+    /// This is the single form that may be persisted, validated, emitted into the
+    /// CLIProxyAPI config, or attached to a `URLRequest` — see `CustomProvider.effectiveHeaders`.
+    static func canonicalized(_ headers: [CustomHeader]) -> [CustomHeader] {
+        headers.map(\.normalized).filter { !$0.key.isEmpty }
+    }
+
+    /// Validation errors for a canonical header list (as produced by `canonicalized(_:)`).
+    /// Each problem is reported at most once so the alert stays readable.
+    static func validationErrors(in headers: [CustomHeader]) -> [String] {
+        var errors: [String] = []
+        var seenNames = Set<String>()
+        var reportedInvalidName = false
+        var reportedInvalidValue = false
+        var reportedDuplicateName = false
+
+        for header in headers {
+            if !isValidName(header.key), !reportedInvalidName {
+                errors.append("customProviders.error.headerNameInvalid".localizedStatic())
+                reportedInvalidName = true
+            }
+            if !isValidValue(header.value), !reportedInvalidValue {
+                errors.append("customProviders.error.headerValueInvalid".localizedStatic())
+                reportedInvalidValue = true
+            }
+            if !seenNames.insert(header.key.lowercased()).inserted, !reportedDuplicateName {
+                errors.append("customProviders.error.headerNameDuplicate".localizedStatic())
+                reportedDuplicateName = true
+            }
+        }
+
+        return errors
+    }
+}
+
+extension URLRequest {
+    /// Attach a canonical custom header list to this request.
+    ///
+    /// Both outgoing request paths in the provider editor (Fetch Models and the mandatory
+    /// pre-save connection test) go through here, so neither can drift from the header set
+    /// that is validated, persisted, and written to the CLIProxyAPI config.
+    /// - Parameter headers: headers already normalized via `CustomHeader.canonicalized(_:)`
+    ///   or read from `CustomProvider.effectiveHeaders`.
+    mutating func applyCustomHeaders(_ headers: [CustomHeader]) {
+        for header in headers {
+            setValue(header.value, forHTTPHeaderField: header.key)
         }
     }
 }
@@ -379,21 +460,9 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
         }
 
         if type.supportsCustomHeaders {
-            var seenHeaderNames = Set<String>()
-            var reportedInvalidName = false
-            var reportedDuplicateName = false
-            for header in headers {
-                let name = header.key.trimmingCharacters(in: .whitespaces)
-                guard !name.isEmpty else { continue }
-                if !CustomHeader.isValidName(name), !reportedInvalidName {
-                    errors.append("customProviders.error.headerNameInvalid".localizedStatic())
-                    reportedInvalidName = true
-                }
-                if !seenHeaderNames.insert(name.lowercased()).inserted, !reportedDuplicateName {
-                    errors.append("customProviders.error.headerNameDuplicate".localizedStatic())
-                    reportedDuplicateName = true
-                }
-            }
+            // Validate the canonical form, not the raw form: normalization happens once
+            // and every consumer (YAML, model fetch, connection test) sees that same set.
+            errors.append(contentsOf: CustomHeader.validationErrors(in: CustomHeader.canonicalized(headers)))
         }
 
         return errors
@@ -402,6 +471,23 @@ struct CustomProvider: Codable, Identifiable, Hashable, Sendable {
     /// Check if provider is valid
     var isValid: Bool {
         validate().isEmpty
+    }
+
+    /// The one representation of this provider's custom headers that any consumer may use:
+    /// the generated CLIProxyAPI YAML, the pre-save connection test, and the Fetch Models
+    /// request all read this property, so the editor, the outgoing requests, the persisted
+    /// provider, and the proxy config always agree on the exact header set.
+    ///
+    /// Entries are canonicalized (surrounding optional whitespace stripped, unnamed entries
+    /// dropped) and then filtered to wire-safe name/value pairs. The filter is defence in
+    /// depth: `validate()` refuses to save anything it would drop, but a provider decoded
+    /// from storage that predates that validation must still not produce a corrupt request
+    /// or an invalid config.
+    var effectiveHeaders: [CustomHeader] {
+        guard type.supportsCustomHeaders else { return [] }
+        return CustomHeader.canonicalized(headers).filter {
+            CustomHeader.isValidName($0.key) && CustomHeader.isValidValue($0.value)
+        }
     }
 }
 
@@ -426,19 +512,9 @@ extension CustomProvider {
         }
     }
 
-    /// Headers that are safe to emit into the YAML config:
-    /// non-empty, RFC 7230 token names only (invalid names are rejected by validation)
-    private var emittableHeaders: [CustomHeader] {
-        headers.compactMap { header in
-            let name = header.key.trimmingCharacters(in: .whitespaces)
-            guard CustomHeader.isValidName(name) else { return nil }
-            return CustomHeader(id: header.id, key: name, value: header.value)
-        }
-    }
-
     /// Render the custom headers map at the given indentation level (in spaces)
     private func headersYAML(indent: Int) -> String {
-        let entries = emittableHeaders
+        let entries = effectiveHeaders
         guard !entries.isEmpty else { return "" }
 
         let pad = String(repeating: " ", count: indent)
@@ -449,10 +525,46 @@ extension CustomProvider {
         return yaml
     }
 
-    private static func escapedYAMLString(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
+    /// Escape a string for a YAML double-quoted scalar.
+    ///
+    /// Covers the complete double-quoted escape set rather than just `\` and `"`, so the
+    /// emitted config round-trips to the exact input string. Without this a literal CR/LF
+    /// is folded into a space by the YAML parser (silently changing a secret) and other C0
+    /// controls make the generated CLIProxyAPI config unparseable. Header names and values
+    /// carrying such characters are already rejected before persistence; this keeps the
+    /// emitter correct on its own for any string it is handed.
+    static func escapedYAMLString(_ value: String) -> String {
+        var escaped = ""
+        escaped.reserveCapacity(value.unicodeScalars.count)
+
+        for scalar in value.unicodeScalars {
+            switch scalar {
+            case "\\": escaped += "\\\\"
+            case "\"": escaped += "\\\""
+            case "\u{00}": escaped += "\\0"
+            case "\u{07}": escaped += "\\a"
+            case "\u{08}": escaped += "\\b"
+            case "\u{09}": escaped += "\\t"
+            case "\u{0A}": escaped += "\\n"
+            case "\u{0B}": escaped += "\\v"
+            case "\u{0C}": escaped += "\\f"
+            case "\u{0D}": escaped += "\\r"
+            case "\u{1B}": escaped += "\\e"
+            case "\u{85}": escaped += "\\N"
+            case "\u{A0}": escaped += "\\_"
+            case "\u{2028}": escaped += "\\L"
+            case "\u{2029}": escaped += "\\P"
+            default:
+                // Remaining C0/C1 controls and DEL have no dedicated escape.
+                if scalar.value < 0x20 || scalar.value == 0x7F || (0x80...0x9F).contains(scalar.value) {
+                    escaped += String(format: "\\x%02X", scalar.value)
+                } else {
+                    escaped.unicodeScalars.append(scalar)
+                }
+            }
+        }
+
+        return escaped
     }
 
     private func generateOpenAICompatibilityYAML() -> String {

--- a/Quotio/Services/CustomProviderService.swift
+++ b/Quotio/Services/CustomProviderService.swift
@@ -188,8 +188,9 @@ final class CustomProviderService {
         try content.write(toFile: configPath, atomically: true, encoding: .utf8)
     }
     
-    /// Remove custom provider sections from config content
-    private func removeCustomProviderSections(from content: String) -> String {
+    /// Remove custom provider sections from config content.
+    /// Internal (not private) so unit tests can verify strip/re-append round-trips.
+    func removeCustomProviderSections(from content: String) -> String {
         var result = content
         
         // Derive and deduplicate the CLIProxyAPI section keys managed by custom providers.

--- a/Quotio/Views/Components/CustomProviderSheet.swift
+++ b/Quotio/Views/Components/CustomProviderSheet.swift
@@ -862,10 +862,12 @@ struct CustomProviderSheet: View {
         }
         
         // Add custom headers
-        for header in headers {
-            request.setValue(header.value, forHTTPHeaderField: header.key)
+        if providerType.supportsCustomHeaders {
+            for header in headers where !header.key.trimmingCharacters(in: .whitespaces).isEmpty {
+                request.setValue(header.value, forHTTPHeaderField: header.key)
+            }
         }
-        
+
         isLoadingModels = true
         modelFetchError = nil
         
@@ -936,7 +938,9 @@ struct CustomProviderSheet: View {
             prefix: prefix.trimmingCharacters(in: .whitespaces).isEmpty ? nil : prefix.trimmingCharacters(in: .whitespaces),
             apiKeys: apiKeys.filter { !$0.apiKey.trimmingCharacters(in: .whitespaces).isEmpty },
             models: limitToSelectedModels ? allModels : [],
-            headers: headers.filter { !$0.key.trimmingCharacters(in: .whitespaces).isEmpty },
+            headers: providerType.supportsCustomHeaders
+                ? headers.filter { !$0.key.trimmingCharacters(in: .whitespaces).isEmpty }
+                : [],
             limitToSelectedModels: limitToSelectedModels,
             isEnabled: isEnabled,
             createdAt: provider?.createdAt ?? Date(),

--- a/Quotio/Views/Components/CustomProviderSheet.swift
+++ b/Quotio/Views/Components/CustomProviderSheet.swift
@@ -831,12 +831,22 @@ struct CustomProviderSheet: View {
             return
         }
         
-        let effectiveBaseURL = baseURL.isEmpty 
+        let effectiveBaseURL = baseURL.isEmpty
             ? (providerType.defaultBaseURL ?? "")
             : normalizedBaseURL(baseURL, for: providerType)
-        
+
         guard let modelsURL = makeModelsURL(baseURL: effectiveBaseURL, providerType: providerType) else {
             modelFetchError = "Invalid base URL"
+            return
+        }
+
+        // Normalize the form's headers once, and validate before any of them touch the
+        // request — the same canonical set is what gets persisted and emitted to YAML.
+        let customHeaders = providerType.supportsCustomHeaders
+            ? CustomHeader.canonicalized(headers)
+            : []
+        if let headerError = CustomHeader.validationErrors(in: customHeaders).first {
+            modelFetchError = headerError
             return
         }
 
@@ -861,12 +871,8 @@ struct CustomProviderSheet: View {
             request.setValue("Bearer \(firstKey.apiKey)", forHTTPHeaderField: "Authorization")
         }
         
-        // Add custom headers
-        if providerType.supportsCustomHeaders {
-            for header in headers where !header.key.trimmingCharacters(in: .whitespaces).isEmpty {
-                request.setValue(header.value, forHTTPHeaderField: header.key)
-            }
-        }
+        // Add custom headers (canonical form, already validated above)
+        request.applyCustomHeaders(customHeaders)
 
         isLoadingModels = true
         modelFetchError = nil
@@ -939,7 +945,7 @@ struct CustomProviderSheet: View {
             apiKeys: apiKeys.filter { !$0.apiKey.trimmingCharacters(in: .whitespaces).isEmpty },
             models: limitToSelectedModels ? allModels : [],
             headers: providerType.supportsCustomHeaders
-                ? headers.filter { !$0.key.trimmingCharacters(in: .whitespaces).isEmpty }
+                ? CustomHeader.canonicalized(headers)
                 : [],
             limitToSelectedModels: limitToSelectedModels,
             isEnabled: isEnabled,
@@ -1021,10 +1027,9 @@ struct CustomProviderSheet: View {
             request.setValue("Bearer \(firstKey.apiKey)", forHTTPHeaderField: "Authorization")
         }
         
-        // Add custom headers if any
-        for header in provider.headers {
-            request.setValue(header.value, forHTTPHeaderField: header.key)
-        }
+        // Add custom headers if any — the same canonical set that is written to the
+        // generated CLIProxyAPI config, so the connection test exercises the real headers.
+        request.applyCustomHeaders(provider.effectiveHeaders)
         
         let (data, response) = try await URLSession.shared.data(for: request)
         

--- a/QuotioTests/CustomProviderHeaderTests.swift
+++ b/QuotioTests/CustomProviderHeaderTests.swift
@@ -153,6 +153,209 @@ final class CustomProviderHeaderTests: XCTestCase {
         XCTAssertFalse(provider.toYAMLBlock().contains("headers:"))
     }
 
+    // MARK: - YAML round-trip through a parser
+
+    func testGeneratedYAMLRoundTripsBackToTheCanonicalHeaders() throws {
+        let provider = makeProvider(
+            type: .openaiCompatibility,
+            headers: [
+                CustomHeader(key: "  X-Tenant-ID\t", value: "  team-a  "),
+                CustomHeader(key: "X-Quoted", value: "say \"hi\" \\ bye"),
+                CustomHeader(key: "X-Tabbed", value: "col-a\tcol-b"),
+                CustomHeader(key: "X-Colonized", value: "a: b # not-a-comment")
+            ]
+        )
+
+        let parsed = try YAMLHeaderBlockReader.blocks(in: provider.toYAMLBlock())
+        XCTAssertEqual(parsed.count, 1)
+        XCTAssertEqual(
+            parsed.first.map { $0.map { [$0.name, $0.value] } },
+            [
+                ["X-Tenant-ID", "team-a"],
+                ["X-Quoted", "say \"hi\" \\ bye"],
+                ["X-Tabbed", "col-a\tcol-b"],
+                ["X-Colonized", "a: b # not-a-comment"]
+            ]
+        )
+
+        // What a YAML consumer sees must equal the canonical set the app sends on the wire.
+        XCTAssertEqual(
+            parsed.first.map { $0.map { [$0.name, $0.value] } },
+            provider.effectiveHeaders.map { [$0.key, $0.value] }
+        )
+    }
+
+    func testYAMLEscapingRoundTripsControlAndWhitespaceCharacters() throws {
+        // These never survive validation, but the emitter must still be lossless:
+        // a bare newline in a quoted scalar is folded to a space by a YAML parser.
+        let originals = [
+            "line1\nline2",
+            "carriage\r\nreturn",
+            "null\u{00}byte",
+            "delete\u{7F}char",
+            "escape\u{1B}[0m",
+            "next\u{85}line",
+            "nbsp\u{A0}space",
+            "sep\u{2028}line",
+            "tab\tand \"quotes\" and \\slash"
+        ]
+
+        for original in originals {
+            let quoted = "\"" + CustomProvider.escapedYAMLString(original) + "\""
+            XCTAssertFalse(quoted.contains("\n"), "escaped scalar must stay on one line: \(original.debugDescription)")
+            XCTAssertFalse(quoted.contains("\r"), "escaped scalar must stay on one line: \(original.debugDescription)")
+            XCTAssertEqual(try YAMLHeaderBlockReader.decodeDoubleQuotedScalar(quoted), original)
+        }
+    }
+
+    // MARK: - Request-building path (the path the reviewer reproduced against CFNetwork)
+
+    func testConnectionTestRequestSendsNormalizedHeaderName() {
+        let provider = makeProvider(
+            type: .openaiCompatibility,
+            headers: [CustomHeader(key: " X-Tenant-ID ", value: " team-a ")]
+        )
+
+        var request = URLRequest(url: URL(string: "https://llm.internal/v1/models")!)
+        request.applyCustomHeaders(provider.effectiveHeaders)
+
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Tenant-ID"), "team-a")
+
+        let sentNames = request.allHTTPHeaderFields?.keys.sorted() ?? []
+        XCTAssertEqual(sentNames.count, 1)
+        for name in sentNames {
+            XCTAssertEqual(name, name.trimmingCharacters(in: .whitespacesAndNewlines))
+            XCTAssertTrue(CustomHeader.isValidName(name), "request carried a non-token header name: \(name.debugDescription)")
+        }
+    }
+
+    func testRequestHeadersMatchGeneratedYAMLHeaders() throws {
+        let rawFormHeaders = [
+            CustomHeader(key: " X-API-Key ", value: "\tsecret-token "),
+            CustomHeader(key: "X-Model-Version", value: "2024-12")
+        ]
+
+        // Fetch Models canonicalizes the raw form input; save persists the same call.
+        let fetchModelsHeaders = CustomHeader.canonicalized(rawFormHeaders)
+        XCTAssertTrue(CustomHeader.validationErrors(in: fetchModelsHeaders).isEmpty)
+
+        var fetchRequest = URLRequest(url: URL(string: "https://llm.internal/v1/models")!)
+        fetchRequest.applyCustomHeaders(fetchModelsHeaders)
+
+        let provider = makeProvider(type: .openaiCompatibility, headers: fetchModelsHeaders)
+        var testRequest = URLRequest(url: URL(string: "https://llm.internal/v1/models")!)
+        testRequest.applyCustomHeaders(provider.effectiveHeaders)
+
+        XCTAssertEqual(fetchRequest.value(forHTTPHeaderField: "X-API-Key"), "secret-token")
+        XCTAssertEqual(testRequest.value(forHTTPHeaderField: "X-API-Key"), "secret-token")
+
+        let emitted = try XCTUnwrap(YAMLHeaderBlockReader.blocks(in: provider.toYAMLBlock()).first)
+        for entry in emitted {
+            XCTAssertEqual(fetchRequest.value(forHTTPHeaderField: entry.name), entry.value)
+            XCTAssertEqual(testRequest.value(forHTTPHeaderField: entry.name), entry.value)
+        }
+    }
+
+    func testEffectiveHeadersAreEmptyForUnsupportedProviderTypes() {
+        for type in [CustomProviderType.glmCompatibility, .clinePass] {
+            let provider = makeProvider(type: type, baseURL: "", headers: sampleHeaders)
+            XCTAssertTrue(provider.effectiveHeaders.isEmpty, "\(type) must not send custom headers")
+        }
+    }
+
+    func testEffectiveHeadersDropEntriesThatValidationWouldReject() {
+        // Simulates a provider persisted before this validation existed.
+        let provider = makeProvider(
+            type: .openaiCompatibility,
+            headers: [
+                CustomHeader(key: "Bad Name", value: "v"),
+                CustomHeader(key: "X-Bad-Value", value: "a\r\nX-Injected: 1"),
+                CustomHeader(key: "X-Good", value: "ok")
+            ]
+        )
+
+        XCTAssertEqual(provider.effectiveHeaders.map(\.key), ["X-Good"])
+
+        var request = URLRequest(url: URL(string: "https://llm.internal/v1/models")!)
+        request.applyCustomHeaders(provider.effectiveHeaders)
+        XCTAssertNil(request.value(forHTTPHeaderField: "X-Injected"))
+        XCTAssertNil(request.value(forHTTPHeaderField: "X-Bad-Value"))
+    }
+
+    // MARK: - Normalization
+
+    func testCanonicalizedTrimsOptionalWhitespaceAndDropsUnnamedEntries() {
+        let canonical = CustomHeader.canonicalized([
+            CustomHeader(key: " X-Tenant-ID\t", value: "\t team-a "),
+            CustomHeader(key: "   ", value: "ignored"),
+            CustomHeader(key: "", value: "ignored")
+        ])
+
+        XCTAssertEqual(canonical.map { [$0.key, $0.value] }, [["X-Tenant-ID", "team-a"]])
+    }
+
+    func testCanonicalizedDoesNotStripNewlinesFromValues() {
+        // Stripping would silently change a secret; validation must reject instead.
+        let canonical = CustomHeader.canonicalized([CustomHeader(key: "X-Secret", value: " line1\nline2 ")])
+        XCTAssertEqual(canonical.first?.value, "line1\nline2")
+        XCTAssertFalse(CustomHeader.validationErrors(in: canonical).isEmpty)
+    }
+
+    func testHeaderNamesAreNormalizedBeforePersistenceValidation() {
+        let provider = makeProvider(
+            type: .openaiCompatibility,
+            headers: [CustomHeader(key: " X-Tenant-ID ", value: " team-a ")]
+        )
+        XCTAssertTrue(provider.validate().isEmpty)
+        XCTAssertEqual(provider.effectiveHeaders.map { [$0.key, $0.value] }, [["X-Tenant-ID", "team-a"]])
+    }
+
+    func testNormalizationMakesWhitespacePaddedDuplicatesDetectable() {
+        let provider = makeProvider(
+            type: .openaiCompatibility,
+            headers: [
+                CustomHeader(key: "X-API-Key", value: "a"),
+                CustomHeader(key: "  X-API-Key  ", value: "b")
+            ]
+        )
+        XCTAssertFalse(provider.validate().isEmpty)
+    }
+
+    // MARK: - Header value validation
+
+    func testIsValidValueAcceptsWireSafeValues() {
+        XCTAssertTrue(CustomHeader.isValidValue(""))
+        XCTAssertTrue(CustomHeader.isValidValue("secret-token"))
+        XCTAssertTrue(CustomHeader.isValidValue("a: b, c=d; e"))
+        XCTAssertTrue(CustomHeader.isValidValue("col-a\tcol-b"))
+    }
+
+    func testIsValidValueRejectsControlCharactersAndNonASCII() {
+        XCTAssertFalse(CustomHeader.isValidValue("line1\nline2"))
+        XCTAssertFalse(CustomHeader.isValidValue("line1\rline2"))
+        XCTAssertFalse(CustomHeader.isValidValue("a\r\nX-Injected: 1"))
+        XCTAssertFalse(CustomHeader.isValidValue("null\u{00}byte"))
+        XCTAssertFalse(CustomHeader.isValidValue("delete\u{7F}"))
+        XCTAssertFalse(CustomHeader.isValidValue("token\u{A0}"))
+        XCTAssertFalse(CustomHeader.isValidValue("bí-mật"))
+    }
+
+    func testValidateRejectsHeaderValueWithLineBreak() {
+        let provider = makeProvider(
+            type: .openaiCompatibility,
+            headers: [CustomHeader(key: "X-Secret", value: "line1\nline2")]
+        )
+        XCTAssertFalse(provider.validate().isEmpty)
+    }
+
+    func testValidateRejectsCRLFHeaderInjectionAttempt() {
+        let provider = makeProvider(
+            type: .openaiCompatibility,
+            headers: [CustomHeader(key: "X-Tenant-ID", value: "team-a\r\nAuthorization: Bearer stolen")]
+        )
+        XCTAssertFalse(provider.validate().isEmpty)
+    }
+
     // MARK: - Header name validation
 
     func testIsValidNameAcceptsRFC7230Tokens() {
@@ -232,5 +435,149 @@ final class CustomProviderHeaderTests: XCTestCase {
         let reappended = strippedOnce + "\n\n# Custom Providers (managed by Quotio)\n" + sections
         let strippedTwice = service.removeCustomProviderSections(from: reappended)
         XCTAssertEqual(strippedTwice, strippedOnce)
+    }
+}
+
+// MARK: - YAML reader
+
+/// A minimal reader for the `headers:` blocks emitted by `CustomProvider.toYAMLBlock()`.
+///
+/// It decodes double-quoted scalars using the YAML 1.2 escape table, so tests can assert
+/// what a YAML consumer (CLIProxyAPI) actually parses back rather than matching the
+/// generated text with substring checks.
+enum YAMLHeaderBlockReader {
+
+    struct ParseError: Error, CustomStringConvertible {
+        let description: String
+    }
+
+    /// Every `headers:` mapping in the document, in order, as ordered name/value pairs.
+    static func blocks(in yaml: String) throws -> [[(name: String, value: String)]] {
+        var result: [[(name: String, value: String)]] = []
+        let lines = yaml.components(separatedBy: "\n")
+        var index = 0
+
+        while index < lines.count {
+            let line = lines[index]
+            index += 1
+            guard line.trimmingCharacters(in: .whitespaces) == "headers:" else { continue }
+
+            let blockIndent = line.prefix { $0 == " " }.count
+            var entries: [(name: String, value: String)] = []
+
+            while index < lines.count {
+                let entryLine = lines[index]
+                let entryIndent = entryLine.prefix { $0 == " " }.count
+                guard !entryLine.trimmingCharacters(in: .whitespaces).isEmpty, entryIndent > blockIndent else { break }
+                entries.append(try parseEntry(entryLine))
+                index += 1
+            }
+
+            result.append(entries)
+        }
+
+        return result
+    }
+
+    /// Decode a single double-quoted YAML scalar, quotes included.
+    static func decodeDoubleQuotedScalar(_ scalar: String) throws -> String {
+        let scalars = Array(scalar.unicodeScalars)
+        var cursor = 0
+        let decoded = try readDoubleQuotedScalar(scalars, &cursor)
+        guard cursor == scalars.count else {
+            throw ParseError(description: "trailing content after scalar: \(scalar.debugDescription)")
+        }
+        return decoded
+    }
+
+    private static func parseEntry(_ line: String) throws -> (name: String, value: String) {
+        let scalars = Array(line.unicodeScalars)
+        var cursor = 0
+
+        func skipSpaces() {
+            while cursor < scalars.count, scalars[cursor] == " " { cursor += 1 }
+        }
+
+        skipSpaces()
+        let name = try readDoubleQuotedScalar(scalars, &cursor)
+        skipSpaces()
+        guard cursor < scalars.count, scalars[cursor] == ":" else {
+            throw ParseError(description: "expected ':' in \(line.debugDescription)")
+        }
+        cursor += 1
+        skipSpaces()
+        let value = try readDoubleQuotedScalar(scalars, &cursor)
+        skipSpaces()
+        guard cursor == scalars.count else {
+            throw ParseError(description: "trailing content in \(line.debugDescription)")
+        }
+        return (name, value)
+    }
+
+    private static func readDoubleQuotedScalar(_ scalars: [Unicode.Scalar], _ cursor: inout Int) throws -> String {
+        guard cursor < scalars.count, scalars[cursor] == "\"" else {
+            throw ParseError(description: "expected a double-quoted scalar at offset \(cursor)")
+        }
+        cursor += 1
+
+        var decoded = String.UnicodeScalarView()
+
+        while cursor < scalars.count {
+            let scalar = scalars[cursor]
+            cursor += 1
+
+            if scalar == "\"" {
+                return String(decoded)
+            }
+            guard scalar == "\\" else {
+                decoded.append(scalar)
+                continue
+            }
+            guard cursor < scalars.count else {
+                throw ParseError(description: "dangling escape at end of scalar")
+            }
+
+            let escape = scalars[cursor]
+            cursor += 1
+
+            switch escape {
+            case "0": decoded.append("\u{00}")
+            case "a": decoded.append("\u{07}")
+            case "b": decoded.append("\u{08}")
+            case "t": decoded.append("\u{09}")
+            case "n": decoded.append("\u{0A}")
+            case "v": decoded.append("\u{0B}")
+            case "f": decoded.append("\u{0C}")
+            case "r": decoded.append("\u{0D}")
+            case "e": decoded.append("\u{1B}")
+            case " ": decoded.append(" ")
+            case "\"": decoded.append("\"")
+            case "/": decoded.append("/")
+            case "\\": decoded.append("\\")
+            case "N": decoded.append("\u{85}")
+            case "_": decoded.append("\u{A0}")
+            case "L": decoded.append("\u{2028}")
+            case "P": decoded.append("\u{2029}")
+            case "x": decoded.append(try readHexEscape(scalars, &cursor, digits: 2))
+            case "u": decoded.append(try readHexEscape(scalars, &cursor, digits: 4))
+            case "U": decoded.append(try readHexEscape(scalars, &cursor, digits: 8))
+            default:
+                throw ParseError(description: "unsupported escape '\\\(escape)'")
+            }
+        }
+
+        throw ParseError(description: "unterminated double-quoted scalar")
+    }
+
+    private static func readHexEscape(_ scalars: [Unicode.Scalar], _ cursor: inout Int, digits: Int) throws -> Unicode.Scalar {
+        guard cursor + digits <= scalars.count else {
+            throw ParseError(description: "truncated hex escape")
+        }
+        let text = String(String.UnicodeScalarView(scalars[cursor..<(cursor + digits)]))
+        cursor += digits
+        guard let code = UInt32(text, radix: 16), let scalar = Unicode.Scalar(code) else {
+            throw ParseError(description: "invalid hex escape '\(text)'")
+        }
+        return scalar
     }
 }

--- a/QuotioTests/CustomProviderHeaderTests.swift
+++ b/QuotioTests/CustomProviderHeaderTests.swift
@@ -1,0 +1,236 @@
+import XCTest
+@testable import Quotio
+
+@MainActor
+final class CustomProviderHeaderTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeProvider(
+        type: CustomProviderType,
+        baseURL: String = "https://llm.internal/v1",
+        apiKeys: [CustomAPIKeyEntry] = [CustomAPIKeyEntry(apiKey: "sk-test-1")],
+        headers: [CustomHeader]
+    ) -> CustomProvider {
+        CustomProvider(
+            name: "Private LLM",
+            type: type,
+            baseURL: baseURL,
+            apiKeys: apiKeys,
+            headers: headers
+        )
+    }
+
+    private let sampleHeaders = [
+        CustomHeader(key: "X-API-Key", value: "secret-token"),
+        CustomHeader(key: "X-Tenant-ID", value: "team-a")
+    ]
+
+    // MARK: - Type gating
+
+    func testSupportedTypesForCustomHeaders() {
+        XCTAssertTrue(CustomProviderType.openaiCompatibility.supportsCustomHeaders)
+        XCTAssertTrue(CustomProviderType.claudeCompatibility.supportsCustomHeaders)
+        XCTAssertTrue(CustomProviderType.geminiCompatibility.supportsCustomHeaders)
+        XCTAssertTrue(CustomProviderType.codexCompatibility.supportsCustomHeaders)
+        XCTAssertFalse(CustomProviderType.glmCompatibility.supportsCustomHeaders)
+        XCTAssertFalse(CustomProviderType.clinePass.supportsCustomHeaders)
+    }
+
+    // MARK: - YAML emission
+
+    func testOpenAICompatibilityEmitsProviderLevelHeaders() {
+        let provider = makeProvider(type: .openaiCompatibility, headers: sampleHeaders)
+        let yaml = provider.toYAMLBlock()
+
+        let expected = """
+          - name: "Private LLM"
+            base-url: "https://llm.internal/v1"
+            headers:
+              "X-API-Key": "secret-token"
+              "X-Tenant-ID": "team-a"
+            api-key-entries:
+              - api-key: "sk-test-1"
+
+        """
+        XCTAssertEqual(yaml, expected)
+    }
+
+    func testClaudeCompatibilityEmitsPerKeyHeaders() {
+        let provider = makeProvider(
+            type: .claudeCompatibility,
+            baseURL: "https://claude.internal",
+            apiKeys: [
+                CustomAPIKeyEntry(apiKey: "sk-a"),
+                CustomAPIKeyEntry(apiKey: "sk-b")
+            ],
+            headers: sampleHeaders
+        )
+        let yaml = provider.toYAMLBlock()
+
+        let expectedKeyBlock = """
+            headers:
+              "X-API-Key": "secret-token"
+              "X-Tenant-ID": "team-a"
+        """
+        // Headers must be emitted once per API key entry
+        XCTAssertEqual(yaml.components(separatedBy: expectedKeyBlock).count - 1, 2)
+        XCTAssertTrue(yaml.contains("  - api-key: \"sk-a\"\n"))
+        XCTAssertTrue(yaml.contains("  - api-key: \"sk-b\"\n"))
+    }
+
+    func testCodexCompatibilityEmitsPerKeyHeaders() {
+        let provider = makeProvider(type: .codexCompatibility, headers: sampleHeaders)
+        let yaml = provider.toYAMLBlock()
+
+        let expected = """
+          - api-key: "sk-test-1"
+            base-url: "https://llm.internal/v1"
+            headers:
+              "X-API-Key": "secret-token"
+              "X-Tenant-ID": "team-a"
+
+        """
+        XCTAssertEqual(yaml, expected)
+    }
+
+    func testGeminiCompatibilityEmitsPerKeyHeaders() {
+        let provider = makeProvider(
+            type: .geminiCompatibility,
+            baseURL: "https://gemini.internal",
+            headers: sampleHeaders
+        )
+        let yaml = provider.toYAMLBlock()
+
+        let expected = """
+          - api-key: "sk-test-1"
+            base-url: "https://gemini.internal"
+            headers:
+              "X-API-Key": "secret-token"
+              "X-Tenant-ID": "team-a"
+
+        """
+        XCTAssertEqual(yaml, expected)
+    }
+
+    func testGlmCompatibilityDoesNotEmitHeaders() {
+        let provider = makeProvider(type: .glmCompatibility, baseURL: "", headers: sampleHeaders)
+        let yaml = provider.toYAMLBlock()
+
+        XCTAssertFalse(yaml.contains("headers:"))
+        XCTAssertFalse(yaml.contains("X-API-Key"))
+    }
+
+    func testHeaderValuesAreEscapedForYAML() {
+        let provider = makeProvider(
+            type: .openaiCompatibility,
+            headers: [CustomHeader(key: "X-Quoted", value: "say \"hi\" \\ bye")]
+        )
+        let yaml = provider.toYAMLBlock()
+
+        XCTAssertTrue(yaml.contains("      \"X-Quoted\": \"say \\\"hi\\\" \\\\ bye\"\n"))
+    }
+
+    func testInvalidOrEmptyHeaderNamesAreNotEmitted() {
+        let provider = makeProvider(
+            type: .openaiCompatibility,
+            headers: [
+                CustomHeader(key: "", value: "ignored"),
+                CustomHeader(key: "   ", value: "ignored"),
+                CustomHeader(key: "Bad Name", value: "ignored"),
+                CustomHeader(key: "X-Valid", value: "kept")
+            ]
+        )
+        let yaml = provider.toYAMLBlock()
+
+        XCTAssertTrue(yaml.contains("      \"X-Valid\": \"kept\"\n"))
+        XCTAssertFalse(yaml.contains("ignored"))
+        XCTAssertFalse(yaml.contains("Bad Name"))
+    }
+
+    func testHeadersOmittedWhenEmpty() {
+        let provider = makeProvider(type: .openaiCompatibility, headers: [])
+        XCTAssertFalse(provider.toYAMLBlock().contains("headers:"))
+    }
+
+    // MARK: - Header name validation
+
+    func testIsValidNameAcceptsRFC7230Tokens() {
+        XCTAssertTrue(CustomHeader.isValidName("X-API-Key"))
+        XCTAssertTrue(CustomHeader.isValidName("X-Model-Version"))
+        XCTAssertTrue(CustomHeader.isValidName("x_custom.header~1"))
+    }
+
+    func testIsValidNameRejectsInvalidCharacters() {
+        XCTAssertFalse(CustomHeader.isValidName(""))
+        XCTAssertFalse(CustomHeader.isValidName("X API Key"))
+        XCTAssertFalse(CustomHeader.isValidName("X-API-Key:"))
+        XCTAssertFalse(CustomHeader.isValidName("Ключ"))
+    }
+
+    func testValidateRejectsInvalidHeaderName() {
+        let provider = makeProvider(
+            type: .openaiCompatibility,
+            headers: [CustomHeader(key: "Bad Name", value: "v")]
+        )
+        XCTAssertFalse(provider.validate().isEmpty)
+    }
+
+    func testValidateRejectsDuplicateHeaderNamesCaseInsensitively() {
+        let provider = makeProvider(
+            type: .openaiCompatibility,
+            headers: [
+                CustomHeader(key: "X-API-Key", value: "a"),
+                CustomHeader(key: "x-api-key", value: "b")
+            ]
+        )
+        XCTAssertFalse(provider.validate().isEmpty)
+    }
+
+    func testValidateAcceptsWellFormedHeaders() {
+        let provider = makeProvider(type: .openaiCompatibility, headers: sampleHeaders)
+        XCTAssertTrue(provider.validate().isEmpty)
+    }
+
+    // MARK: - Codable round-trip
+
+    func testHeadersSurviveCodableRoundTrip() throws {
+        let provider = makeProvider(type: .claudeCompatibility, headers: sampleHeaders)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let decoded = try decoder.decode(CustomProvider.self, from: encoder.encode(provider))
+        XCTAssertEqual(decoded.headers, provider.headers)
+    }
+
+    // MARK: - Config strip/re-append round-trip
+
+    func testConfigStripAndReappendIsIdempotent() {
+        let baseConfig = """
+        port: 8317
+        auth-dir: "~/.cli-proxy-api"
+        remote-management:
+          allow-remote: false
+        """
+
+        let providers = [
+            makeProvider(type: .openaiCompatibility, headers: sampleHeaders),
+            makeProvider(type: .geminiCompatibility, baseURL: "https://gemini.internal", headers: sampleHeaders)
+        ]
+        let sections = providers.toYAMLSections()
+        XCTAssertTrue(sections.contains("\"X-API-Key\": \"secret-token\""))
+
+        let service = CustomProviderService.shared
+
+        let withSections = baseConfig + "\n\n# Custom Providers (managed by Quotio)\n" + sections
+        let strippedOnce = service.removeCustomProviderSections(from: withSections)
+        XCTAssertEqual(strippedOnce, baseConfig)
+
+        let reappended = strippedOnce + "\n\n# Custom Providers (managed by Quotio)\n" + sections
+        let strippedTwice = service.removeCustomProviderSections(from: reappended)
+        XCTAssertEqual(strippedTwice, strippedOnce)
+    }
+}


### PR DESCRIPTION
## Motivation

Private LLM deployments (vLLM, TGI, internal OpenAI-compatible gateways) frequently rely on custom HTTP headers for authentication, tenancy routing, or model versioning (`X-API-Key`, `X-Tenant-ID`, `X-Model-Version`, ...). Quotio already ships a custom header editor, but it is only enabled for **Gemini-compatible** providers — the exact provider types used for private deployments (OpenAI-compatible, Claude-compatible, Codex-compatible) could not configure headers at all.

Closes #212

## Proxy config format reference

CLIProxyAPI natively supports a `headers` map for all four provider types this PR enables, so the emitted config is honored end-to-end:

- `openai-compatibility` (provider level): [`OpenAICompatibility.Headers`](https://github.com/router-for-me/CLIProxyAPI/blob/2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e/internal/config/config_types.go#L612-L613)
- `claude-api-key` (per key entry): [`ClaudeKey.Headers`](https://github.com/router-for-me/CLIProxyAPI/blob/2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e/internal/config/config_types.go#L346-L347)
- `codex-api-key` (per key entry): [`CodexKey.Headers`](https://github.com/router-for-me/CLIProxyAPI/blob/2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e/internal/config/config_types.go#L444-L445)
- `gemini-api-key` (per key entry, already supported by Quotio): [`GeminiKey.Headers`](https://github.com/router-for-me/CLIProxyAPI/blob/2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e/internal/config/config_types.go#L533-L534)

Example emitted section:

```yaml
openai-compatibility:
  - name: "Private vLLM"
    base-url: "https://llm.internal/v1"
    headers:
      "X-API-Key": "secret"
      "X-Tenant-ID": "team-a"
    api-key-entries:
      - api-key: "sk-..."
```

The proxy applies these headers on upstream requests and documents that custom headers intentionally override built-in defaults ([`internal/util/header_helpers.go`](https://github.com/router-for-me/CLIProxyAPI/blob/main/internal/util/header_helpers.go)), which is exactly the issue's use case (e.g. `X-API-Key` instead of standard `Authorization`). Overriding auth headers is therefore allowed rather than blocked.

**Deliberately excluded:** `glm-api-key` (the section only exists in the bundled Plus binary and has no publicly documented `headers` support — emitting an unknown field there would be a guess) and ClinePass (managed service with fixed authentication).

## UX

The existing "Custom Headers" key/value rows in the Add/Edit Custom Provider sheet now appear for OpenAI-, Claude-, and Codex-compatible providers as well (same section, same styling, existing localized strings). Custom headers are also applied to the sheet's "Fetch models" and connection-test requests, so a private endpoint that requires them can be tested before saving.

Validation (localized in en/fr/vi/zh-Hans):
- header names must be RFC 7230 tokens (ASCII letters, digits, ``!#$%&'*+-.^_`|~``)
- duplicate names (case-insensitive) are rejected — the YAML `headers` map cannot express duplicates

Header values are stored exactly like API keys are today (same provider persistence), never logged, and YAML emission quotes keys and escapes `"`/`\` in values so arbitrary secret values cannot break the config.

## Implementation notes

- `CustomProviderType.supportsCustomHeaders` now returns true for openai/claude/gemini/codex compatibility types; the sheet and persistence key off it
- YAML emission places `headers` at the provider level for `openai-compatibility` and per key entry for `claude-api-key` / `gemini-api-key` / `codex-api-key`, matching the proxy structs above
- Invalid or empty header names are never emitted (defense in depth on top of validation)
- `CustomProviderService.removeCustomProviderSections(from:)` visibility changed from `private` to internal so tests can verify the strip/re-append round-trip

## Test evidence

New `QuotioTests/CustomProviderHeaderTests.swift` (17 tests): per-type YAML emission and placement, quoting/escaping, empty/invalid name filtering, RFC 7230 name validation, case-insensitive duplicate detection, Codable round-trip, and config strip/re-append idempotence (headers survive `syncToConfigFile`-style rewrites without corrupting the config).

```
xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build
** BUILD SUCCEEDED **

xcodebuild test -project Quotio.xcodeproj -scheme Quotio -destination 'platform=macOS'
** TEST SUCCEEDED **   (82 tests passed, 0 failed)
```
