### PR TITLE
feat(opencode): split Gemini models into a Google-protocol provider

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -1857,6 +1857,151 @@
         }
       }
     },
+    "agents.opencode.configSuccess" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuration updated. Run 'opencode' and use /models to select a model (e.g., %@)."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuration mise à jour. Lancez « opencode » et utilisez /models pour sélectionner un modèle (par ex. %@)."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã cập nhật cấu hình. Chạy 'opencode' và dùng /models để chọn mô hình (ví dụ: %@)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置已更新。运行 'opencode' 并使用 /models 选择模型（例如 %@）。"
+          }
+        }
+      }
+    },
+    "agents.opencode.default.manual" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove 'provider.quotio' and 'provider.quotio-gemini' sections from ~/.config/opencode/opencode.json"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimez les sections « provider.quotio » et « provider.quotio-gemini » de ~/.config/opencode/opencode.json"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa các mục 'provider.quotio' và 'provider.quotio-gemini' khỏi ~/.config/opencode/opencode.json"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从 ~/.config/opencode/opencode.json 中移除 'provider.quotio' 和 'provider.quotio-gemini' 部分"
+          }
+        }
+      }
+    },
+    "agents.opencode.default.removed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Removed Quotio providers. OpenCode will use its default providers."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fournisseurs Quotio supprimés. OpenCode utilisera ses fournisseurs par défaut."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã xóa các nhà cung cấp Quotio. OpenCode sẽ dùng các nhà cung cấp mặc định."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已移除 Quotio 提供商。OpenCode 将使用其默认提供商。"
+          }
+        }
+      }
+    },
+    "agents.opencode.mergeAndSaveFiles" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Merge the provider.quotio and provider.quotio-gemini sections into your existing ~/.config/opencode/opencode.json:"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fusionnez les sections provider.quotio et provider.quotio-gemini dans votre fichier ~/.config/opencode/opencode.json existant :"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gộp các mục provider.quotio và provider.quotio-gemini vào tệp ~/.config/opencode/opencode.json hiện có:"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将 provider.quotio 和 provider.quotio-gemini 部分合并到您现有的 ~/.config/opencode/opencode.json："
+          }
+        }
+      }
+    },
+    "agents.opencode.mergeProviders" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Merge provider.quotio and provider.quotio-gemini into ~/.config/opencode/opencode.json"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fusionnez provider.quotio et provider.quotio-gemini dans ~/.config/opencode/opencode.json"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gộp provider.quotio và provider.quotio-gemini vào ~/.config/opencode/opencode.json"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将 provider.quotio 和 provider.quotio-gemini 合并到 ~/.config/opencode/opencode.json"
+          }
+        }
+      }
+    },
     "agents.proxyRemovalWarning" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -771,7 +771,7 @@ actor AgentConfigurationService {
                     authPath: nil,
                     shellConfig: nil,
                     rawConfigs: [],
-                    instructions: "Removed Quotio providers. OpenCode will use its default providers.",
+                    instructions: "agents.opencode.default.removed".localizedStatic(),
                     modelsConfigured: 0
                 )
             } catch {
@@ -786,7 +786,7 @@ actor AgentConfigurationService {
             authPath: nil,
             shellConfig: nil,
             rawConfigs: [],
-            instructions: "Remove 'provider.quotio' and 'provider.quotio-gemini' sections from ~/.config/opencode/opencode.json",
+            instructions: "agents.opencode.default.manual".localizedStatic(),
             modelsConfigured: 0
         )
     }
@@ -1192,6 +1192,28 @@ actor AgentConfigurationService {
         return lowered.contains("gemini") && !lowered.contains("claude")
     }
 
+    /// The opencode.json provider key that emits a given model, derived from
+    /// the same partitioning rule as `openCodeQuotioProviderEntries`.
+    nonisolated static func openCodeProviderKey(for modelName: String) -> String {
+        isOpenCodeGeminiNativeModel(modelName) ? "quotio-gemini" : "quotio"
+    }
+
+    /// The full OpenCode model selector for a model. OpenCode selects models by
+    /// `provider_id/model_id`, where `provider_id` is the key under `provider`
+    /// in opencode.json (https://opencode.ai/docs/models/), so a Gemini-native
+    /// model must be referenced as `quotio-gemini/<model>`.
+    nonisolated static func openCodeModelSelector(for modelName: String) -> String {
+        "\(openCodeProviderKey(for: modelName))/\(modelName)"
+    }
+
+    /// A selector example that is guaranteed to exist in the generated config:
+    /// it is built from an actual emitted model, under the provider that
+    /// actually emits it.
+    nonisolated static func openCodeModelSelectorExample(models: [AvailableModel]) -> String {
+        guard let first = models.first else { return "quotio/model" }
+        return openCodeModelSelector(for: first.name)
+    }
+
     /// Builds the Quotio-managed provider entries for opencode.json.
     /// Models are deterministically partitioned by name: Gemini-native models
     /// go into a Google-protocol "quotio-gemini" provider (emitted only when
