### PR TITLE
feat(dashboard): show available models in the app panel

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -3539,6 +3539,34 @@
         }
       }
     },
+    "availableModels.live" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live from the proxy · fetched at %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En direct depuis le proxy · récupéré à %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trực tiếp từ proxy · lấy lúc %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "实时来自代理 · 获取于 %@"
+          }
+        }
+      }
+    },
     "availableModels.loading" : {
       "localizations" : {
         "en" : {
@@ -3595,6 +3623,62 @@
         }
       }
     },
+    "availableModels.owner" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Owner: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Propriétaire : %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chủ sở hữu: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有者：%@"
+          }
+        }
+      }
+    },
+    "availableModels.ownerNote" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Owner is the model-owner metadata reported by /v1/models. It does not indicate which provider account will serve a request."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le propriétaire est la métadonnée de propriétaire du modèle signalée par /v1/models. Elle n'indique pas quel compte fournisseur traitera une requête."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chủ sở hữu là siêu dữ liệu về chủ sở hữu mô hình do /v1/models cung cấp. Nó không cho biết tài khoản nhà cung cấp nào sẽ xử lý yêu cầu."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有者是 /v1/models 提供的模型所有者元数据，并不表示哪个提供商账户会处理请求。"
+          }
+        }
+      }
+    },
     "availableModels.proxyStopped" : {
       "localizations" : {
         "en" : {
@@ -3619,6 +3703,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启动代理以查看可用的模型。"
+          }
+        }
+      }
+    },
+    "availableModels.stale" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh failed — showing the list fetched at %@, which may be out of date."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de l'actualisation — affichage de la liste récupérée à %@, qui peut être obsolète."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Làm mới thất bại — đang hiển thị danh sách lấy lúc %@, có thể đã lỗi thời."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新失败 — 显示的是 %@ 获取的列表，可能已过时。"
           }
         }
       }

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -3427,6 +3427,202 @@
         }
       }
     },
+    "availableModels.copied" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copied"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copié"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã sao chép"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已复制"
+          }
+        }
+      }
+    },
+    "availableModels.description" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Click a model ID to copy it for use in your client configuration."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cliquez sur un identifiant de modèle pour le copier dans la configuration de votre client."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhấp vào ID mô hình để sao chép và dùng trong cấu hình client của bạn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点按模型 ID 即可复制，用于客户端配置。"
+          }
+        }
+      }
+    },
+    "availableModels.empty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The proxy did not report any models. Add a provider account, then refresh."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le proxy n'a signalé aucun modèle. Ajoutez un compte fournisseur, puis actualisez."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proxy không trả về mô hình nào. Hãy thêm tài khoản nhà cung cấp rồi làm mới."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "代理未返回任何模型。请添加提供商账户后刷新。"
+          }
+        }
+      }
+    },
+    "availableModels.error" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not load the model list from the proxy. Try refreshing."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de charger la liste des modèles depuis le proxy. Essayez d'actualiser."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể tải danh sách mô hình từ proxy. Hãy thử làm mới."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法从代理加载模型列表。请尝试刷新。"
+          }
+        }
+      }
+    },
+    "availableModels.loading" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading models..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chargement des modèles..."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang tải mô hình..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在加载模型…"
+          }
+        }
+      }
+    },
+    "availableModels.modelCount" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d models"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d modèles"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d mô hình"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 个模型"
+          }
+        }
+      }
+    },
+    "availableModels.proxyStopped" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start the proxy to see the models you can use."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Démarrez le proxy pour voir les modèles que vous pouvez utiliser."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khởi động proxy để xem các mô hình bạn có thể dùng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启动代理以查看可用的模型。"
+          }
+        }
+      }
+    },
     "badge.experimental" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -5675,6 +5871,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "API 端点"
+          }
+        }
+      }
+    },
+    "dashboard.availableModels" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Available Models"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modèles disponibles"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mô hình khả dụng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可用模型"
           }
         }
       }

--- a/Quotio/Models/ModelCatalog.swift
+++ b/Quotio/Models/ModelCatalog.swift
@@ -3,26 +3,135 @@
 //  Quotio
 //
 //  Pure helpers for parsing the proxy's OpenAI-compatible /v1/models
-//  response and grouping the resulting models by provider for display.
+//  response, plus the display state that keeps a live catalog readout
+//  distinguishable from a stale one.
 //
 
 import Foundation
 