@@ -1321,7 +1343,7 @@ actor AgentConfigurationService {
                     content: jsonString,
                     filename: "opencode.json",
                     targetPath: configPath,
-                    instructions: "Merge provider.quotio and provider.quotio-gemini into ~/.config/opencode/opencode.json"
+                    instructions: "agents.opencode.mergeProviders".localizedStatic()
                 )
             ]
 
@@ -1341,7 +1363,10 @@ actor AgentConfigurationService {
                     mode: mode,
                     configPath: configPath,
                     rawConfigs: rawConfigs,
-                    instructions: "Configuration updated. Run 'opencode' and use /models to select a model (e.g., quotio/\(modelsToUse.first?.name ?? "model")).",
+                    instructions: String.localizedStringWithFormat(
+                        "agents.opencode.configSuccess".localizedStatic(),
+                        Self.openCodeModelSelectorExample(models: modelsToUse)
+                    ),
                     modelsConfigured: modelsToUse.count,
                     backupPath: backupPath
                 )
@@ -1351,7 +1376,7 @@ actor AgentConfigurationService {
                     mode: mode,
                     configPath: configPath,
                     rawConfigs: rawConfigs,
-                    instructions: "Merge the provider.quotio and provider.quotio-gemini sections into your existing ~/.config/opencode/opencode.json:",
+                    instructions: "agents.opencode.mergeAndSaveFiles".localizedStatic(),
                     modelsConfigured: modelsToUse.count
                 )
             }

--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -758,11 +758,8 @@ actor AgentConfigurationService {
                 let backupPath = "\(configPath).backup.\(Int(Date().timeIntervalSince1970))"
                 try fileManager.copyItem(atPath: configPath, toPath: backupPath)
                 
-                // Remove quotio provider
-                if var providers = config["provider"] as? [String: Any] {
-                    providers.removeValue(forKey: "quotio")
-                    config["provider"] = providers.isEmpty ? nil : providers
-                }
+                // Remove all Quotio-managed providers (quotio and quotio-gemini)
+                config = Self.openCodeConfigRemovingQuotioProviders(config)
                 
                 let updatedData = try JSONSerialization.data(withJSONObject: config, options: [.prettyPrinted, .sortedKeys])
                 try updatedData.write(to: URL(fileURLWithPath: configPath))
@@ -774,7 +771,7 @@ actor AgentConfigurationService {
                     authPath: nil,
                     shellConfig: nil,
                     rawConfigs: [],
-                    instructions: "Removed Quotio provider. OpenCode will use its default providers.",
+                    instructions: "Removed Quotio providers. OpenCode will use its default providers.",
                     modelsConfigured: 0
                 )
             } catch {
@@ -789,7 +786,7 @@ actor AgentConfigurationService {
             authPath: nil,
             shellConfig: nil,
             rawConfigs: [],
-            instructions: "Remove 'provider.quotio' section from ~/.config/opencode/opencode.json",
+            instructions: "Remove 'provider.quotio' and 'provider.quotio-gemini' sections from ~/.config/opencode/opencode.json",
             modelsConfigured: 0
         )
     }
@@ -1181,30 +1178,123 @@ actor AgentConfigurationService {
         return backupPath
     }
     
+    // MARK: - OpenCode provider partitioning (#227)
+
+    /// Provider keys in opencode.json that are managed by Quotio.
+    nonisolated static let openCodeManagedProviderKeys = ["quotio", "quotio-gemini"]
+
+    /// True when a model is Gemini-native and should be served through
+    /// Google's protocol on the proxy's /v1beta endpoint instead of the
+    /// Anthropic-flavored /v1 endpoint. Antigravity exposes Claude models
+    /// under "gemini-claude-*" ids — those stay on the Anthropic protocol.
+    nonisolated static func isOpenCodeGeminiNativeModel(_ modelName: String) -> Bool {
+        let lowered = modelName.lowercased()
+        return lowered.contains("gemini") && !lowered.contains("claude")
+    }
+
+    /// Builds the Quotio-managed provider entries for opencode.json.
+    /// Models are deterministically partitioned by name: Gemini-native models
+    /// go into a Google-protocol "quotio-gemini" provider (emitted only when
+    /// such models exist), everything else stays in the Anthropic-flavored
+    /// "quotio" provider (#227).
+    nonisolated static func openCodeQuotioProviderEntries(
+        models: [AvailableModel],
+        apiKey: String,
+        baseURL: String
+    ) -> [String: [String: Any]] {
+        var anthropicModels: [String: [String: Any]] = [:]
+        var geminiModels: [String: [String: Any]] = [:]
+
+        for model in models {
+            if isOpenCodeGeminiNativeModel(model.name) {
+                geminiModels[model.name] = buildOpenCodeModelConfig(for: model.name)
+            } else {
+                anthropicModels[model.name] = buildOpenCodeModelConfig(for: model.name)
+            }
+        }
+
+        var entries: [String: [String: Any]] = [
+            "quotio": [
+                "models": anthropicModels,
+                "name": "Quotio",
+                "npm": "@ai-sdk/anthropic",
+                "options": [
+                    "apiKey": apiKey,
+                    "baseURL": "\(baseURL)/v1",
+                    "litellmProxy": true
+                ]
+            ]
+        ]
+
+        if !geminiModels.isEmpty {
+            entries["quotio-gemini"] = [
+                "models": geminiModels,
+                "name": "Quotio (Gemini)",
+                "npm": "@ai-sdk/google",
+                "options": [
+                    "apiKey": apiKey,
+                    "baseURL": "\(baseURL)/v1beta"
+                ]
+            ]
+        }
+
+        return entries
+    }
+
+    /// Applies the Quotio-managed provider entries onto an existing
+    /// opencode.json "provider" object, preserving all user providers.
+    /// Managed keys that are no longer emitted (e.g. "quotio-gemini" after
+    /// all Gemini models disappeared) are removed so no stale Quotio entry
+    /// lingers.
+    nonisolated static func openCodeProvidersApplyingQuotioEntries(
+        _ providers: [String: Any],
+        entries: [String: [String: Any]]
+    ) -> [String: Any] {
+        var updated = providers
+        for key in openCodeManagedProviderKeys where entries[key] == nil {
+            updated.removeValue(forKey: key)
+        }
+        for (key, value) in entries {
+            updated[key] = value
+        }
+        return updated
+    }
+
+    /// Removes every Quotio-managed provider entry from a parsed
+    /// opencode.json object, preserving all other user settings. Drops the
+    /// "provider" key entirely when no providers remain.
+    nonisolated static func openCodeConfigRemovingQuotioProviders(_ config: [String: Any]) -> [String: Any] {
+        var updated = config
+        guard var providers = updated["provider"] as? [String: Any] else {
+            return updated
+        }
+        for key in openCodeManagedProviderKeys {
+            providers.removeValue(forKey: key)
+        }
+        if providers.isEmpty {
+            updated.removeValue(forKey: "provider")
+        } else {
+            updated["provider"] = providers
+        }
+        return updated
+    }
+
     private func generateOpenCodeConfig(config: AgentConfiguration, mode: ConfigurationMode, availableModels: [AvailableModel]) -> AgentConfigResult {
         let home = fileManager.homeDirectoryForCurrentUser.path
         let configDir = "\(home)/.config/opencode"
         let configPath = "\(configDir)/opencode.json"
         let baseURL = config.proxyURL.replacingOccurrences(of: "/v1", with: "")
 
-        // Convert available models to OpenCode format dynamically
-        var quotioModels: [String: [String: Any]] = [:]
+        // Convert available models to OpenCode format dynamically.
+        // Gemini-native models get their own Google-protocol provider so they
+        // are served through /v1beta instead of the Anthropic-flavored
+        // endpoint, which confuses them (#227).
         let modelsToUse = availableModels.isEmpty ? AvailableModel.allModels : availableModels
-
-        for model in modelsToUse {
-            quotioModels[model.name] = buildOpenCodeModelConfig(for: model.name)
-        }
-
-        let quotioProvider: [String: Any] = [
-            "models": quotioModels,
-            "name": "Quotio",
-            "npm": "@ai-sdk/anthropic",
-            "options": [
-                "apiKey": config.apiKey,
-                "baseURL": "\(baseURL)/v1",
-                "litellmProxy": true
-            ]
-        ]
+        let providerEntries = Self.openCodeQuotioProviderEntries(
+            models: modelsToUse,
+            apiKey: config.apiKey,
+            baseURL: baseURL
+        )
 
         do {
             var existingConfig: [String: Any] = [:]
@@ -1219,9 +1309,8 @@ actor AgentConfigurationService {
                 existingConfig["$schema"] = "https://opencode.ai/config.json"
             }
 
-            var providers = existingConfig["provider"] as? [String: Any] ?? [:]
-            providers["quotio"] = quotioProvider
-            existingConfig["provider"] = providers
+            let providers = existingConfig["provider"] as? [String: Any] ?? [:]
+            existingConfig["provider"] = Self.openCodeProvidersApplyingQuotioEntries(providers, entries: providerEntries)
 
             let jsonData = try JSONSerialization.data(withJSONObject: existingConfig, options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
             let jsonString = String(data: jsonData, encoding: .utf8) ?? "{}"
@@ -1232,7 +1321,7 @@ actor AgentConfigurationService {
                     content: jsonString,
                     filename: "opencode.json",
                     targetPath: configPath,
-                    instructions: "Merge provider.quotio into ~/.config/opencode/opencode.json"
+                    instructions: "Merge provider.quotio and provider.quotio-gemini into ~/.config/opencode/opencode.json"
                 )
             ]
 
@@ -1253,7 +1342,7 @@ actor AgentConfigurationService {
                     configPath: configPath,
                     rawConfigs: rawConfigs,
                     instructions: "Configuration updated. Run 'opencode' and use /models to select a model (e.g., quotio/\(modelsToUse.first?.name ?? "model")).",
-                    modelsConfigured: quotioModels.count,
+                    modelsConfigured: modelsToUse.count,
                     backupPath: backupPath
                 )
             } else {
@@ -1262,8 +1351,8 @@ actor AgentConfigurationService {
                     mode: mode,
                     configPath: configPath,
                     rawConfigs: rawConfigs,
-                    instructions: "Merge provider.quotio section into your existing ~/.config/opencode/opencode.json:",
-                    modelsConfigured: quotioModels.count
+                    instructions: "Merge the provider.quotio and provider.quotio-gemini sections into your existing ~/.config/opencode/opencode.json:",
+                    modelsConfigured: modelsToUse.count
                 )
             }
         } catch {
@@ -1272,7 +1361,7 @@ actor AgentConfigurationService {
     }
 
     /// Build OpenCode model configuration based on model name patterns
-    private func buildOpenCodeModelConfig(for modelName: String) -> [String: Any] {
+    nonisolated private static func buildOpenCodeModelConfig(for modelName: String) -> [String: Any] {
         let displayName = modelName.split(separator: "-")
             .map { $0.capitalized }
             .joined(separator: " ")

--- a/QuotioTests/OpenCodeProviderSplitTests.swift
+++ b/QuotioTests/OpenCodeProviderSplitTests.swift
@@ -103,6 +103,114 @@ final class OpenCodeProviderSplitTests: XCTestCase {
         XCTAssertFalse(quotioModels.keys.contains("gemini-3-pro-preview"))
     }
 
+    // MARK: - Model selection example (#227 review)
+    //
+    // OpenCode selects models by `provider_id/model_id`, where `provider_id` is
+    // the key under `provider` in opencode.json — https://opencode.ai/docs/models/
+    // After the split a Gemini-native model lives under `quotio-gemini`, so the
+    // example shown to the user must not hardcode the `quotio` prefix.
+
+    func testModelSelectorUsesGeminiProviderForGeminiNativeModels() {
+        XCTAssertEqual(
+            AgentConfigurationService.openCodeModelSelector(for: "gemini-3-pro-preview"),
+            "quotio-gemini/gemini-3-pro-preview"
+        )
+        XCTAssertEqual(
+            AgentConfigurationService.openCodeModelSelector(for: "gemini-2.5-flash"),
+            "quotio-gemini/gemini-2.5-flash"
+        )
+    }
+
+    func testModelSelectorUsesAnthropicProviderForEverythingElse() {
+        XCTAssertEqual(
+            AgentConfigurationService.openCodeModelSelector(for: "gemini-claude-sonnet-4-5"),
+            "quotio/gemini-claude-sonnet-4-5"
+        )
+        XCTAssertEqual(
+            AgentConfigurationService.openCodeModelSelector(for: "gpt-5.1-codex"),
+            "quotio/gpt-5.1-codex"
+        )
+    }
+
+    /// Regression: a list whose first entry is Gemini-native must not be
+    /// advertised as `quotio/<model>` — that provider does not contain it.
+    func testSelectorExampleForGeminiFirstModelList() {
+        let models = [
+            AvailableModel(id: "gemini-3-pro-preview", name: "gemini-3-pro-preview", provider: "google", isDefault: false),
+            AvailableModel(id: "gpt-5.1-codex", name: "gpt-5.1-codex", provider: "openai", isDefault: false)
+        ]
+
+        XCTAssertEqual(
+            AgentConfigurationService.openCodeModelSelectorExample(models: models),
+            "quotio-gemini/gemini-3-pro-preview"
+        )
+    }
+
+    /// Regression: a Gemini-only list emits no `quotio` provider at all, so the
+    /// example must point at `quotio-gemini`.
+    func testSelectorExampleForGeminiOnlyModelList() {
+        let models = [
+            AvailableModel(id: "gemini-2.5-flash", name: "gemini-2.5-flash", provider: "google", isDefault: false),
+            AvailableModel(id: "gemini-3-pro-preview", name: "gemini-3-pro-preview", provider: "google", isDefault: false)
+        ]
+
+        XCTAssertEqual(
+            AgentConfigurationService.openCodeModelSelectorExample(models: models),
+            "quotio-gemini/gemini-2.5-flash"
+        )
+    }
+
+    func testSelectorExampleForAnthropicFirstModelList() {
+        XCTAssertEqual(
+            AgentConfigurationService.openCodeModelSelectorExample(models: mixedModels),
+            "quotio/gemini-claude-opus-4-6-thinking"
+        )
+    }
+
+    func testSelectorExampleFallsBackWhenNoModelsAreAvailable() {
+        XCTAssertEqual(
+            AgentConfigurationService.openCodeModelSelectorExample(models: []),
+            "quotio/model"
+        )
+    }
+
+    /// The advertised example must always resolve inside the config that is
+    /// actually written: the provider key must be emitted, and the model must
+    /// be one of that provider's models.
+    func testSelectorExampleAlwaysResolvesInsideGeneratedEntries() throws {
+        let geminiOnly = [
+            AvailableModel(id: "gemini-2.5-flash", name: "gemini-2.5-flash", provider: "google", isDefault: false)
+        ]
+        let anthropicOnly = [
+            AvailableModel(id: "gpt-5.1-codex", name: "gpt-5.1-codex", provider: "openai", isDefault: false)
+        ]
+        let geminiFirst = [
+            AvailableModel(id: "gemini-3-pro-preview", name: "gemini-3-pro-preview", provider: "google", isDefault: false),
+            AvailableModel(id: "gemini-claude-sonnet-4-5", name: "gemini-claude-sonnet-4-5", provider: "anthropic", isDefault: false)
+        ]
+
+        for models in [mixedModels, geminiOnly, anthropicOnly, geminiFirst, AvailableModel.allModels] {
+            let entries = AgentConfigurationService.openCodeQuotioProviderEntries(
+                models: models,
+                apiKey: apiKey,
+                baseURL: baseURL
+            )
+            let example = AgentConfigurationService.openCodeModelSelectorExample(models: models)
+            let parts = example.split(separator: "/", maxSplits: 1).map(String.init)
+            XCTAssertEqual(parts.count, 2, "Example must be provider_id/model_id, got \(example)")
+
+            let providerEntry = try XCTUnwrap(
+                entries[parts[0]],
+                "Example \(example) references provider '\(parts[0])' that is not emitted"
+            )
+            let providerModels = try XCTUnwrap(providerEntry["models"] as? [String: Any])
+            XCTAssertNotNil(
+                providerModels[parts[1]],
+                "Example \(example) references a model missing from provider '\(parts[0])'"
+            )
+        }
+    }
+
     // MARK: - openCodeProvidersApplyingQuotioEntries
 
     func testApplyingEntriesPreservesUserProviders() throws {

--- a/QuotioTests/OpenCodeProviderSplitTests.swift
+++ b/QuotioTests/OpenCodeProviderSplitTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+@testable import Quotio
+
+final class OpenCodeProviderSplitTests: XCTestCase {
+
+    private let apiKey = "quotio-local-test"
+    private let baseURL = "http://127.0.0.1:8317"
+
+    private let mixedModels: [AvailableModel] = [
+        AvailableModel(id: "gemini-claude-opus-4-6-thinking", name: "gemini-claude-opus-4-6-thinking", provider: "anthropic", isDefault: false),
+        AvailableModel(id: "gemini-claude-sonnet-4-5", name: "gemini-claude-sonnet-4-5", provider: "anthropic", isDefault: false),
+        AvailableModel(id: "gemini-3-pro-preview", name: "gemini-3-pro-preview", provider: "google", isDefault: false),
+        AvailableModel(id: "gemini-2.5-flash", name: "gemini-2.5-flash", provider: "google", isDefault: false),
+        AvailableModel(id: "gpt-5.1-codex", name: "gpt-5.1-codex", provider: "openai", isDefault: false)
+    ]
+
+    // MARK: - isOpenCodeGeminiNativeModel
+
+    func testGeminiNativeModelsAreDetected() {
+        XCTAssertTrue(AgentConfigurationService.isOpenCodeGeminiNativeModel("gemini-3-pro-preview"))
+        XCTAssertTrue(AgentConfigurationService.isOpenCodeGeminiNativeModel("gemini-3-flash-preview"))
+        XCTAssertTrue(AgentConfigurationService.isOpenCodeGeminiNativeModel("gemini-2.5-flash"))
+        XCTAssertTrue(AgentConfigurationService.isOpenCodeGeminiNativeModel("gemini-2.5-computer-use-preview-10-2025"))
+    }
+
+    func testAntigravityClaudeModelsStayOnAnthropicProtocol() {
+        XCTAssertFalse(AgentConfigurationService.isOpenCodeGeminiNativeModel("gemini-claude-opus-4-6-thinking"))
+        XCTAssertFalse(AgentConfigurationService.isOpenCodeGeminiNativeModel("gemini-claude-sonnet-4-5"))
+        XCTAssertFalse(AgentConfigurationService.isOpenCodeGeminiNativeModel("claude-sonnet-4-5"))
+    }
+
+    func testNonGeminiModelsAreNotGeminiNative() {
+        XCTAssertFalse(AgentConfigurationService.isOpenCodeGeminiNativeModel("gpt-5.1-codex"))
+        XCTAssertFalse(AgentConfigurationService.isOpenCodeGeminiNativeModel("qwen3-coder-plus"))
+    }
+
+    // MARK: - openCodeQuotioProviderEntries
+
+    func testMixedModelsProduceTwoProviders() throws {
+        let entries = AgentConfigurationService.openCodeQuotioProviderEntries(
+            models: mixedModels,
+            apiKey: apiKey,
+            baseURL: baseURL
+        )
+
+        XCTAssertEqual(Set(entries.keys), ["quotio", "quotio-gemini"])
+
+        let quotio = try XCTUnwrap(entries["quotio"])
+        XCTAssertEqual(quotio["npm"] as? String, "@ai-sdk/anthropic")
+        let quotioOptions = try XCTUnwrap(quotio["options"] as? [String: Any])
+        XCTAssertEqual(quotioOptions["baseURL"] as? String, "http://127.0.0.1:8317/v1")
+        XCTAssertEqual(quotioOptions["apiKey"] as? String, apiKey)
+        XCTAssertEqual(quotioOptions["litellmProxy"] as? Bool, true)
+        let quotioModels = try XCTUnwrap(quotio["models"] as? [String: Any])
+        XCTAssertEqual(Set(quotioModels.keys), [
+            "gemini-claude-opus-4-6-thinking",
+            "gemini-claude-sonnet-4-5",
+            "gpt-5.1-codex"
+        ])
+
+        let gemini = try XCTUnwrap(entries["quotio-gemini"])
+        XCTAssertEqual(gemini["npm"] as? String, "@ai-sdk/google")
+        XCTAssertEqual(gemini["name"] as? String, "Quotio (Gemini)")
+        let geminiOptions = try XCTUnwrap(gemini["options"] as? [String: Any])
+        XCTAssertEqual(geminiOptions["baseURL"] as? String, "http://127.0.0.1:8317/v1beta")
+        XCTAssertEqual(geminiOptions["apiKey"] as? String, apiKey)
+        XCTAssertNil(geminiOptions["litellmProxy"], "Anthropic-specific option must not leak into the Google provider")
+        let geminiModels = try XCTUnwrap(gemini["models"] as? [String: Any])
+        XCTAssertEqual(Set(geminiModels.keys), ["gemini-3-pro-preview", "gemini-2.5-flash"])
+    }
+
+    func testNoGeminiModelsProducesSingleProviderAsBefore() throws {
+        let models = [
+            AvailableModel(id: "gemini-claude-sonnet-4-5", name: "gemini-claude-sonnet-4-5", provider: "anthropic", isDefault: false),
+            AvailableModel(id: "gpt-5.1-codex", name: "gpt-5.1-codex", provider: "openai", isDefault: false)
+        ]
+
+        let entries = AgentConfigurationService.openCodeQuotioProviderEntries(
+            models: models,
+            apiKey: apiKey,
+            baseURL: baseURL
+        )
+
+        XCTAssertEqual(Set(entries.keys), ["quotio"])
+        let quotio = try XCTUnwrap(entries["quotio"])
+        let quotioModels = try XCTUnwrap(quotio["models"] as? [String: Any])
+        XCTAssertEqual(Set(quotioModels.keys), ["gemini-claude-sonnet-4-5", "gpt-5.1-codex"])
+    }
+
+    func testDefaultModelCatalogSplitsIntoBothProviders() throws {
+        let entries = AgentConfigurationService.openCodeQuotioProviderEntries(
+            models: AvailableModel.allModels,
+            apiKey: apiKey,
+            baseURL: baseURL
+        )
+
+        XCTAssertEqual(Set(entries.keys), ["quotio", "quotio-gemini"])
+        let quotioModels = try XCTUnwrap(entries["quotio"]?["models"] as? [String: Any])
+        let geminiModels = try XCTUnwrap(entries["quotio-gemini"]?["models"] as? [String: Any])
+        XCTAssertEqual(quotioModels.count + geminiModels.count, AvailableModel.allModels.count)
+        XCTAssertTrue(geminiModels.keys.allSatisfy { $0.contains("gemini") && !$0.contains("claude") })
+        XCTAssertTrue(quotioModels.keys.contains("gemini-claude-opus-4-6-thinking"))
+        XCTAssertFalse(quotioModels.keys.contains("gemini-3-pro-preview"))
+    }
+
+    // MARK: - openCodeProvidersApplyingQuotioEntries
+
+    func testApplyingEntriesPreservesUserProviders() throws {
+        let existing: [String: Any] = [
+            "myrouter": ["npm": "@ai-sdk/openai-compatible"],
+            "quotio": ["options": ["apiKey": "stale-key"]]
+        ]
+
+        let entries = AgentConfigurationService.openCodeQuotioProviderEntries(
+            models: mixedModels,
+            apiKey: apiKey,
+            baseURL: baseURL
+        )
+        let updated = AgentConfigurationService.openCodeProvidersApplyingQuotioEntries(existing, entries: entries)
+
+        XCTAssertNotNil(updated["myrouter"], "User-defined provider must survive")
+        let quotio = try XCTUnwrap(updated["quotio"] as? [String: Any])
+        let options = try XCTUnwrap(quotio["options"] as? [String: Any])
+        XCTAssertEqual(options["apiKey"] as? String, apiKey, "Stale quotio entry must be replaced")
+        XCTAssertNotNil(updated["quotio-gemini"])
+    }
+
+    func testApplyingEntriesRemovesStaleGeminiProviderWhenNoGeminiModelsRemain() {
+        let existing: [String: Any] = [
+            "quotio": ["name": "Quotio"],
+            "quotio-gemini": ["name": "Quotio (Gemini)"],
+            "myrouter": ["npm": "@ai-sdk/openai-compatible"]
+        ]
+
+        let entries = AgentConfigurationService.openCodeQuotioProviderEntries(
+            models: [AvailableModel(id: "gpt-5.1-codex", name: "gpt-5.1-codex", provider: "openai", isDefault: false)],
+            apiKey: apiKey,
+            baseURL: baseURL
+        )
+        let updated = AgentConfigurationService.openCodeProvidersApplyingQuotioEntries(existing, entries: entries)
+
+        XCTAssertNil(updated["quotio-gemini"], "Stale Quotio-managed Gemini provider must be removed")
+        XCTAssertNotNil(updated["quotio"])
+        XCTAssertNotNil(updated["myrouter"])
+    }
+
+    // MARK: - openCodeConfigRemovingQuotioProviders
+
+    func testRevertRemovesBothQuotioManagedProviders() throws {
+        let config: [String: Any] = [
+            "$schema": "https://opencode.ai/config.json",
+            "theme": "dark",
+            "provider": [
+                "quotio": ["name": "Quotio"],
+                "quotio-gemini": ["name": "Quotio (Gemini)"],
+                "myrouter": ["npm": "@ai-sdk/openai-compatible"]
+            ]
+        ]
+
+        let updated = AgentConfigurationService.openCodeConfigRemovingQuotioProviders(config)
+
+        XCTAssertEqual(updated["theme"] as? String, "dark")
+        let providers = try XCTUnwrap(updated["provider"] as? [String: Any])
+        XCTAssertNil(providers["quotio"])
+        XCTAssertNil(providers["quotio-gemini"])
+        XCTAssertNotNil(providers["myrouter"])
+    }
+
+    func testRevertDropsEmptyProviderObject() {
+        let config: [String: Any] = [
+            "theme": "dark",
+            "provider": [
+                "quotio": ["name": "Quotio"],
+                "quotio-gemini": ["name": "Quotio (Gemini)"]
+            ]
+        ]
+
+        let updated = AgentConfigurationService.openCodeConfigRemovingQuotioProviders(config)
+
+        XCTAssertEqual(updated["theme"] as? String, "dark")
+        XCTAssertNil(updated["provider"])
+    }
+
+    func testRevertLeavesConfigWithoutProvidersUntouched() {
+        let config: [String: Any] = ["theme": "dark"]
+
+        let updated = AgentConfigurationService.openCodeConfigRemovingQuotioProviders(config)
+
+        XCTAssertEqual(updated.count, 1)
+        XCTAssertEqual(updated["theme"] as? String, "dark")
+    }
+}


### PR DESCRIPTION
## Motivation

From #227:

> Right now, autoconfiguring Opencode will put all models in a Anthropic-flavor provider. This works great for Claude, but gives Gemini models on Antigravity an identity crisis where they start spending time on contemplating whether they are Opencode or Antigravity instead of doing the task.
>
> This is reported not to happen when using those models on Google's protocol on the /v1beta endpoint. Make it so that the automatic config for Opencode creates 2 separate providers for the assorted models.

`generateOpenCodeConfig` previously emitted a single `provider.quotio` entry with `npm: "@ai-sdk/anthropic"` and `baseURL: <proxy>/v1`, and dumped every model into it — including the Gemini-native ones (`gemini-3-pro-preview`, `gemini-2.5-flash`, ...) that Antigravity exposes alongside its `gemini-claude-*` Claude models.

## Protocol / endpoint reference

CLIProxyAPI exposes a Gemini-native (Google protocol) surface on `/v1beta` in addition to the OpenAI/Anthropic-compatible `/v1` routes — `internal/api/server_routes.go`:

```go
// Gemini compatible API routes
v1beta := s.engine.Group("/v1beta")
v1beta.Use(AuthMiddleware(s.accessManager))
{
    v1beta.GET("/models", s.geminiModelsHandler(geminiHandlers))
    v1beta.POST("/interactions", geminiHandlers.Interactions)
    v1beta.POST("/models/*action", geminiHandlers.GeminiHandler)
    v1beta.GET("/models/*action", s.geminiGetHandler(geminiHandlers))
}
```

So the endpoint the reporter describes really is available locally, and OpenCode can reach it through the `@ai-sdk/google` provider package.

## What changed

When OpenCode config is generated, models are partitioned deterministically by id:

- **`provider.quotio`** — unchanged: `@ai-sdk/anthropic`, `<proxy>/v1`, `litellmProxy: true`. Holds Claude models (including Antigravity's `gemini-claude-*` ids) and everything else (GPT, Qwen, MiniMax, ...).
- **`provider.quotio-gemini`** — new: `@ai-sdk/google`, `<proxy>/v1beta`. Holds Gemini-native models only.

The Gemini entry is emitted **only when Gemini-native models are present**, so non-Antigravity setups produce exactly the same single-provider config as today.

The partition rule is a small pure function: a model is Gemini-native when its id contains `gemini` and does *not* contain `claude`. That keeps `gemini-claude-opus-4-6-thinking` on the Anthropic protocol, which is where it belongs.

Revert (`generateOpenCodeDefaultConfig`) now removes both Quotio-managed provider keys, and re-running the setup drops a stale `quotio-gemini` entry if the Gemini models disappear from the account. User-defined providers and all other fields are preserved in both directions.

The new logic lives in pure `nonisolated static` helpers so it is unit-testable without touching the filesystem:

- `isOpenCodeGeminiNativeModel(_:)`
- `openCodeQuotioProviderEntries(models:apiKey:baseURL:)`
- `openCodeProvidersApplyingQuotioEntries(_:entries:)`
- `openCodeConfigRemovingQuotioProviders(_:)`

## Note on overlap with #477

#477 (same fork) reworks the same OpenCode functions: it makes the merge/revert JSONC-tolerant via `mergedOpenCodeJSON(existing:quotioProvider:)` and `openCodeJSONRemovingQuotioProvider(existing:)`. This PR is based on `master` and does not depend on it, but the two touch adjacent lines in `generateOpenCodeConfig` / `generateOpenCodeDefaultConfig`, so a merge conflict is likely whichever lands second. The resolution is mechanical and I'm happy to rebase whichever one you merge later:

- `mergedOpenCodeJSON` grows a `quotioProviders: [String: [String: Any]]` parameter instead of a single `quotioProvider`, applied through `openCodeProvidersApplyingQuotioEntries`.
- `openCodeJSONRemovingQuotioProvider` drops both managed keys via `openCodeConfigRemovingQuotioProviders` (the "nothing to remove → leave file untouched" behaviour is preserved by checking whether either key is present).

## Test evidence

New `QuotioTests/OpenCodeProviderSplitTests.swift` (11 cases) covers:

- partitioning: Gemini-native detection, `gemini-claude-*` staying on Anthropic, non-Gemini models
- two-provider emission for a mixed Antigravity model list (npm packages, `/v1` vs `/v1beta` baseURLs, model membership, no `litellmProxy` leaking into the Google provider)
- the full `AvailableModel.allModels` catalog splitting with no model lost
- single-provider output preserved when no Gemini-native models exist
- merge preserving user-defined providers and replacing a stale `quotio` entry
- stale `quotio-gemini` removal on re-run
- revert removing both managed keys, dropping an empty `provider` object, and leaving a provider-less config untouched

```
xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build
** BUILD SUCCEEDED **

xcodebuild test -project Quotio.xcodeproj -scheme Quotio -configuration Debug -destination 'platform=macOS'
** TEST SUCCEEDED **   (77 tests passed, including the 11 new ones)
```

Closes #227