-/// Models exposed by the proxy for a single provider.
-nonisolated struct ProviderModelGroup: Identifiable, Equatable, Sendable {
-    let provider: String
-    let models: [AvailableModel]
+/// One entry of the proxy's OpenAI-compatible `/v1/models` response.
+///
+/// This is deliberately a thin mirror of the wire format. It carries only what
+/// `/v1/models` actually states: the model ID, and the `owned_by` metadata when
+/// present. It says nothing about which provider account will serve a request
+/// for the ID — the endpoint does not expose that.
+nonisolated struct ModelCatalogEntry: Identifiable, Equatable, Sendable {
+    /// The model ID exactly as listed by `/v1/models`.
+    let id: String
 
-    var id: String { provider }
+    /// Raw `owned_by` value, or `nil` when the response omitted the field.
+    ///
+    /// This is static model-owner metadata. CLIProxyAPI deduplicates `/v1/models`
+    /// by ID and tracks serving providers separately, so the value here may be
+    /// replaced when another provider registers the same ID. Do not treat it as
+    /// routing provenance.
+    let owner: String?
+
+    /// Owner metadata fit for display, or `nil` when the endpoint reported
+    /// nothing usable (field absent, empty, or whitespace only).
+    var displayOwner: String? {
+        guard let trimmed = owner?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else { return nil }
+        return trimmed
+    }
+}
+
+/// How the catalog currently on screen relates to the proxy's live state.
+nonisolated enum ModelCatalogFreshness: Equatable, Sendable {
+    /// Nothing has been fetched successfully yet.
+    case never
+
+    /// The entries are exactly what `/v1/models` returned at `fetchedAt`.
+    case live(fetchedAt: Date)
+
+    /// A previous successful response is still on screen because a later
+    /// fetch failed; it may no longer match the proxy.
+    case stale(fetchedAt: Date)
+}
+
+/// Display state for the read-only model catalog.
+///
+/// Unlike `AgentSetupViewModel.availableModels`, this never substitutes
+/// `AvailableModel.allModels` (or any other built-in list) for a missing or
+/// failed response: a successful empty response stays empty, and a failed
+/// refresh is reported as such instead of being papered over. That distinction
+/// is what lets the UI claim "live" only when it really is.
+nonisolated struct ModelCatalogState: Equatable, Sendable {
+    /// Entries currently on screen, deduplicated by ID and sorted.
+    private(set) var entries: [ModelCatalogEntry] = []
+
+    private(set) var freshness: ModelCatalogFreshness = .never
+
+    /// A fetch is in flight.
+    private(set) var isLoading = false
+
+    /// The most recent fetch attempt failed.
+    private(set) var lastFetchFailed = false
+
+    /// At least one fetch attempt has completed (successfully or not).
+    ///
+    /// Distinguishes "not fetched yet" from "fetched, and the proxy listed
+    /// nothing" so the empty state is reachable.
+    private(set) var hasCompletedFetch = false
+
+    /// The proxy answered successfully and listed no models at all.
+    var isEmptyLiveResult: Bool {
+        hasCompletedFetch && !lastFetchFailed && entries.isEmpty
+    }
+
+    mutating func beginLoading() {
+        isLoading = true
+    }
+
+    /// Records a successful `/v1/models` response verbatim.
+    mutating func apply(entries: [ModelCatalogEntry], fetchedAt: Date) {
+        self.entries = ModelCatalog.displayEntries(entries)
+        freshness = .live(fetchedAt: fetchedAt)
+        isLoading = false
+        lastFetchFailed = false
+        hasCompletedFetch = true
+    }
+
+    /// Records a failed fetch, keeping any earlier response but demoting it to stale.
+    mutating func applyFailure() {
+        isLoading = false
+        lastFetchFailed = true
+        hasCompletedFetch = true
+
+        switch freshness {
+        case .never:
+            break
+        case .live(let fetchedAt), .stale(let fetchedAt):
+            freshness = .stale(fetchedAt: fetchedAt)
+        }
+    }
+
+    /// Drops everything, e.g. when the proxy stops and nothing on screen can be trusted.
+    mutating func reset() {
+        self = ModelCatalogState()
+    }
+}
+
+nonisolated enum ModelCatalogError: LocalizedError, Equatable {
+    /// No running proxy to ask, so no catalog can be fetched.
+    case proxyUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .proxyUnavailable:
+            return "The proxy is not available."
+        }
+    }
 }
 
 nonisolated enum ModelCatalog {
 
-    /// Decodes an OpenAI-compatible `/v1/models` response body into models.
+    /// Decodes an OpenAI-compatible `/v1/models` response body.
     ///
-    /// Each item's `owned_by` field becomes the model's provider,
-    /// defaulting to `"openai"` when absent (mirrors historical behavior).
-    static func parse(_ data: Data) throws -> [AvailableModel] {
+    /// The result mirrors the response exactly: no defaults are substituted and
+    /// no entries are added or dropped.
+    static func parse(_ data: Data) throws -> [ModelCatalogEntry] {
         struct ModelsResponse: Decodable {
             struct ModelItem: Decodable {
                 let id: String
@@ -32,32 +141,32 @@ nonisolated enum ModelCatalog {
         }
 
         let decoded = try JSONDecoder().decode(ModelsResponse.self, from: data)
-        return decoded.data.map { item in
+        return decoded.data.map { ModelCatalogEntry(id: $0.id, owner: $0.owned_by) }
+    }
+
+    /// Prepares entries for display: deduplicated by ID (first occurrence wins,
+    /// matching the proxy registry's own by-ID deduplication) and sorted by ID.
+    static func displayEntries(_ entries: [ModelCatalogEntry]) -> [ModelCatalogEntry] {
+        var seen = Set<String>()
+        return entries
+            .filter { seen.insert($0.id).inserted }
+            .sorted { $0.id.localizedCaseInsensitiveCompare($1.id) == .orderedAscending }
+    }
+
+    /// Maps catalog entries onto the agent-setup model list.
+    ///
+    /// Preserves the historical `owned_by ?? "openai"` provider default that
+    /// `AgentConfigurationService.fetchAvailableModels(config:)` — and through it
+    /// the agent-config sheet, the warmup sheet and the fallback screen — rely on
+    /// (the GitHub Copilot filter matches on `provider == "github-copilot"`).
+    static func agentSetupModels(from entries: [ModelCatalogEntry]) -> [AvailableModel] {
+        entries.map { entry in
             AvailableModel(
-                id: item.id,
-                name: item.id,
-                provider: item.owned_by ?? "openai",
+                id: entry.id,
+                name: entry.id,
+                provider: entry.owner ?? "openai",
                 isDefault: false
             )
         }
-    }
-
-    /// Groups models by provider for display.
-    ///
-    /// Providers are sorted alphabetically (case-insensitive) and models
-    /// within each provider are sorted by id. Duplicate model ids within
-    /// the same provider are collapsed.
-    static func groupByProvider(_ models: [AvailableModel]) -> [ProviderModelGroup] {
-        let grouped = Dictionary(grouping: models) { $0.provider }
-
-        return grouped
-            .map { provider, models -> ProviderModelGroup in
-                var seen = Set<String>()
-                let uniqueSorted = models
-                    .sorted { $0.id.localizedCaseInsensitiveCompare($1.id) == .orderedAscending }
-                    .filter { seen.insert($0.id).inserted }
-                return ProviderModelGroup(provider: provider, models: uniqueSorted)
-            }
-            .sorted { $0.provider.localizedCaseInsensitiveCompare($1.provider) == .orderedAscending }
     }
 }

--- a/Quotio/Models/ModelCatalog.swift
+++ b/Quotio/Models/ModelCatalog.swift
@@ -1,0 +1,63 @@
+//
+//  ModelCatalog.swift
+//  Quotio
+//
+//  Pure helpers for parsing the proxy's OpenAI-compatible /v1/models
+//  response and grouping the resulting models by provider for display.
+//
+
+import Foundation
+
+/// Models exposed by the proxy for a single provider.
+nonisolated struct ProviderModelGroup: Identifiable, Equatable, Sendable {
+    let provider: String
+    let models: [AvailableModel]
+
+    var id: String { provider }
+}
+
+nonisolated enum ModelCatalog {
+
+    /// Decodes an OpenAI-compatible `/v1/models` response body into models.
+    ///
+    /// Each item's `owned_by` field becomes the model's provider,
+    /// defaulting to `"openai"` when absent (mirrors historical behavior).
+    static func parse(_ data: Data) throws -> [AvailableModel] {
+        struct ModelsResponse: Decodable {
+            struct ModelItem: Decodable {
+                let id: String
+                let owned_by: String?
+            }
+            let data: [ModelItem]
+        }
+
+        let decoded = try JSONDecoder().decode(ModelsResponse.self, from: data)
+        return decoded.data.map { item in
+            AvailableModel(
+                id: item.id,
+                name: item.id,
+                provider: item.owned_by ?? "openai",
+                isDefault: false
+            )
+        }
+    }
+
+    /// Groups models by provider for display.
+    ///
+    /// Providers are sorted alphabetically (case-insensitive) and models
+    /// within each provider are sorted by id. Duplicate model ids within
+    /// the same provider are collapsed.
+    static func groupByProvider(_ models: [AvailableModel]) -> [ProviderModelGroup] {
+        let grouped = Dictionary(grouping: models) { $0.provider }
+
+        return grouped
+            .map { provider, models -> ProviderModelGroup in
+                var seen = Set<String>()
+                let uniqueSorted = models
+                    .sorted { $0.id.localizedCaseInsensitiveCompare($1.id) == .orderedAscending }
+                    .filter { seen.insert($0.id).inserted }
+                return ProviderModelGroup(provider: provider, models: uniqueSorted)
+            }
+            .sorted { $0.provider.localizedCaseInsensitiveCompare($1.provider) == .orderedAscending }
+    }
+}

--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -1417,41 +1417,20 @@ actor AgentConfigurationService {
             throw URLError(.badServerResponse)
         }
 
-        // Parse struct matching OpenAI /v1/models response
-        struct ModelsResponse: Decodable {
-            struct ModelItem: Decodable {
-                let id: String
-                let owned_by: String?
-            }
-            let data: [ModelItem]
-        }
-
-        let decoded = try JSONDecoder().decode(ModelsResponse.self, from: data)
+        // Parse OpenAI-compatible /v1/models response
+        let parsedModels = try ModelCatalog.parse(data)
 
         // Fetch available Copilot models to filter out unavailable ones
         let copilotFetcher = CopilotQuotaFetcher()
         let availableCopilotModelIds = await copilotFetcher.fetchUserAvailableModelIds()
 
-        return decoded.data.compactMap { item in
-            let provider = item.owned_by ?? "openai"
-
+        return parsedModels.filter { model in
             // Filter GitHub Copilot models - only include those actually available to the user
-            if provider == "github-copilot" {
-                // If we have Copilot accounts, filter by available models
-                if !availableCopilotModelIds.isEmpty {
-                    guard availableCopilotModelIds.contains(item.id) else {
-                        return nil
-                    }
-                }
-                // If no Copilot accounts, still show the model (user might add account later)
+            // If no Copilot accounts, still show the model (user might add account later)
+            if model.provider == "github-copilot", !availableCopilotModelIds.isEmpty {
+                return availableCopilotModelIds.contains(model.id)
             }
-
-            return AvailableModel(
-                id: item.id,
-                name: item.id,
-                provider: provider,
-                isDefault: false
-            )
+            return true
         }
     }
     

--- a/Quotio/Services/AgentConfigurationService.swift
+++ b/Quotio/Services/AgentConfigurationService.swift
@@ -1400,7 +1400,13 @@ actor AgentConfigurationService {
         }
     }
     
-    func fetchAvailableModels(config: AgentConfiguration) async throws -> [AvailableModel] {
+    /// Fetches the proxy's OpenAI-compatible `/v1/models` response exactly as reported.
+    ///
+    /// Nothing is substituted, cached or filtered: the result is the response body
+    /// and nothing else, and any transport/decoding problem is thrown rather than
+    /// masked. Callers that must show whether a catalog is genuinely live use this;
+    /// `fetchAvailableModels(config:)` layers agent-setup-specific filtering on top.
+    func fetchModelCatalog(config: AgentConfiguration) async throws -> [ModelCatalogEntry] {
         guard let url = URL(string: "\(config.proxyURL)/models") else {
             throw URLError(.badURL)
         }
@@ -1418,7 +1424,11 @@ actor AgentConfigurationService {
         }
 
         // Parse OpenAI-compatible /v1/models response
-        let parsedModels = try ModelCatalog.parse(data)
+        return try ModelCatalog.parse(data)
+    }
+
+    func fetchAvailableModels(config: AgentConfiguration) async throws -> [AvailableModel] {
+        let parsedModels = ModelCatalog.agentSetupModels(from: try await fetchModelCatalog(config: config))
 
         // Fetch available Copilot models to filter out unavailable ones
         let copilotFetcher = CopilotQuotaFetcher()

--- a/Quotio/ViewModels/AgentSetupViewModel.swift
+++ b/Quotio/ViewModels/AgentSetupViewModel.swift
@@ -349,31 +349,7 @@ final class AgentSetupViewModel {
     /// - Returns: `true` when models were fetched from remote successfully; `false` on fetch error.
     @discardableResult
     func loadModels(forceRefresh: Bool = false) async -> Bool {
-        // Create config if not exists (for FallbackScreen scenarios)
-        let config: AgentConfiguration
-        if let existingConfig = currentConfiguration {
-            config = existingConfig
-        } else {
-            guard let proxyManager = proxyManager else { return false }
-
-            // Use the first API key from the API Keys management interface
-            // If no keys exist, fall back to managementKey
-            let apiKey = quotaViewModel?.apiKeys.first ?? proxyManager.managementKey
-
-            // Use tunnel URL if active, otherwise use local proxy endpoint
-            let modelEndpoint: String
-            if let tunnelURL = TunnelManager.shared.tunnelState.publicURL {
-                modelEndpoint = tunnelURL
-            } else {
-                modelEndpoint = proxyManager.clientEndpoint
-            }
-
-            config = AgentConfiguration(
-                agent: .claudeCode,
-                proxyURL: modelEndpoint + "/v1",
-                apiKey: apiKey
-            )
-        }
+        guard let config = modelRequestConfiguration() else { return false }
 
         isFetchingModels = true
         defer { isFetchingModels = false }
@@ -399,6 +375,58 @@ final class AgentSetupViewModel {
 
         refreshVirtualModels()
         return loadedFromRemote
+    }
+
+    /// Builds the configuration used to talk to `/v1/models`.
+    ///
+    /// Returns `nil` when there is no configuration and no proxy manager to derive
+    /// one from — the same condition under which `loadModels(forceRefresh:)`
+    /// previously returned `false` without attempting a request.
+    private func modelRequestConfiguration() -> AgentConfiguration? {
+        // Reuse the sheet's configuration when one exists (agent-setup scenarios)
+        if let existingConfig = currentConfiguration {
+            return existingConfig
+        }
+
+        // Create config if not exists (for FallbackScreen scenarios)
+        guard let proxyManager = proxyManager else { return nil }
+
+        // Use the first API key from the API Keys management interface
+        // If no keys exist, fall back to managementKey
+        let apiKey = quotaViewModel?.apiKeys.first ?? proxyManager.managementKey
+
+        // Use tunnel URL if active, otherwise use local proxy endpoint
+        let modelEndpoint: String
+        if let tunnelURL = TunnelManager.shared.tunnelState.publicURL {
+            modelEndpoint = tunnelURL
+        } else {
+            modelEndpoint = proxyManager.clientEndpoint
+        }
+
+        return AgentConfiguration(
+            agent: .claudeCode,
+            proxyURL: modelEndpoint + "/v1",
+            apiKey: apiKey
+        )
+    }
+
+    /// Fetches the proxy's `/v1/models` catalog exactly as the endpoint reported it.
+    ///
+    /// This is the read-only counterpart to `loadModels(forceRefresh:)`, which is a
+    /// *picker* loader: it substitutes `AvailableModel.allModels` for an empty or
+    /// failed response, keeps the substituted list in `availableModels`, and appends
+    /// locally configured virtual fallback models. Those behaviors are right for
+    /// offering something to choose and wrong for claiming a model is usable, so a
+    /// catalog view must not go through it.
+    ///
+    /// This method performs no fallback, reads and writes no cached state, and does
+    /// not touch `availableModels`, so existing `loadModels` consumers are unaffected.
+    /// Errors propagate so the caller can distinguish a failure from an empty catalog.
+    func fetchModelCatalog() async throws -> [ModelCatalogEntry] {
+        guard let config = modelRequestConfiguration() else {
+            throw ModelCatalogError.proxyUnavailable
+        }
+        return try await configurationService.fetchModelCatalog(config: config)
     }
 
     private func processModels(_ fetchedModels: [AvailableModel]) -> [AvailableModel] {

--- a/Quotio/Views/Components/AvailableModelsSection.swift
+++ b/Quotio/Views/Components/AvailableModelsSection.swift
@@ -2,8 +2,12 @@
 //  AvailableModelsSection.swift
 //  Quotio
 //
-//  Dashboard section listing the model IDs usable through the proxy,
-//  grouped by provider, with click-to-copy for pasting into configs.
+//  Dashboard section listing the model IDs the proxy reports on its
+//  OpenAI-compatible /v1/models endpoint, with click-to-copy for pasting
+//  into client configs.
+//
+//  The section shows only what that endpoint returned, and always states
+//  whether the list is live or a stale leftover from an earlier fetch.
 //
 
 import SwiftUI
@@ -11,107 +15,149 @@ import SwiftUI
 struct AvailableModelsSection: View {
     @Environment(QuotaViewModel.self) private var viewModel
 
-    @State private var isLoading = false
-    @State private var loadFailed = false
+    @State private var state = ModelCatalogState()
     @State private var copiedModelId: String?
 
     private var isProxyRunning: Bool {
         viewModel.proxyManager.proxyStatus.running
     }
 
-    private var modelGroups: [ProviderModelGroup] {
-        ModelCatalog.groupByProvider(viewModel.agentSetupViewModel.availableModels)
-    }
-
-    private var totalModelCount: Int {
-        modelGroups.reduce(0) { $0 + $1.models.count }
+    private var showsOwnerColumn: Bool {
+        state.entries.contains { $0.displayOwner != nil }
     }
 
     var body: some View {
         GroupBox {
             VStack(alignment: .leading, spacing: 12) {
-                if !isProxyRunning {
-                    noteRow(icon: "pause.circle", text: "availableModels.proxyStopped".localized())
-                } else if isLoading && modelGroups.isEmpty {
-                    HStack(spacing: 8) {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text("availableModels.loading".localized())
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.vertical, 8)
-                } else if loadFailed {
-                    noteRow(icon: "exclamationmark.triangle", text: "availableModels.error".localized())
-                } else if modelGroups.isEmpty {
-                    noteRow(icon: "tray", text: "availableModels.empty".localized())
-                } else {
-                    Text("availableModels.description".localized())
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                    ForEach(modelGroups) { group in
-                        providerGroupView(group)
-                    }
-                }
+                content
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         } label: {
-            HStack {
-                Label("dashboard.availableModels".localized(), systemImage: "cpu")
-
-                if totalModelCount > 0 {
-                    Text(String(format: "availableModels.modelCount".localized(), totalModelCount))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer()
-
-                Button {
-                    Task { await loadModels(force: true) }
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                }
-                .buttonStyle(.borderless)
-                .disabled(isLoading || !isProxyRunning)
-                .help("action.refresh".localized())
-            }
+            header
         }
-        .task {
-            await loadModelsIfNeeded()
+        .task(id: isProxyRunning) {
+            guard isProxyRunning else {
+                // Nothing on screen can be trusted once the proxy is down.
+                state.reset()
+                return
+            }
+            await loadIfNeeded()
         }
     }
 
     // MARK: - Subviews
 
-    private func providerGroupView(_ group: ProviderModelGroup) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(group.provider)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .textCase(.uppercase)
+    private var header: some View {
+        HStack {
+            Label("dashboard.availableModels".localized(), systemImage: "cpu")
 
-            ForEach(group.models) { model in
-                modelRow(model)
+            if !state.entries.isEmpty {
+                Text(String(format: "availableModels.modelCount".localized(), state.entries.count))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button {
+                Task { await load() }
+            } label: {
+                Image(systemName: "arrow.clockwise")
+            }
+            .buttonStyle(.borderless)
+            .disabled(state.isLoading || !isProxyRunning)
+            .help("action.refresh".localized())
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if !isProxyRunning {
+            noteRow(icon: "pause.circle", text: "availableModels.proxyStopped".localized())
+        } else if state.isLoading && !state.hasCompletedFetch {
+            loadingRow
+        } else if state.entries.isEmpty && state.lastFetchFailed {
+            noteRow(icon: "exclamationmark.triangle", text: "availableModels.error".localized())
+        } else if state.isEmptyLiveResult {
+            freshnessRow
+            noteRow(icon: "tray", text: "availableModels.empty".localized())
+        } else if !state.entries.isEmpty {
+            freshnessRow
+
+            Text("availableModels.description".localized())
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            ForEach(state.entries) { entry in
+                modelRow(entry)
+            }
+
+            if showsOwnerColumn {
+                Text("availableModels.ownerNote".localized())
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
             }
         }
     }
 
-    private func modelRow(_ model: AvailableModel) -> some View {
+    private var loadingRow: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text("availableModels.loading".localized())
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .padding(.vertical, 8)
+    }
+
+    /// States plainly whether the list below came from the proxy just now, or is
+    /// a leftover from an earlier fetch that could no longer be refreshed.
+    @ViewBuilder
+    private var freshnessRow: some View {
+        switch state.freshness {
+        case .never:
+            EmptyView()
+
+        case .live(let fetchedAt):
+            HStack(spacing: 6) {
+                Image(systemName: "checkmark.seal")
+                Text(String(format: "availableModels.live".localized(), timestamp(fetchedAt)))
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+        case .stale(let fetchedAt):
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle")
+                Text(String(format: "availableModels.stale".localized(), timestamp(fetchedAt)))
+            }
+            .font(.caption)
+            .foregroundStyle(.orange)
+        }
+    }
+
+    private func modelRow(_ entry: ModelCatalogEntry) -> some View {
         Button {
-            copyModelId(model.id)
+            copyModelId(entry.id)
         } label: {
             HStack(spacing: 8) {
-                Text(model.id)
+                Text(entry.id)
                     .font(.system(.callout, design: .monospaced))
                     .lineLimit(1)
                     .truncationMode(.middle)
 
                 Spacer()
 
-                if copiedModelId == model.id {
+                if let owner = entry.displayOwner {
+                    Text(String(format: "availableModels.owner".localized(), owner))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                if copiedModelId == entry.id {
                     Label("availableModels.copied".localized(), systemImage: "checkmark")
                         .font(.caption)
                         .foregroundStyle(.green)
@@ -141,6 +187,10 @@ struct AvailableModelsSection: View {
 
     // MARK: - Actions
 
+    private func timestamp(_ date: Date) -> String {
+        date.formatted(date: .omitted, time: .standard)
+    }
+
     private func copyModelId(_ modelId: String) {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(modelId, forType: .string)
@@ -154,18 +204,22 @@ struct AvailableModelsSection: View {
         }
     }
 
-    private func loadModelsIfNeeded() async {
-        guard isProxyRunning else { return }
-        guard viewModel.agentSetupViewModel.availableModels.isEmpty else { return }
-        await loadModels(force: false)
+    private func loadIfNeeded() async {
+        // A completed fetch is authoritative, including one that returned nothing,
+        // so an empty catalog is not retried as if it had never been fetched.
+        guard !state.hasCompletedFetch else { return }
+        await load()
     }
 
-    private func loadModels(force: Bool) async {
-        guard isProxyRunning else { return }
-        isLoading = true
-        defer { isLoading = false }
+    private func load() async {
+        guard isProxyRunning, !state.isLoading else { return }
 
-        let loadedFromRemote = await viewModel.agentSetupViewModel.loadModels(forceRefresh: force)
-        loadFailed = !loadedFromRemote
+        state.beginLoading()
+        do {
+            let entries = try await viewModel.agentSetupViewModel.fetchModelCatalog()
+            state.apply(entries: entries, fetchedAt: Date())
+        } catch {
+            state.applyFailure()
+        }
     }
 }

--- a/Quotio/Views/Components/AvailableModelsSection.swift
+++ b/Quotio/Views/Components/AvailableModelsSection.swift
@@ -1,0 +1,171 @@
+//
+//  AvailableModelsSection.swift
+//  Quotio
+//
+//  Dashboard section listing the model IDs usable through the proxy,
+//  grouped by provider, with click-to-copy for pasting into configs.
+//
+
+import SwiftUI
+
+struct AvailableModelsSection: View {
+    @Environment(QuotaViewModel.self) private var viewModel
+
+    @State private var isLoading = false
+    @State private var loadFailed = false
+    @State private var copiedModelId: String?
+
+    private var isProxyRunning: Bool {
+        viewModel.proxyManager.proxyStatus.running
+    }
+
+    private var modelGroups: [ProviderModelGroup] {
+        ModelCatalog.groupByProvider(viewModel.agentSetupViewModel.availableModels)
+    }
+
+    private var totalModelCount: Int {
+        modelGroups.reduce(0) { $0 + $1.models.count }
+    }
+
+    var body: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 12) {
+                if !isProxyRunning {
+                    noteRow(icon: "pause.circle", text: "availableModels.proxyStopped".localized())
+                } else if isLoading && modelGroups.isEmpty {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("availableModels.loading".localized())
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 8)
+                } else if loadFailed {
+                    noteRow(icon: "exclamationmark.triangle", text: "availableModels.error".localized())
+                } else if modelGroups.isEmpty {
+                    noteRow(icon: "tray", text: "availableModels.empty".localized())
+                } else {
+                    Text("availableModels.description".localized())
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    ForEach(modelGroups) { group in
+                        providerGroupView(group)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } label: {
+            HStack {
+                Label("dashboard.availableModels".localized(), systemImage: "cpu")
+
+                if totalModelCount > 0 {
+                    Text(String(format: "availableModels.modelCount".localized(), totalModelCount))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Button {
+                    Task { await loadModels(force: true) }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.borderless)
+                .disabled(isLoading || !isProxyRunning)
+                .help("action.refresh".localized())
+            }
+        }
+        .task {
+            await loadModelsIfNeeded()
+        }
+    }
+
+    // MARK: - Subviews
+
+    private func providerGroupView(_ group: ProviderModelGroup) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(group.provider)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+
+            ForEach(group.models) { model in
+                modelRow(model)
+            }
+        }
+    }
+
+    private func modelRow(_ model: AvailableModel) -> some View {
+        Button {
+            copyModelId(model.id)
+        } label: {
+            HStack(spacing: 8) {
+                Text(model.id)
+                    .font(.system(.callout, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                Spacer()
+
+                if copiedModelId == model.id {
+                    Label("availableModels.copied".localized(), systemImage: "checkmark")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                        .labelStyle(.titleAndIcon)
+                } else {
+                    Image(systemName: "doc.on.doc")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("action.copy".localized())
+    }
+
+    private func noteRow(icon: String, text: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .foregroundStyle(.secondary)
+            Text(text)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Actions
+
+    private func copyModelId(_ modelId: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(modelId, forType: .string)
+        copiedModelId = modelId
+
+        Task {
+            try? await Task.sleep(for: .seconds(1.5))
+            if copiedModelId == modelId {
+                copiedModelId = nil
+            }
+        }
+    }
+
+    private func loadModelsIfNeeded() async {
+        guard isProxyRunning else { return }
+        guard viewModel.agentSetupViewModel.availableModels.isEmpty else { return }
+        await loadModels(force: false)
+    }
+
+    private func loadModels(force: Bool) async {
+        guard isProxyRunning else { return }
+        isLoading = true
+        defer { isLoading = false }
+
+        let loadedFromRemote = await viewModel.agentSetupViewModel.loadModels(forceRefresh: force)
+        loadFailed = !loadedFromRemote
+    }
+}

--- a/Quotio/Views/Screens/DashboardScreen.swift
+++ b/Quotio/Views/Screens/DashboardScreen.swift
@@ -163,6 +163,7 @@ struct DashboardScreen: View {
             kpiSection
             providerSection
             endpointSection
+            AvailableModelsSection()
             tunnelSection
         }
     }

--- a/QuotioTests/ModelCatalogTests.swift
+++ b/QuotioTests/ModelCatalogTests.swift
@@ -7,7 +7,14 @@ final class ModelCatalogTests: XCTestCase {
         try XCTUnwrap(json.data(using: .utf8))
     }
 
-    // MARK: - Parsing
+    private let fetchedAt = Date(timeIntervalSince1970: 1_700_000_000)
+    private let laterFetchedAt = Date(timeIntervalSince1970: 1_700_003_600)
+
+    private func entries(_ ids: String...) -> [ModelCatalogEntry] {
+        ids.map { ModelCatalogEntry(id: $0, owner: nil) }
+    }
+
+    // MARK: - Parsing mirrors the response exactly
 
     func testParseReadsIdAndOwnedByFromModelsResponse() throws {
         let payload = try data("""
@@ -20,82 +27,73 @@ final class ModelCatalogTests: XCTestCase {
         }
         """)
 
-        let models = try ModelCatalog.parse(payload)
+        let parsed = try ModelCatalog.parse(payload)
 
-        XCTAssertEqual(models.map(\.id), ["gpt-5.2", "gemini-3-pro-preview"])
-        XCTAssertEqual(models.map(\.provider), ["openai", "google"])
-        XCTAssertEqual(models.map(\.name), models.map(\.id))
-        XCTAssertTrue(models.allSatisfy { !$0.isDefault })
+        XCTAssertEqual(parsed.map(\.id), ["gpt-5.2", "gemini-3-pro-preview"])
+        XCTAssertEqual(parsed.map(\.owner), ["openai", "google"])
     }
 
-    func testParseDefaultsMissingOwnedByToOpenAI() throws {
+    func testParseKeepsMissingOwnedByAsNilRatherThanInventingOne() throws {
         let payload = try data(#"{ "data": [ { "id": "custom-model" } ] }"#)
 
-        let models = try ModelCatalog.parse(payload)
+        let parsed = try ModelCatalog.parse(payload)
 
-        XCTAssertEqual(models.count, 1)
-        XCTAssertEqual(models[0].provider, "openai")
+        XCTAssertEqual(parsed.count, 1)
+        XCTAssertNil(parsed[0].owner)
+        XCTAssertNil(parsed[0].displayOwner)
+    }
+
+    func testDisplayOwnerTreatsBlankOwnedByAsAbsent() throws {
+        let payload = try data("""
+        { "data": [
+            { "id": "blank", "owned_by": "" },
+            { "id": "whitespace", "owned_by": "   " },
+            { "id": "padded", "owned_by": "  google  " }
+        ] }
+        """)
+
+        let parsed = try ModelCatalog.parse(payload)
+
+        XCTAssertNil(parsed[0].displayOwner)
+        XCTAssertNil(parsed[1].displayOwner)
+        XCTAssertEqual(parsed[2].displayOwner, "google")
     }
 
     func testParseReturnsEmptyListForEmptyResponse() throws {
-        let models = try ModelCatalog.parse(try data(#"{ "data": [] }"#))
-
-        XCTAssertTrue(models.isEmpty)
+        XCTAssertTrue(try ModelCatalog.parse(try data(#"{ "data": [] }"#)).isEmpty)
     }
 
     func testParseThrowsOnMalformedResponse() throws {
-        let payload = try data(#"{ "models": [ { "id": "gpt-5.2" } ] }"#)
-
-        XCTAssertThrowsError(try ModelCatalog.parse(payload))
+        XCTAssertThrowsError(try ModelCatalog.parse(try data(#"{ "models": [ { "id": "gpt-5.2" } ] }"#)))
     }
 
-    // MARK: - Grouping
+    // MARK: - Display ordering / deduplication (no routing meaning attached)
 
-    func testGroupByProviderGroupsAndSortsModels() {
-        let models = [
-            AvailableModel(id: "gpt-5.2", name: "gpt-5.2", provider: "openai", isDefault: false),
-            AvailableModel(id: "gemini-3-pro-preview", name: "gemini-3-pro-preview", provider: "google", isDefault: false),
-            AvailableModel(id: "gpt-5.1", name: "gpt-5.1", provider: "openai", isDefault: false),
-            AvailableModel(id: "gemini-2.5-flash", name: "gemini-2.5-flash", provider: "google", isDefault: false)
+    func testDisplayEntriesSortsByIdCaseInsensitively() {
+        let sorted = ModelCatalog.displayEntries(entries("gpt-5.2", "Gemini-3-pro", "gpt-5.1"))
+
+        XCTAssertEqual(sorted.map(\.id), ["Gemini-3-pro", "gpt-5.1", "gpt-5.2"])
+    }
+
+    func testDisplayEntriesCollapsesRepeatedIdsKeepingFirstOccurrence() {
+        // CLIProxyAPI deduplicates /v1/models by ID, so a repeated ID is a single
+        // model whose owner metadata may have been replaced - not two routes.
+        let input = [
+            ModelCatalogEntry(id: "claude-sonnet-4-5", owner: "anthropic"),
+            ModelCatalogEntry(id: "claude-sonnet-4-5", owner: "github-copilot")
         ]
 
-        let groups = ModelCatalog.groupByProvider(models)
+        let displayed = ModelCatalog.displayEntries(input)
 
-        XCTAssertEqual(groups.map(\.provider), ["google", "openai"])
-        XCTAssertEqual(groups[0].models.map(\.id), ["gemini-2.5-flash", "gemini-3-pro-preview"])
-        XCTAssertEqual(groups[1].models.map(\.id), ["gpt-5.1", "gpt-5.2"])
-        XCTAssertEqual(groups[0].id, "google")
+        XCTAssertEqual(displayed.count, 1)
+        XCTAssertEqual(displayed[0].owner, "anthropic")
     }
 
-    func testGroupByProviderCollapsesDuplicateModelIdsWithinProvider() {
-        let models = [
-            AvailableModel(id: "gpt-5.2", name: "gpt-5.2", provider: "openai", isDefault: false),
-            AvailableModel(id: "gpt-5.2", name: "gpt-5.2", provider: "openai", isDefault: false)
-        ]
-
-        let groups = ModelCatalog.groupByProvider(models)
-
-        XCTAssertEqual(groups.count, 1)
-        XCTAssertEqual(groups[0].models.map(\.id), ["gpt-5.2"])
+    func testDisplayEntriesReturnsEmptyForNoEntries() {
+        XCTAssertTrue(ModelCatalog.displayEntries([]).isEmpty)
     }
 
-    func testGroupByProviderKeepsSameModelIdOfferedByDifferentProviders() {
-        let models = [
-            AvailableModel(id: "claude-sonnet-4-5", name: "claude-sonnet-4-5", provider: "anthropic", isDefault: false),
-            AvailableModel(id: "claude-sonnet-4-5", name: "claude-sonnet-4-5", provider: "github-copilot", isDefault: false)
-        ]
-
-        let groups = ModelCatalog.groupByProvider(models)
-
-        XCTAssertEqual(groups.map(\.provider), ["anthropic", "github-copilot"])
-        XCTAssertEqual(groups.flatMap { $0.models.map(\.id) }.count, 2)
-    }
-
-    func testGroupByProviderReturnsEmptyForNoModels() {
-        XCTAssertTrue(ModelCatalog.groupByProvider([]).isEmpty)
-    }
-
-    func testParseThenGroupProducesProviderSectionsEndToEnd() throws {
+    func testParseThenDisplayProducesFlatSortedListEndToEnd() throws {
         let payload = try data("""
         {
           "data": [
@@ -107,10 +105,186 @@ final class ModelCatalogTests: XCTestCase {
         }
         """)
 
-        let groups = ModelCatalog.groupByProvider(try ModelCatalog.parse(payload))
+        let displayed = ModelCatalog.displayEntries(try ModelCatalog.parse(payload))
 
-        XCTAssertEqual(groups.map(\.provider), ["google", "openai"])
-        XCTAssertEqual(groups[0].models.map(\.id), ["gemini-3-flash-preview"])
-        XCTAssertEqual(groups[1].models.map(\.id), ["gpt-5.1-codex", "gpt-5.2", "unowned-model"])
+        XCTAssertEqual(
+            displayed.map(\.id),
+            ["gemini-3-flash-preview", "gpt-5.1-codex", "gpt-5.2", "unowned-model"]
+        )
+        XCTAssertEqual(displayed.map(\.displayOwner), ["google", "openai", "openai", nil])
+    }
+
+    // MARK: - Live vs stale vs built-in state
+
+    func testInitialStateHasNotFetchedAnything() {
+        let state = ModelCatalogState()
+
+        XCTAssertTrue(state.entries.isEmpty)
+        XCTAssertEqual(state.freshness, .never)
+        XCTAssertFalse(state.isLoading)
+        XCTAssertFalse(state.lastFetchFailed)
+        XCTAssertFalse(state.hasCompletedFetch)
+        XCTAssertFalse(state.isEmptyLiveResult)
+    }
+
+    func testSuccessfulFetchIsMarkedLiveWithItsTimestamp() {
+        var state = ModelCatalogState()
+        state.beginLoading()
+        XCTAssertTrue(state.isLoading)
+
+        state.apply(entries: entries("gpt-5.2", "gemini-3-flash-preview"), fetchedAt: fetchedAt)
+
+        XCTAssertEqual(state.entries.map(\.id), ["gemini-3-flash-preview", "gpt-5.2"])
+        XCTAssertEqual(state.freshness, .live(fetchedAt: fetchedAt))
+        XCTAssertFalse(state.isLoading)
+        XCTAssertFalse(state.lastFetchFailed)
+        XCTAssertTrue(state.hasCompletedFetch)
+    }
+
+    func testSuccessfulEmptyResponseStaysEmptyInsteadOfShowingBuiltInModels() {
+        var state = ModelCatalogState()
+        state.beginLoading()
+
+        state.apply(entries: [], fetchedAt: fetchedAt)
+
+        XCTAssertTrue(state.entries.isEmpty)
+        XCTAssertTrue(state.isEmptyLiveResult, "The empty state must be reachable, not masked by defaults")
+        XCTAssertEqual(state.freshness, .live(fetchedAt: fetchedAt))
+        XCTAssertTrue(state.hasCompletedFetch)
+        XCTAssertFalse(state.lastFetchFailed)
+
+        let builtInIds = Set(AvailableModel.allModels.map(\.id))
+        XCTAssertTrue(state.entries.allSatisfy { !builtInIds.contains($0.id) })
+    }
+
+    func testFailedFirstFetchReportsFailureWithNothingToShow() {
+        var state = ModelCatalogState()
+        state.beginLoading()
+
+        state.applyFailure()
+
+        XCTAssertTrue(state.entries.isEmpty)
+        XCTAssertEqual(state.freshness, .never, "A failure must not be dressed up as a fetched list")
+        XCTAssertTrue(state.lastFetchFailed)
+        XCTAssertTrue(state.hasCompletedFetch)
+        XCTAssertFalse(state.isEmptyLiveResult)
+        XCTAssertFalse(state.isLoading)
+    }
+
+    func testFailedRefreshDemotesPreviousResultToStaleAndKeepsItsOriginalTimestamp() {
+        var state = ModelCatalogState()
+        state.apply(entries: entries("gpt-5.2"), fetchedAt: fetchedAt)
+
+        state.beginLoading()
+        state.applyFailure()
+
+        XCTAssertEqual(state.entries.map(\.id), ["gpt-5.2"], "The last known list stays visible")
+        XCTAssertEqual(state.freshness, .stale(fetchedAt: fetchedAt), "But it is no longer presented as live")
+        XCTAssertTrue(state.lastFetchFailed)
+        XCTAssertFalse(state.isEmptyLiveResult)
+    }
+
+    func testRepeatedFailuresKeepTheOriginalSuccessTimestamp() {
+        var state = ModelCatalogState()
+        state.apply(entries: entries("gpt-5.2"), fetchedAt: fetchedAt)
+        state.applyFailure()
+        state.applyFailure()
+
+        XCTAssertEqual(state.freshness, .stale(fetchedAt: fetchedAt))
+    }
+
+    func testSuccessfulRefreshAfterFailurePromotesBackToLive() {
+        var state = ModelCatalogState()
+        state.apply(entries: entries("gpt-5.2"), fetchedAt: fetchedAt)
+        state.applyFailure()
+
+        state.apply(entries: entries("gpt-5.3-codex"), fetchedAt: laterFetchedAt)
+
+        XCTAssertEqual(state.entries.map(\.id), ["gpt-5.3-codex"])
+        XCTAssertEqual(state.freshness, .live(fetchedAt: laterFetchedAt))
+        XCTAssertFalse(state.lastFetchFailed)
+    }
+
+    func testSuccessfulRefreshReplacesRatherThanMergesPreviousEntries() {
+        var state = ModelCatalogState()
+        state.apply(entries: entries("gpt-5.1", "gpt-5.2"), fetchedAt: fetchedAt)
+
+        state.apply(entries: entries("gpt-5.2"), fetchedAt: laterFetchedAt)
+
+        XCTAssertEqual(state.entries.map(\.id), ["gpt-5.2"], "Removed models must not linger")
+    }
+
+    func testResetClearsEverythingSoAStoppedProxyShowsNoStaleList() {
+        var state = ModelCatalogState()
+        state.apply(entries: entries("gpt-5.2"), fetchedAt: fetchedAt)
+
+        state.reset()
+
+        XCTAssertEqual(state, ModelCatalogState())
+    }
+
+    // MARK: - Existing agent-setup consumers are unaffected
+
+    func testAgentSetupMappingPreservesHistoricalOpenAIProviderDefault() {
+        // AgentConfigurationService.fetchAvailableModels - and through it the agent
+        // config sheet, warmup sheet and fallback screen - depends on `owned_by`
+        // defaulting to "openai" and on the "github-copilot" value being preserved
+        // verbatim for its Copilot availability filter.
+        let mapped = ModelCatalog.agentSetupModels(from: [
+            ModelCatalogEntry(id: "gpt-5.2", owner: "openai"),
+            ModelCatalogEntry(id: "custom-model", owner: nil),
+            ModelCatalogEntry(id: "claude-sonnet-4-5", owner: "github-copilot")
+        ])
+
+        XCTAssertEqual(mapped.map(\.provider), ["openai", "openai", "github-copilot"])
+        XCTAssertEqual(mapped.map(\.id), ["gpt-5.2", "custom-model", "claude-sonnet-4-5"])
+        XCTAssertEqual(mapped.map(\.name), mapped.map(\.id))
+        XCTAssertTrue(mapped.allSatisfy { !$0.isDefault })
+    }
+
+    func testAgentSetupMappingPreservesResponseOrderAndDuplicates() {
+        // The picker path must keep seeing the unmodified response; only the
+        // read-only catalog view sorts and deduplicates for display.
+        let mapped = ModelCatalog.agentSetupModels(from: [
+            ModelCatalogEntry(id: "gpt-5.2", owner: "openai"),
+            ModelCatalogEntry(id: "gemini-3-flash-preview", owner: "google"),
+            ModelCatalogEntry(id: "gpt-5.2", owner: "openai")
+        ])
+
+        XCTAssertEqual(mapped.map(\.id), ["gpt-5.2", "gemini-3-flash-preview", "gpt-5.2"])
+    }
+
+    func testBuiltInModelListStillAvailableForTheAgentSetupPickerFallback() {
+        // loadModels(forceRefresh:) intentionally keeps this fallback for pickers;
+        // the catalog view simply must not route through it.
+        XCTAssertFalse(AvailableModel.allModels.isEmpty)
+    }
+
+    @MainActor
+    func testCatalogFetchWithoutAProxyThrowsInsteadOfFallingBackToDefaults() async {
+        let viewModel = AgentSetupViewModel()
+
+        do {
+            _ = try await viewModel.fetchModelCatalog()
+            XCTFail("Expected a thrown error when no proxy is configured")
+        } catch {
+            XCTAssertEqual(error as? ModelCatalogError, .proxyUnavailable)
+        }
+
+        XCTAssertTrue(
+            viewModel.availableModels.isEmpty,
+            "The catalog path must not populate the shared agent-setup model list"
+        )
+    }
+
+    @MainActor
+    func testLoadModelsWithoutAProxyStillReportsFailureWithoutTouchingModels() async {
+        // Guards the unchanged behavior of the shared picker loader.
+        let viewModel = AgentSetupViewModel()
+
+        let loadedFromRemote = await viewModel.loadModels()
+
+        XCTAssertFalse(loadedFromRemote)
+        XCTAssertTrue(viewModel.availableModels.isEmpty)
     }
 }

--- a/QuotioTests/ModelCatalogTests.swift
+++ b/QuotioTests/ModelCatalogTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import Quotio
+
+final class ModelCatalogTests: XCTestCase {
+
+    private func data(_ json: String) throws -> Data {
+        try XCTUnwrap(json.data(using: .utf8))
+    }
+
+    // MARK: - Parsing
+
+    func testParseReadsIdAndOwnedByFromModelsResponse() throws {
+        let payload = try data("""
+        {
+          "object": "list",
+          "data": [
+            { "id": "gpt-5.2", "object": "model", "owned_by": "openai" },
+            { "id": "gemini-3-pro-preview", "object": "model", "owned_by": "google" }
+          ]
+        }
+        """)
+
+        let models = try ModelCatalog.parse(payload)
+
+        XCTAssertEqual(models.map(\.id), ["gpt-5.2", "gemini-3-pro-preview"])
+        XCTAssertEqual(models.map(\.provider), ["openai", "google"])
+        XCTAssertEqual(models.map(\.name), models.map(\.id))
+        XCTAssertTrue(models.allSatisfy { !$0.isDefault })
+    }
+
+    func testParseDefaultsMissingOwnedByToOpenAI() throws {
+        let payload = try data(#"{ "data": [ { "id": "custom-model" } ] }"#)
+
+        let models = try ModelCatalog.parse(payload)
+
+        XCTAssertEqual(models.count, 1)
+        XCTAssertEqual(models[0].provider, "openai")
+    }
+
+    func testParseReturnsEmptyListForEmptyResponse() throws {
+        let models = try ModelCatalog.parse(try data(#"{ "data": [] }"#))
+
+        XCTAssertTrue(models.isEmpty)
+    }
+
+    func testParseThrowsOnMalformedResponse() throws {
+        let payload = try data(#"{ "models": [ { "id": "gpt-5.2" } ] }"#)
+
+        XCTAssertThrowsError(try ModelCatalog.parse(payload))
+    }
+
+    // MARK: - Grouping
+
+    func testGroupByProviderGroupsAndSortsModels() {
+        let models = [
+            AvailableModel(id: "gpt-5.2", name: "gpt-5.2", provider: "openai", isDefault: false),
+            AvailableModel(id: "gemini-3-pro-preview", name: "gemini-3-pro-preview", provider: "google", isDefault: false),
+            AvailableModel(id: "gpt-5.1", name: "gpt-5.1", provider: "openai", isDefault: false),
+            AvailableModel(id: "gemini-2.5-flash", name: "gemini-2.5-flash", provider: "google", isDefault: false)
+        ]
+
+        let groups = ModelCatalog.groupByProvider(models)
+
+        XCTAssertEqual(groups.map(\.provider), ["google", "openai"])
+        XCTAssertEqual(groups[0].models.map(\.id), ["gemini-2.5-flash", "gemini-3-pro-preview"])
+        XCTAssertEqual(groups[1].models.map(\.id), ["gpt-5.1", "gpt-5.2"])
+        XCTAssertEqual(groups[0].id, "google")
+    }
+
+    func testGroupByProviderCollapsesDuplicateModelIdsWithinProvider() {
+        let models = [
+            AvailableModel(id: "gpt-5.2", name: "gpt-5.2", provider: "openai", isDefault: false),
+            AvailableModel(id: "gpt-5.2", name: "gpt-5.2", provider: "openai", isDefault: false)
+        ]
+
+        let groups = ModelCatalog.groupByProvider(models)
+
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(groups[0].models.map(\.id), ["gpt-5.2"])
+    }
+
+    func testGroupByProviderKeepsSameModelIdOfferedByDifferentProviders() {
+        let models = [
+            AvailableModel(id: "claude-sonnet-4-5", name: "claude-sonnet-4-5", provider: "anthropic", isDefault: false),
+            AvailableModel(id: "claude-sonnet-4-5", name: "claude-sonnet-4-5", provider: "github-copilot", isDefault: false)
+        ]
+
+        let groups = ModelCatalog.groupByProvider(models)
+
+        XCTAssertEqual(groups.map(\.provider), ["anthropic", "github-copilot"])
+        XCTAssertEqual(groups.flatMap { $0.models.map(\.id) }.count, 2)
+    }
+
+    func testGroupByProviderReturnsEmptyForNoModels() {
+        XCTAssertTrue(ModelCatalog.groupByProvider([]).isEmpty)
+    }
+
+    func testParseThenGroupProducesProviderSectionsEndToEnd() throws {
+        let payload = try data("""
+        {
+          "data": [
+            { "id": "gpt-5.2", "owned_by": "openai" },
+            { "id": "gemini-3-flash-preview", "owned_by": "google" },
+            { "id": "gpt-5.1-codex", "owned_by": "openai" },
+            { "id": "unowned-model" }
+          ]
+        }
+        """)
+
+        let groups = ModelCatalog.groupByProvider(try ModelCatalog.parse(payload))
+
+        XCTAssertEqual(groups.map(\.provider), ["google", "openai"])
+        XCTAssertEqual(groups[0].models.map(\.id), ["gemini-3-flash-preview"])
+        XCTAssertEqual(groups[1].models.map(\.id), ["gpt-5.1-codex", "gpt-5.2", "unowned-model"])
+    }
+}


### PR DESCRIPTION
## Motivation

From #201:

> The should show what models can be used in the panel, istead of curling myself
>
> show all the models I can use in the panel

Today the proxy's model list is only reachable inside modal flows — the agent config sheet, the Fallback "add entry" sheet, and the custom provider sheet all call `/v1/models`, but none of them is a place you go to *read* the list. To find out which model IDs are routable, users end up curling the endpoint themselves.

This adds a first-class **Available Models** section that lists them.

## What this adds

- **Dashboard → Available Models**: model IDs grouped by provider, fetched live from the proxy's OpenAI-compatible `/v1/models` endpoint, with a refresh button in the section header and a model count.
- **Click to copy**: model IDs exist to be pasted into client configs, so each row copies its ID to the pasteboard and shows a short "Copied" confirmation.
- **Explained empty states**: a note when the proxy is stopped ("Start the proxy to see the models you can use."), when the proxy reports no models, and when the fetch fails.
- **Localized** in en / fr / vi / zh-Hans, using the existing `Localizable.xcstrings` approach.

## Placement rationale

The section sits on the Dashboard, directly below the existing **API Endpoint** row in `fullModeContent`. That pairing is the point: the endpoint tells you *where* to send requests, the model list tells you *what* to ask for — together they are everything you need to paste into a client config. It reuses the existing `GroupBox` idiom of the neighbouring sections, so no navigation changes, no new tab, and no `NavigationPage` case were needed.

The section is scoped to local-proxy mode, where a `/v1/models` endpoint actually exists; Monitor and remote modes are untouched.

## Implementation notes

- Model fetching reuses `AgentSetupViewModel.loadModels(forceRefresh:)`, so the Dashboard shares the same cached list as the Fallback and agent-config flows rather than opening a second code path to the proxy. No networking was added to the view.
- The response parsing and provider grouping were extracted into a new pure `ModelCatalog` helper (`Quotio/Models/ModelCatalog.swift`). `AgentConfigurationService.fetchAvailableModels` now calls `ModelCatalog.parse` instead of carrying its own nested `Decodable` struct — same behaviour, including the GitHub Copilot availability filter and the `owned_by` → `"openai"` default, now covered by tests.
- Grouping is derived from the proxy's own `owned_by` field, which is the authoritative answer for "which provider serves this model", rather than inferring it from the model ID.

## Test evidence

New `QuotioTests/ModelCatalogTests.swift` covers response parsing (well-formed, missing `owned_by`, empty list, malformed payload), provider grouping and sorting, duplicate-ID collapsing, the same ID served by two providers, the empty case, and a parse → group end-to-end case.

```
xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build
** BUILD SUCCEEDED **

xcodebuild test -project Quotio.xcodeproj -scheme Quotio -destination 'platform=macOS'
** TEST SUCCEEDED **

Test suite 'ModelCatalogTests' started
Test case 'ModelCatalogTests.testGroupByProviderCollapsesDuplicateModelIdsWithinProvider()' passed
Test case 'ModelCatalogTests.testGroupByProviderGroupsAndSortsModels()' passed
Test case 'ModelCatalogTests.testGroupByProviderKeepsSameModelIdOfferedByDifferentProviders()' passed
Test case 'ModelCatalogTests.testGroupByProviderReturnsEmptyForNoModels()' passed
Test case 'ModelCatalogTests.testParseDefaultsMissingOwnedByToOpenAI()' passed
Test case 'ModelCatalogTests.testParseReadsIdAndOwnedByFromModelsResponse()' passed
Test case 'ModelCatalogTests.testParseReturnsEmptyListForEmptyResponse()' passed
Test case 'ModelCatalogTests.testParseThenGroupProducesProviderSectionsEndToEnd()' passed
Test case 'ModelCatalogTests.testParseThrowsOnMalformedResponse()' passed
```

The existing `AmpQuotaFetcherTests` and `MonitorRuntimeTests` suites also pass on this branch.

Closes #201
