### PR TITLE
feat(agents): restore agent configs on quit (opt-in)

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -2205,6 +2205,35 @@
         }
       }
     },
+    "agents.restoreOnQuit.ownership" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only configs Quotio can verify it wrote are reverted. A config edited outside Quotio, or one pointing at a different local proxy, is left untouched. Apply an agent's setup once from here so Quotio can record it."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seules les configurations dont Quotio peut vérifier qu'il les a écrites sont restaurées. Une configuration modifiée en dehors de Quotio, ou pointant vers un autre proxy local, reste intacte. Appliquez une fois la configuration d'un agent depuis cet écran pour que Quotio puisse l'enregistrer."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chỉ những cấu hình mà Quotio xác minh được là do chính nó ghi mới được hoàn nguyên. Cấu hình bị chỉnh sửa bên ngoài Quotio, hoặc trỏ tới một proxy cục bộ khác, sẽ được giữ nguyên. Hãy áp dụng thiết lập của agent một lần tại đây để Quotio ghi nhận."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅还原 Quotio 能够确认由自己写入的配置。在 Quotio 之外被修改的配置，或指向其他本地代理的配置，将保持不变。请在此处应用一次代理工具的设置，以便 Quotio 记录归属。"
+          }
+        }
+      }
+    },
     "agents.saveConfig" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -2118,6 +2118,93 @@
         }
       }
     },
+    "agents.restoreOnQuit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore agent configs when Quotio quits"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restaurer les configurations des agents à la fermeture de Quotio"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khôi phục cấu hình agent khi thoát Quotio"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出 Quotio 时还原代理工具配置"
+          }
+        }
+      }
+    },
+    "agents.restoreOnQuit.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When Quotio quits, it removes its proxy settings from every agent it configured, so those agents go back to their own subscriptions. A backup is written before each change."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "À la fermeture, Quotio retire ses paramètres de proxy de chaque agent qu'il a configuré, afin que ces agents reviennent à leurs propres abonnements. Une sauvegarde est écrite avant chaque modification."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khi thoát, Quotio sẽ xóa thiết lập proxy khỏi mọi agent mà nó đã cấu hình, để các agent đó quay lại dùng gói đăng ký riêng. Một bản sao lưu được ghi trước mỗi thay đổi."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出时，Quotio 会从其配置过的每个代理工具中移除代理设置，让这些工具回到各自的订阅。每次修改前都会写入备份。"
+          }
+        }
+      }
+    },
+    "agents.restoreOnQuit.limitation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Off by default. A crash or a force quit cannot be intercepted, so configs stay in place after one."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactivé par défaut. Un plantage ou une fermeture forcée ne peut pas être intercepté : les configurations restent alors en place."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mặc định tắt. Không thể can thiệp khi ứng dụng gặp sự cố hoặc bị buộc thoát, nên cấu hình sẽ được giữ nguyên trong các trường hợp đó."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "默认关闭。崩溃或强制退出无法被拦截，此时配置将保持不变。"
+          }
+        }
+      }
+    },
     "agents.saveConfig" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -491,6 +491,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Stop background polling
         AtomFeedUpdateService.shared.stopPolling()
 
+        // Opt-in: hand agent configs back to their own subscriptions before the
+        // proxy they point at disappears.
+        restoreAgentConfigurationsIfEnabled()
+
         CLIProxyManager.terminateProxyOnShutdown()
         
         // Use semaphore to ensure tunnel cleanup completes before app terminates
@@ -508,6 +512,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // Fallback: force kill orphan processes if stopTunnel timed out
             TunnelManager.cleanupOrphans()
             NSLog("[AppDelegate] Tunnel cleanup timed out, forced orphan cleanup")
+        }
+    }
+
+    /// Reverts agents Quotio configured back to their default (non-proxy) setup.
+    /// No-op unless the user opted in. Runs on a detached task while the main
+    /// thread waits, so it cannot deadlock against the main actor, and is capped
+    /// by a timeout so a slow filesystem can never hang termination.
+    private func restoreAgentConfigurationsIfEnabled() {
+        guard AgentQuitRestoreSettings().isEnabled else { return }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        let restoreTimeout: DispatchTime = .now() + .seconds(3)
+
+        Task.detached(priority: .userInitiated) {
+            let outcome = await AgentQuitRestoreService.shared.restoreConfiguredAgents()
+            NSLog("[AppDelegate] Agent config restore on quit: \(outcome.summary)")
+            semaphore.signal()
+        }
+
+        if semaphore.wait(timeout: restoreTimeout) == .timedOut {
+            NSLog("[AppDelegate] Agent config restore on quit timed out")
         }
     }
 

--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -487,13 +487,53 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             && window.level == .normal
     }
 
+    /// Opt-in: hand agent configs back to their own subscriptions *before* AppKit
+    /// starts tearing the app down.
+    ///
+    /// The revert touches several files per agent, so it cannot be squeezed into
+    /// `applicationWillTerminate` - that callback has no way to hold termination
+    /// open, and a revert still running when the process dies leaves a partially
+    /// restored set of configs. `.terminateLater` defers the decision instead,
+    /// and `AgentQuitRestoreTerminationCoordinator` guarantees the matching
+    /// `reply(toApplicationShouldTerminate:)` is delivered exactly once - on
+    /// completion, or on a deadline if the revert wedges. Returning
+    /// `.terminateLater` without ever replying would hang the app, which is
+    /// worse than skipping the revert.
+    ///
+    /// Not reached when `AppResetService` relaunches the app: that path calls
+    /// `exit(0)` and bypasses the termination handlers entirely, which is the
+    /// behaviour we want - Quotio is coming straight back up, so its agent
+    /// configs should stay in place.
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard AgentQuitRestoreSettings().isEnabled else { return .terminateNow }
+
+        // A second quit while the first is still restoring means the user is
+        // waiting on us; stop deferring and let AppKit through.
+        guard agentRestoreCoordinator == nil else { return .terminateNow }
+
+        let coordinator = AgentQuitRestoreTerminationCoordinator(
+            restore: { progress in
+                await AgentQuitRestoreService.shared.restoreConfiguredAgents(progress: progress)
+            },
+            onResolved: { result in
+                switch result {
+                case .completed(let outcome):
+                    NSLog("[AppDelegate] Agent config restore on quit: \(outcome.summary)")
+                case .timedOut(let partial):
+                    NSLog("[AppDelegate] Agent config restore on quit timed out; completed so far: \(partial.summary)")
+                }
+                NSApp.reply(toApplicationShouldTerminate: true)
+            }
+        )
+        agentRestoreCoordinator = coordinator
+        coordinator.begin()
+
+        return .terminateLater
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         // Stop background polling
         AtomFeedUpdateService.shared.stopPolling()
-
-        // Opt-in: hand agent configs back to their own subscriptions before the
-        // proxy they point at disappears.
-        restoreAgentConfigurationsIfEnabled()
 
         CLIProxyManager.terminateProxyOnShutdown()
         
@@ -515,26 +555,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Reverts agents Quotio configured back to their default (non-proxy) setup.
-    /// No-op unless the user opted in. Runs on a detached task while the main
-    /// thread waits, so it cannot deadlock against the main actor, and is capped
-    /// by a timeout so a slow filesystem can never hang termination.
-    private func restoreAgentConfigurationsIfEnabled() {
-        guard AgentQuitRestoreSettings().isEnabled else { return }
-
-        let semaphore = DispatchSemaphore(value: 0)
-        let restoreTimeout: DispatchTime = .now() + .seconds(3)
-
-        Task.detached(priority: .userInitiated) {
-            let outcome = await AgentQuitRestoreService.shared.restoreConfiguredAgents()
-            NSLog("[AppDelegate] Agent config restore on quit: \(outcome.summary)")
-            semaphore.signal()
-        }
-
-        if semaphore.wait(timeout: restoreTimeout) == .timedOut {
-            NSLog("[AppDelegate] Agent config restore on quit timed out")
-        }
-    }
+    /// Retains the in-flight quit-time restore so its reply is guaranteed to be
+    /// delivered, and marks that termination is already being deferred.
+    private var agentRestoreCoordinator: AgentQuitRestoreTerminationCoordinator?
 
     func applicationDidBecomeActive(_ notification: Notification) {
         let keyWindowIsDashboardCandidate = NSApp.keyWindow.map(isDashboardWindowCandidate) ?? false

--- a/Quotio/Services/AgentConfigOwnership.swift
+++ b/Quotio/Services/AgentConfigOwnership.swift
@@ -1,0 +1,359 @@
+//
+//  AgentConfigOwnership.swift
+//  Quotio - Prove Quotio authored an agent config before reverting it
+//
+//  A base URL pointing at `localhost` says an agent talks to *some* local
+//  proxy; it does not say the proxy is Quotio's. Users run their own local
+//  gateways (LiteLLM, Ollama shims, corporate relays), and reverting those is
+//  destroying configuration Quotio never wrote.
+//
+//  Ownership is therefore established from something Quotio itself authored:
+//
+//  1. A receipt written when Quotio applied the config (the endpoint plus a
+//     fingerprint of the API key Quotio issued). If the endpoint and key on
+//     disk still match the receipt, the bytes there are Quotio's. If a receipt
+//     exists but no longer matches, the user changed it by hand and Quotio must
+//     keep its hands off.
+//  2. Failing that, a Quotio-authored marker that no other tool would write -
+//     the `cliproxyapi` provider Codex CLI is pointed at, or OpenCode's
+//     `provider.quotio` entry. This is the fallback for configs applied before
+//     receipts existed.
+//
+//  Agents with neither (Claude Code, Amp CLI, Factory Droid all use
+//  vendor-standard keys with nothing Quotio-specific in them) are left alone
+//  when no receipt is present. Skipping a revert is recoverable; deleting a
+//  config Quotio did not write is not.
+//
+
+import CryptoKit
+import Foundation
+
+// MARK: - Receipt
+
+/// What Quotio wrote for one agent, recorded at the moment it wrote it.
+///
+/// The API key is stored only as a SHA-256 fingerprint: the check needs to
+/// compare keys, not read them back, so the secret never lands in `UserDefaults`.
+nonisolated struct AgentConfigOwnershipRecord: Codable, Sendable, Equatable {
+    let agent: CLIAgent
+    /// Endpoint Quotio wrote, normalised (no `/v1` suffix, no trailing slash).
+    let baseURL: String
+    /// SHA-256 hex of the API key Quotio wrote.
+    let apiKeyFingerprint: String
+    /// `false` when Quotio created the agent's primary config file itself, i.e.
+    /// there was no file there before. Recorded for issue #128's "remove it if
+    /// Quotio created it" semantics; see the PR notes for the current scope.
+    let primaryConfigExisted: Bool
+    let recordedAt: Date
+
+    static func fingerprint(ofAPIKey key: String) -> String {
+        SHA256.hash(data: Data(key.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    /// Trims `/v1` and trailing slashes so the value written by setup and the
+    /// value read back from disk compare equal regardless of which form the
+    /// agent's file format stores.
+    static func normalizedBaseURL(_ raw: String) -> String {
+        var value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        while value.hasSuffix("/") { value.removeLast() }
+        if value.hasSuffix("/v1") { value.removeLast(3) }
+        while value.hasSuffix("/") { value.removeLast() }
+        return value
+    }
+
+    init(agent: CLIAgent, baseURL: String, apiKey: String, primaryConfigExisted: Bool, recordedAt: Date = Date()) {
+        self.agent = agent
+        self.baseURL = Self.normalizedBaseURL(baseURL)
+        self.apiKeyFingerprint = Self.fingerprint(ofAPIKey: apiKey)
+        self.primaryConfigExisted = primaryConfigExisted
+        self.recordedAt = recordedAt
+    }
+}
+
+// MARK: - Receipt Storage
+
+/// Persists one receipt per agent.
+///
+/// `@unchecked` only because `UserDefaults` is not formally `Sendable`; it is
+/// documented as thread-safe and this type adds no mutable state of its own.
+nonisolated struct AgentConfigOwnershipStore: @unchecked Sendable {
+    static let storageKey = "agentConfigOwnershipReceipts"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func record(for agent: CLIAgent) -> AgentConfigOwnershipRecord? {
+        all()[agent.rawValue]
+    }
+
+    func save(_ record: AgentConfigOwnershipRecord) {
+        var records = all()
+        records[record.agent.rawValue] = record
+        persist(records)
+    }
+
+    func clear(agent: CLIAgent) {
+        var records = all()
+        guard records.removeValue(forKey: agent.rawValue) != nil else { return }
+        persist(records)
+    }
+
+    private func all() -> [String: AgentConfigOwnershipRecord] {
+        guard let data = defaults.data(forKey: Self.storageKey),
+              let decoded = try? JSONDecoder().decode([String: AgentConfigOwnershipRecord].self, from: data) else {
+            return [:]
+        }
+        return decoded
+    }
+
+    private func persist(_ records: [String: AgentConfigOwnershipRecord]) {
+        guard let data = try? JSONEncoder().encode(records) else { return }
+        defaults.set(data, forKey: Self.storageKey)
+    }
+}
+
+// MARK: - Decision
+
+nonisolated enum AgentConfigOwnershipProof: String, Sendable, Equatable {
+    /// The endpoint and API key on disk still match the receipt Quotio wrote.
+    case receipt
+    /// No receipt, but a marker only Quotio writes is still in the file.
+    case authoredMarker
+}
+
+nonisolated enum AgentConfigOwnershipDoubt: String, Sendable, Equatable {
+    /// Nothing on disk, or the agent is not pointed at any proxy.
+    case notConfigured
+    /// A receipt exists but the file no longer holds what Quotio wrote.
+    case externallyModified
+    /// No receipt and no Quotio-authored marker: ownership cannot be shown.
+    case noEvidence
+}
+
+nonisolated enum AgentConfigOwnership: Sendable, Equatable {
+    case owned(AgentConfigOwnershipProof)
+    case notOwned(AgentConfigOwnershipDoubt)
+
+    var isOwned: Bool {
+        if case .owned = self { return true }
+        return false
+    }
+
+    var reason: String {
+        switch self {
+        case .owned(let proof): return proof.rawValue
+        case .notOwned(let doubt): return doubt.rawValue
+        }
+    }
+}
+
+// MARK: - On-Disk State
+
+/// One endpoint/credential pair found in an agent's config.
+///
+/// Most agents hold exactly one. Factory Droid holds an array of
+/// `custom_models`, so it can yield several - only the entries matching the
+/// receipt belong to Quotio.
+nonisolated struct AgentConfigEndpoint: Sendable, Equatable {
+    let baseURL: String?
+    let apiKey: String?
+}
+
+nonisolated struct AgentOnDiskConfig: Sendable, Equatable {
+    var endpoints: [AgentConfigEndpoint] = []
+    /// A key or section only Quotio writes is present.
+    var hasAuthoredMarker: Bool = false
+
+    var isEmpty: Bool { endpoints.isEmpty && !hasAuthoredMarker }
+}
+
+// MARK: - Verifier
+
+/// Reads what is actually on disk for an agent and decides whether Quotio may
+/// modify it. The home directory is injectable so tests never read or write the
+/// developer's real agent configs.
+/// `@unchecked` only because `FileManager` is not formally `Sendable`; reads are
+/// thread-safe and this type adds no mutable state of its own.
+nonisolated struct AgentConfigOwnershipVerifier: @unchecked Sendable {
+    private let homeDirectory: String
+    private let fileManager: FileManager
+
+    init(homeDirectory: String? = nil, fileManager: FileManager = .default) {
+        self.homeDirectory = homeDirectory ?? fileManager.homeDirectoryForCurrentUser.path
+        self.fileManager = fileManager
+    }
+
+    /// Decide whether Quotio wrote the config currently on disk for `agent`.
+    func ownership(of agent: CLIAgent, record: AgentConfigOwnershipRecord?) -> AgentConfigOwnership {
+        let onDisk = readOnDiskConfig(for: agent)
+
+        guard !onDisk.isEmpty else { return .notOwned(.notConfigured) }
+
+        if let record {
+            let matches = onDisk.endpoints.contains { endpoint in
+                guard let baseURL = endpoint.baseURL, let apiKey = endpoint.apiKey else { return false }
+                return AgentConfigOwnershipRecord.normalizedBaseURL(baseURL) == record.baseURL
+                    && AgentConfigOwnershipRecord.fingerprint(ofAPIKey: apiKey) == record.apiKeyFingerprint
+            }
+            return matches ? .owned(.receipt) : .notOwned(.externallyModified)
+        }
+
+        // No receipt: fall back to a marker no other tool writes.
+        return onDisk.hasAuthoredMarker ? .owned(.authoredMarker) : .notOwned(.noEvidence)
+    }
+
+    // MARK: On-disk readers
+
+    func readOnDiskConfig(for agent: CLIAgent) -> AgentOnDiskConfig {
+        switch agent {
+        case .claudeCode: return readClaudeCode()
+        case .codexCLI: return readCodex()
+        case .ampCLI: return readAmp()
+        case .openCode: return readOpenCode()
+        case .factoryDroid: return readFactoryDroid()
+        }
+    }
+
+    /// `~/.claude/settings.json`. `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN`
+    /// are Anthropic's own variable names, so there is no Quotio marker here -
+    /// only the receipt can establish ownership.
+    private func readClaudeCode() -> AgentOnDiskConfig {
+        guard let json = readJSONObject(at: "\(homeDirectory)/.claude/settings.json"),
+              let env = json["env"] as? [String: String] else {
+            return AgentOnDiskConfig()
+        }
+
+        guard let baseURL = env["ANTHROPIC_BASE_URL"] else { return AgentOnDiskConfig() }
+
+        return AgentOnDiskConfig(
+            endpoints: [AgentConfigEndpoint(baseURL: baseURL, apiKey: env["ANTHROPIC_AUTH_TOKEN"])],
+            hasAuthoredMarker: false
+        )
+    }
+
+    /// `~/.codex/config.toml` plus `~/.codex/auth.json`. The provider id
+    /// `cliproxyapi` is written by Quotio and by nothing else, so it doubles as
+    /// the marker.
+    private func readCodex() -> AgentOnDiskConfig {
+        let configPath = "\(homeDirectory)/.codex/config.toml"
+        guard let content = try? String(contentsOfFile: configPath, encoding: .utf8) else {
+            return AgentOnDiskConfig()
+        }
+
+        var baseURL: String?
+        var inCliproxySection = false
+        var hasMarker = false
+
+        for line in content.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.hasPrefix("[") {
+                inCliproxySection = trimmed.hasPrefix("[model_providers.cliproxyapi]")
+                if inCliproxySection { hasMarker = true }
+                continue
+            }
+
+            if trimmed.hasPrefix("model_provider") && trimmed.contains("cliproxyapi") {
+                hasMarker = true
+                continue
+            }
+
+            if inCliproxySection, trimmed.hasPrefix("base_url"), let value = tomlValue(from: trimmed) {
+                baseURL = value
+            }
+        }
+
+        guard hasMarker || baseURL != nil else { return AgentOnDiskConfig() }
+
+        // The key lives in the sibling auth.json, which setup writes at the same time.
+        let apiKey = (readJSONObject(at: "\(homeDirectory)/.codex/auth.json")?["OPENAI_API_KEY"]) as? String
+
+        return AgentOnDiskConfig(
+            endpoints: [AgentConfigEndpoint(baseURL: baseURL, apiKey: apiKey)],
+            hasAuthoredMarker: hasMarker
+        )
+    }
+
+    /// `~/.config/amp/settings.json` plus `~/.local/share/amp/secrets.json`.
+    /// `amp.url` is Amp's own key, so there is no marker - receipt only.
+    private func readAmp() -> AgentOnDiskConfig {
+        guard let settings = readJSONObject(at: "\(homeDirectory)/.config/amp/settings.json"),
+              let baseURL = settings["amp.url"] as? String else {
+            return AgentOnDiskConfig()
+        }
+
+        // Setup stores the key under "apiKey@<amp.url>" in the data directory.
+        let secrets = readJSONObject(at: "\(homeDirectory)/.local/share/amp/secrets.json")
+        let apiKey = secrets?["apiKey@\(baseURL)"] as? String
+
+        return AgentOnDiskConfig(
+            endpoints: [AgentConfigEndpoint(baseURL: baseURL, apiKey: apiKey)],
+            hasAuthoredMarker: false
+        )
+    }
+
+    /// `~/.config/opencode/opencode.json`. The provider is literally keyed
+    /// `quotio`, which is as unambiguous a marker as it gets.
+    private func readOpenCode() -> AgentOnDiskConfig {
+        guard let json = readJSONObject(at: "\(homeDirectory)/.config/opencode/opencode.json"),
+              let providers = json["provider"] as? [String: Any],
+              let quotio = providers["quotio"] as? [String: Any] else {
+            return AgentOnDiskConfig()
+        }
+
+        let options = quotio["options"] as? [String: Any]
+
+        return AgentOnDiskConfig(
+            endpoints: [
+                AgentConfigEndpoint(
+                    baseURL: options?["baseURL"] as? String,
+                    apiKey: options?["apiKey"] as? String
+                )
+            ],
+            hasAuthoredMarker: true
+        )
+    }
+
+    /// `~/.factory/config.json`. Entries in `custom_models` carry no Quotio
+    /// field, so every localhost entry looks alike - the receipt is the only
+    /// way to tell Quotio's entries from a user's own local model.
+    private func readFactoryDroid() -> AgentOnDiskConfig {
+        guard let json = readJSONObject(at: "\(homeDirectory)/.factory/config.json"),
+              let customModels = json["custom_models"] as? [[String: Any]],
+              !customModels.isEmpty else {
+            return AgentOnDiskConfig()
+        }
+
+        return AgentOnDiskConfig(
+            endpoints: customModels.map {
+                AgentConfigEndpoint(baseURL: $0["base_url"] as? String, apiKey: $0["api_key"] as? String)
+            },
+            hasAuthoredMarker: false
+        )
+    }
+
+    // MARK: Parsing helpers
+
+    private func readJSONObject(at path: String) -> [String: Any]? {
+        guard fileManager.fileExists(atPath: path),
+              let data = fileManager.contents(atPath: path),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json
+    }
+
+    private func tomlValue(from line: String) -> String? {
+        guard let equalIndex = line.firstIndex(of: "=") else { return nil }
+        var value = String(line[line.index(after: equalIndex)...]).trimmingCharacters(in: .whitespaces)
+        if value.hasPrefix("\""), value.hasSuffix("\""), value.count >= 2 {
+            value = String(value.dropFirst().dropLast())
+        }
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Quotio/Services/AgentQuitRestoreService.swift
+++ b/Quotio/Services/AgentQuitRestoreService.swift
@@ -1,0 +1,138 @@
+//
+//  AgentQuitRestoreService.swift
+//  Quotio - Restore agent configurations when the app quits
+//
+//  Opt-in: when enabled, every agent whose on-disk config currently points at
+//  Quotio's proxy is reverted through the same "Use default" path the agent
+//  sheet exposes, so the agent falls back to its own subscription once Quotio
+//  is gone.
+//
+
+import Foundation
+
+// MARK: - Settings
+
+/// Persistence for the "restore agent configs on quit" preference.
+///
+/// Default is `false` so existing installs keep their current behaviour: configs
+/// stay in place across restarts, which is what users who relaunch Quotio expect.
+nonisolated struct AgentQuitRestoreSettings {
+    static let storageKey = "restoreAgentConfigsOnQuit"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var isEnabled: Bool {
+        get { defaults.bool(forKey: Self.storageKey) }
+        nonmutating set { defaults.set(newValue, forKey: Self.storageKey) }
+    }
+}
+
+// MARK: - Revert Abstraction
+
+/// The subset of `AgentConfigurationService` the quit-time orchestration needs.
+/// Kept as a protocol so the orchestration can be tested without touching real
+/// config files in the user's home directory.
+protocol AgentConfigReverting: Sendable {
+    /// `true` when the agent's saved config currently points at Quotio's proxy.
+    func isConfiguredForQuotioProxy(agent: CLIAgent) async -> Bool
+
+    /// Runs the agent's existing revert-to-default path.
+    func revertToDefault(agent: CLIAgent) async throws -> AgentConfigResult
+}
+
+extension AgentConfigurationService: AgentConfigReverting {
+    func isConfiguredForQuotioProxy(agent: CLIAgent) -> Bool {
+        readConfiguration(agent: agent)?.isProxyConfigured == true
+    }
+
+    /// Reuses `generateConfiguration` with `setupMode == .defaultSetup`, i.e. the
+    /// exact code path behind the per-agent "Default" setup button. Nothing about
+    /// the revert logic (including backups) is duplicated here.
+    func revertToDefault(agent: CLIAgent) async throws -> AgentConfigResult {
+        let config = AgentConfiguration(
+            agent: agent,
+            proxyURL: "",
+            apiKey: "",
+            setupMode: .defaultSetup
+        )
+
+        return try await generateConfiguration(
+            agent: agent,
+            config: config,
+            mode: .automatic,
+            detectionService: AgentDetectionService()
+        )
+    }
+}
+
+// MARK: - Outcome
+
+nonisolated struct AgentQuitRestoreFailure: Sendable, Equatable {
+    let agent: CLIAgent
+    let message: String
+}
+
+nonisolated struct AgentQuitRestoreOutcome: Sendable, Equatable {
+    /// Agents whose Quotio proxy config was successfully removed.
+    var reverted: [CLIAgent] = []
+    /// Agents that were not configured for Quotio's proxy, so nothing was touched.
+    var skipped: [CLIAgent] = []
+    /// Agents whose revert failed. Failures never stop the remaining agents.
+    var failures: [AgentQuitRestoreFailure] = []
+
+    var summary: String {
+        let revertedList = reverted.map(\.rawValue).joined(separator: ", ")
+        let failedList = failures.map { "\($0.agent.rawValue): \($0.message)" }.joined(separator: "; ")
+        return "reverted=[\(revertedList)] skipped=\(skipped.count) failed=[\(failedList)]"
+    }
+}
+
+// MARK: - Service
+
+/// Orchestrates the quit-time revert across every known agent.
+actor AgentQuitRestoreService {
+    static let shared = AgentQuitRestoreService(reverter: AgentConfigurationService())
+
+    private let reverter: AgentConfigReverting
+
+    init(reverter: AgentConfigReverting) {
+        self.reverter = reverter
+    }
+
+    /// Reverts every agent that Quotio currently has configured for its proxy.
+    ///
+    /// Agents are handled independently: a thrown error or an unsuccessful result
+    /// for one agent is recorded and the loop continues, so a single broken config
+    /// can never block the rest of the revert (or app termination).
+    func restoreConfiguredAgents(agents: [CLIAgent] = CLIAgent.allCases) async -> AgentQuitRestoreOutcome {
+        var outcome = AgentQuitRestoreOutcome()
+
+        for agent in agents {
+            guard await reverter.isConfiguredForQuotioProxy(agent: agent) else {
+                outcome.skipped.append(agent)
+                continue
+            }
+
+            do {
+                let result = try await reverter.revertToDefault(agent: agent)
+                if result.success {
+                    outcome.reverted.append(agent)
+                } else {
+                    outcome.failures.append(
+                        AgentQuitRestoreFailure(agent: agent, message: result.error ?? "unknown error")
+                    )
+                }
+            } catch {
+                outcome.failures.append(
+                    AgentQuitRestoreFailure(agent: agent, message: error.localizedDescription)
+                )
+            }
+        }
+
+        return outcome
+    }
+}

--- a/Quotio/Services/AgentQuitRestoreService.swift
+++ b/Quotio/Services/AgentQuitRestoreService.swift
@@ -2,10 +2,19 @@
 //  AgentQuitRestoreService.swift
 //  Quotio - Restore agent configurations when the app quits
 //
-//  Opt-in: when enabled, every agent whose on-disk config currently points at
-//  Quotio's proxy is reverted through the same "Use default" path the agent
-//  sheet exposes, so the agent falls back to its own subscription once Quotio
-//  is gone.
+//  Opt-in: when enabled, every agent whose on-disk config Quotio can *prove* it
+//  wrote is reverted through the same "Use default" path the agent sheet
+//  exposes, so the agent falls back to its own subscription once Quotio is gone.
+//
+//  Two properties matter here and are enforced separately:
+//
+//  * Ownership - a config is only touched when `AgentConfigOwnership` says
+//    Quotio authored what is currently on disk. Pointing at localhost is not
+//    ownership; see `AgentConfigOwnership.swift`.
+//  * Termination ordering - the app must not die halfway through the revert,
+//    and must not hang forever if the revert wedges. That contract lives in
+//    `AgentQuitRestoreTerminationCoordinator`, which is deliberately separate
+//    from `AppDelegate` so it can be tested without an `NSApplication`.
 //
 
 import Foundation
@@ -37,18 +46,11 @@ nonisolated struct AgentQuitRestoreSettings {
 /// Kept as a protocol so the orchestration can be tested without touching real
 /// config files in the user's home directory.
 protocol AgentConfigReverting: Sendable {
-    /// `true` when the agent's saved config currently points at Quotio's proxy.
-    func isConfiguredForQuotioProxy(agent: CLIAgent) async -> Bool
-
     /// Runs the agent's existing revert-to-default path.
     func revertToDefault(agent: CLIAgent) async throws -> AgentConfigResult
 }
 
 extension AgentConfigurationService: AgentConfigReverting {
-    func isConfiguredForQuotioProxy(agent: CLIAgent) -> Bool {
-        readConfiguration(agent: agent)?.isProxyConfigured == true
-    }
-
     /// Reuses `generateConfiguration` with `setupMode == .defaultSetup`, i.e. the
     /// exact code path behind the per-agent "Default" setup button. Nothing about
     /// the revert logic (including backups) is duplicated here.
@@ -69,6 +71,31 @@ extension AgentConfigurationService: AgentConfigReverting {
     }
 }
 
+// MARK: - Ownership Abstraction
+
+/// Answers "did Quotio write what is on disk for this agent right now?".
+nonisolated protocol AgentConfigOwnershipResolving: Sendable {
+    func ownership(of agent: CLIAgent) -> AgentConfigOwnership
+}
+
+/// Production resolver: receipt first, Quotio-authored file marker as fallback.
+nonisolated struct DefaultAgentConfigOwnershipResolver: AgentConfigOwnershipResolving {
+    private let store: AgentConfigOwnershipStore
+    private let verifier: AgentConfigOwnershipVerifier
+
+    init(
+        store: AgentConfigOwnershipStore = AgentConfigOwnershipStore(),
+        verifier: AgentConfigOwnershipVerifier = AgentConfigOwnershipVerifier()
+    ) {
+        self.store = store
+        self.verifier = verifier
+    }
+
+    func ownership(of agent: CLIAgent) -> AgentConfigOwnership {
+        verifier.ownership(of: agent, record: store.record(for: agent))
+    }
+}
+
 // MARK: - Outcome
 
 nonisolated struct AgentQuitRestoreFailure: Sendable, Equatable {
@@ -76,63 +103,192 @@ nonisolated struct AgentQuitRestoreFailure: Sendable, Equatable {
     let message: String
 }
 
+nonisolated struct AgentQuitRestoreSkip: Sendable, Equatable {
+    let agent: CLIAgent
+    let reason: AgentConfigOwnershipDoubt
+}
+
 nonisolated struct AgentQuitRestoreOutcome: Sendable, Equatable {
     /// Agents whose Quotio proxy config was successfully removed.
     var reverted: [CLIAgent] = []
-    /// Agents that were not configured for Quotio's proxy, so nothing was touched.
-    var skipped: [CLIAgent] = []
+    /// Agents Quotio could not prove it owned, so nothing was touched.
+    var skipped: [AgentQuitRestoreSkip] = []
     /// Agents whose revert failed. Failures never stop the remaining agents.
     var failures: [AgentQuitRestoreFailure] = []
 
     var summary: String {
         let revertedList = reverted.map(\.rawValue).joined(separator: ", ")
+        let skippedList = skipped.map { "\($0.agent.rawValue): \($0.reason.rawValue)" }.joined(separator: "; ")
         let failedList = failures.map { "\($0.agent.rawValue): \($0.message)" }.joined(separator: "; ")
-        return "reverted=[\(revertedList)] skipped=\(skipped.count) failed=[\(failedList)]"
+        return "reverted=[\(revertedList)] skipped=[\(skippedList)] failed=[\(failedList)]"
+    }
+}
+
+// MARK: - Progress
+
+/// Lets a caller read how far a run got without waiting for it to finish, so a
+/// timeout can report what was actually completed instead of just "gave up".
+///
+/// Lock-based rather than actor-isolated on purpose: the watchdog must be able
+/// to read progress even while the restore loop is inside a blocking
+/// filesystem call.
+nonisolated final class AgentQuitRestoreProgress: @unchecked Sendable {
+    private let lock = NSLock()
+    private var outcome = AgentQuitRestoreOutcome()
+
+    init() {}
+
+    func snapshot() -> AgentQuitRestoreOutcome {
+        lock.withLock { outcome }
+    }
+
+    fileprivate func update(_ body: (inout AgentQuitRestoreOutcome) -> Void) {
+        lock.withLock { body(&outcome) }
     }
 }
 
 // MARK: - Service
 
 /// Orchestrates the quit-time revert across every known agent.
-actor AgentQuitRestoreService {
-    static let shared = AgentQuitRestoreService(reverter: AgentConfigurationService())
+///
+/// Deliberately a `Sendable` class rather than an `actor`: the watchdog in
+/// `AgentQuitRestoreTerminationCoordinator` must never queue behind this work,
+/// and actor reentrancy would let a wedged revert block a progress read.
+nonisolated final class AgentQuitRestoreService: Sendable {
+    static let shared = AgentQuitRestoreService(
+        reverter: AgentConfigurationService(),
+        ownership: DefaultAgentConfigOwnershipResolver()
+    )
 
     private let reverter: AgentConfigReverting
+    private let ownership: AgentConfigOwnershipResolving
 
-    init(reverter: AgentConfigReverting) {
+    init(reverter: AgentConfigReverting, ownership: AgentConfigOwnershipResolving) {
         self.reverter = reverter
+        self.ownership = ownership
     }
 
-    /// Reverts every agent that Quotio currently has configured for its proxy.
+    /// Reverts every agent Quotio can prove it configured for its proxy.
     ///
     /// Agents are handled independently: a thrown error or an unsuccessful result
     /// for one agent is recorded and the loop continues, so a single broken config
     /// can never block the rest of the revert (or app termination).
-    func restoreConfiguredAgents(agents: [CLIAgent] = CLIAgent.allCases) async -> AgentQuitRestoreOutcome {
-        var outcome = AgentQuitRestoreOutcome()
-
+    @discardableResult
+    func restoreConfiguredAgents(
+        agents: [CLIAgent] = CLIAgent.allCases,
+        progress: AgentQuitRestoreProgress = AgentQuitRestoreProgress()
+    ) async -> AgentQuitRestoreOutcome {
         for agent in agents {
-            guard await reverter.isConfiguredForQuotioProxy(agent: agent) else {
-                outcome.skipped.append(agent)
+            let decision = ownership.ownership(of: agent)
+
+            guard case .owned(let proof) = decision else {
+                if case .notOwned(let doubt) = decision {
+                    progress.update { $0.skipped.append(AgentQuitRestoreSkip(agent: agent, reason: doubt)) }
+                }
                 continue
             }
+
+            Log.debug("Quit restore: \(agent.rawValue) ownership proven via \(proof.rawValue)")
 
             do {
                 let result = try await reverter.revertToDefault(agent: agent)
                 if result.success {
-                    outcome.reverted.append(agent)
+                    progress.update { $0.reverted.append(agent) }
                 } else {
-                    outcome.failures.append(
-                        AgentQuitRestoreFailure(agent: agent, message: result.error ?? "unknown error")
-                    )
+                    progress.update {
+                        $0.failures.append(
+                            AgentQuitRestoreFailure(agent: agent, message: result.error ?? "unknown error")
+                        )
+                    }
                 }
             } catch {
-                outcome.failures.append(
-                    AgentQuitRestoreFailure(agent: agent, message: error.localizedDescription)
-                )
+                progress.update {
+                    $0.failures.append(
+                        AgentQuitRestoreFailure(agent: agent, message: error.localizedDescription)
+                    )
+                }
             }
         }
 
-        return outcome
+        return progress.snapshot()
+    }
+}
+
+// MARK: - Termination Coordination
+
+nonisolated enum AgentQuitRestoreTerminationResult: Sendable, Equatable {
+    /// Every agent was processed before the deadline.
+    case completed(AgentQuitRestoreOutcome)
+    /// The deadline was reached first. Carries whatever finished by then, so the
+    /// log names the agents that were left alone rather than just reporting a
+    /// timeout.
+    case timedOut(partial: AgentQuitRestoreOutcome)
+
+    var outcome: AgentQuitRestoreOutcome {
+        switch self {
+        case .completed(let outcome), .timedOut(let outcome): return outcome
+        }
+    }
+}
+
+/// Holds AppKit's termination decision open until the revert finishes, and
+/// guarantees the decision is delivered exactly once.
+///
+/// `applicationShouldTerminate` returns `.terminateLater`, which means AppKit
+/// waits indefinitely until `reply(toApplicationShouldTerminate:)` is called.
+/// Never replying is worse than the bug this feature fixes - the app would hang
+/// and the user would have to force quit - so a watchdog replies on a deadline
+/// even if the restore is wedged. Whichever path gets there first wins; the
+/// other becomes a no-op.
+///
+/// Everything runs on the main actor, which is both where AppKit requires the
+/// reply and what makes "exactly once" hold without a lock.
+@MainActor
+final class AgentQuitRestoreTerminationCoordinator {
+    /// How long termination may be held open. Long enough for five agents'
+    /// worth of small file rewrites, short enough to stay well inside the
+    /// shorter OS budget for a logout/restart-initiated quit.
+    static let defaultTimeout: Duration = .seconds(5)
+
+    private let timeout: Duration
+    private let restore: @Sendable (AgentQuitRestoreProgress) async -> AgentQuitRestoreOutcome
+    private let onResolved: @MainActor (AgentQuitRestoreTerminationResult) -> Void
+    private var hasResolved = false
+
+    init(
+        timeout: Duration = AgentQuitRestoreTerminationCoordinator.defaultTimeout,
+        restore: @escaping @Sendable (AgentQuitRestoreProgress) async -> AgentQuitRestoreOutcome,
+        onResolved: @escaping @MainActor (AgentQuitRestoreTerminationResult) -> Void
+    ) {
+        self.timeout = timeout
+        self.restore = restore
+        self.onResolved = onResolved
+    }
+
+    /// Starts the revert and the watchdog. Returns immediately; the caller
+    /// should hand `.terminateLater` back to AppKit.
+    func begin() {
+        let progress = AgentQuitRestoreProgress()
+        let restore = self.restore
+        let timeout = self.timeout
+
+        // Both tasks capture `self` strongly on purpose: the reply must still be
+        // delivered if the caller drops its reference to the coordinator, and a
+        // dropped reply would hang the app rather than merely skip the revert.
+        Task { @MainActor in
+            let outcome = await restore(progress)
+            self.resolve(.completed(outcome))
+        }
+
+        Task { @MainActor in
+            try? await Task.sleep(for: timeout)
+            self.resolve(.timedOut(partial: progress.snapshot()))
+        }
+    }
+
+    private func resolve(_ result: AgentQuitRestoreTerminationResult) {
+        guard !hasResolved else { return }
+        hasResolved = true
+        onResolved(result)
     }
 }

--- a/Quotio/ViewModels/AgentSetupViewModel.swift
+++ b/Quotio/ViewModels/AgentSetupViewModel.swift
@@ -210,6 +210,8 @@ final class AgentSetupViewModel {
                     )
                 }
 
+                recordConfigOwnership(agent: agent, config: config, result: result)
+
                 await detectionService.markAsConfigured(agent)
                 await refreshAgentStatuses()
             }
@@ -223,6 +225,30 @@ final class AgentSetupViewModel {
             errorMessage = error.localizedDescription
             configResult = .failure(error: error.localizedDescription)
         }
+    }
+
+    /// Records what Quotio just wrote so a later quit-time revert can prove it
+    /// owns the file instead of guessing from a `localhost` base URL. Reverting
+    /// to the agent's own default drops the receipt, since Quotio no longer owns
+    /// anything there.
+    private func recordConfigOwnership(agent: CLIAgent, config: AgentConfiguration, result: AgentConfigResult) {
+        let store = AgentConfigOwnershipStore()
+
+        guard config.setupMode != .defaultSetup else {
+            store.clear(agent: agent)
+            return
+        }
+
+        store.save(
+            AgentConfigOwnershipRecord(
+                agent: agent,
+                baseURL: config.proxyURL,
+                apiKey: config.apiKey,
+                // Setup only takes a backup when a config file was already
+                // there, so its absence means Quotio created the file itself.
+                primaryConfigExisted: result.backupPath != nil
+            )
+        )
     }
 
     func addToShellProfile() async {

--- a/Quotio/Views/Screens/AgentSetupScreen.swift
+++ b/Quotio/Views/Screens/AgentSetupScreen.swift
@@ -122,6 +122,11 @@ struct AgentSetupScreen: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
+            Text("agents.restoreOnQuit.ownership".localized())
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
             Text("agents.restoreOnQuit.limitation".localized())
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/Quotio/Views/Screens/AgentSetupScreen.swift
+++ b/Quotio/Views/Screens/AgentSetupScreen.swift
@@ -7,6 +7,7 @@ import SwiftUI
 
 struct AgentSetupScreen: View {
     @Environment(QuotaViewModel.self) private var quotaViewModel
+    @AppStorage(AgentQuitRestoreSettings.storageKey) private var restoreConfigsOnQuit = false
     @State private var selectedAgentForConfig: CLIAgent?
     @State private var sheetPresentationID = UUID()
     @State private var hasLoadedOnce = false
@@ -78,6 +79,8 @@ struct AgentSetupScreen: View {
                 if !notInstalledAgents.isEmpty {
                     notInstalledSection
                 }
+
+                restoreOnQuitSection
             }
             .padding(20)
         }
@@ -109,6 +112,27 @@ struct AgentSetupScreen: View {
         .padding(.horizontal, 4)
     }
     
+    private var restoreOnQuitSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Toggle("agents.restoreOnQuit".localized(), isOn: $restoreConfigsOnQuit)
+                .toggleStyle(.switch)
+
+            Text("agents.restoreOnQuit.desc".localized())
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text("agents.restoreOnQuit.limitation".localized())
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color.secondary.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
     private var installedSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("agents.installed".localized())

--- a/QuotioTests/AgentConfigOwnershipTests.swift
+++ b/QuotioTests/AgentConfigOwnershipTests.swift
@@ -1,0 +1,300 @@
+import XCTest
+@testable import Quotio
+
+/// Every test here runs against a throwaway home directory. Nothing in this file
+/// may read or write the developer's real `~/.claude`, `~/.codex`, `~/.config`
+/// or `~/.factory`.
+final class AgentConfigOwnershipTests: XCTestCase {
+
+    private var home: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        home = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("quotio-ownership-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let home { try? FileManager.default.removeItem(at: home) }
+        home = nil
+        try super.tearDownWithError()
+    }
+
+    private var verifier: AgentConfigOwnershipVerifier {
+        AgentConfigOwnershipVerifier(homeDirectory: home.path)
+    }
+
+    private let quotioURL = "http://127.0.0.1:8317"
+    private let quotioKey = "quotio-local-6C1E9C0E-6D5E-4C1B-9D0F-2F4B7A0C5E11"
+
+    // MARK: - Receipt storage
+
+    func testReceiptRoundTripsAndNeverStoresTheRawKey() throws {
+        let defaults = try makeIsolatedDefaults(#function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        let store = AgentConfigOwnershipStore(defaults: defaults)
+        let record = AgentConfigOwnershipRecord(
+            agent: .claudeCode,
+            baseURL: quotioURL,
+            apiKey: quotioKey,
+            primaryConfigExisted: true
+        )
+        store.save(record)
+
+        XCTAssertEqual(store.record(for: .claudeCode), record)
+        XCTAssertNil(store.record(for: .codexCLI))
+
+        // The key itself must not be recoverable from UserDefaults.
+        let raw = try XCTUnwrap(defaults.data(forKey: AgentConfigOwnershipStore.storageKey))
+        let blob = String(decoding: raw, as: UTF8.self)
+        XCTAssertFalse(blob.contains(quotioKey))
+        XCTAssertTrue(blob.contains(record.apiKeyFingerprint))
+
+        store.clear(agent: .claudeCode)
+        XCTAssertNil(store.record(for: .claudeCode))
+    }
+
+    func testBaseURLNormalisationMatchesTheFormsAgentsStore() {
+        let canonical = AgentConfigOwnershipRecord.normalizedBaseURL(quotioURL)
+        XCTAssertEqual(AgentConfigOwnershipRecord.normalizedBaseURL("\(quotioURL)/v1"), canonical)
+        XCTAssertEqual(AgentConfigOwnershipRecord.normalizedBaseURL("\(quotioURL)/"), canonical)
+        XCTAssertEqual(AgentConfigOwnershipRecord.normalizedBaseURL("\(quotioURL)/v1/"), canonical)
+    }
+
+    // MARK: - Nothing configured
+
+    func testAgentWithNoConfigOnDiskIsNotOwned() {
+        for agent in CLIAgent.allCases {
+            XCTAssertEqual(
+                verifier.ownership(of: agent, record: nil),
+                .notOwned(.notConfigured),
+                "\(agent.rawValue) should report notConfigured on an empty home"
+            )
+        }
+    }
+
+    // MARK: - Receipt proves ownership, per agent
+
+    func testReceiptProvesOwnershipForEveryAgent() throws {
+        try writeClaudeConfig(baseURL: quotioURL, apiKey: quotioKey)
+        try writeCodexConfig(baseURL: quotioURL, apiKey: quotioKey, withCliproxyProvider: true)
+        try writeAmpConfig(baseURL: quotioURL, apiKey: quotioKey)
+        try writeOpenCodeConfig(baseURL: "\(quotioURL)/v1", apiKey: quotioKey)
+        try writeFactoryConfig(entries: [(baseURL: "\(quotioURL)/v1", apiKey: quotioKey)])
+
+        for agent in CLIAgent.allCases {
+            let record = AgentConfigOwnershipRecord(
+                agent: agent,
+                baseURL: quotioURL,
+                apiKey: quotioKey,
+                primaryConfigExisted: false
+            )
+            XCTAssertEqual(
+                verifier.ownership(of: agent, record: record),
+                .owned(.receipt),
+                "\(agent.rawValue) should be owned when disk still matches the receipt"
+            )
+        }
+    }
+
+    // MARK: - A different local proxy is not Quotio's
+
+    func testForeignLocalhostProxyIsNeverRevertedWithoutEvidence() throws {
+        // A user-run local gateway on localhost, which Quotio never wrote.
+        let foreignURL = "http://localhost:4000"
+        let foreignKey = "sk-my-own-litellm-key"
+
+        try writeClaudeConfig(baseURL: foreignURL, apiKey: foreignKey)
+        try writeAmpConfig(baseURL: foreignURL, apiKey: foreignKey)
+        try writeFactoryConfig(entries: [(baseURL: "\(foreignURL)/v1", apiKey: foreignKey)])
+
+        // These three agents carry no Quotio-authored marker, so with no receipt
+        // there is nothing to justify touching them.
+        for agent in [CLIAgent.claudeCode, .ampCLI, .factoryDroid] {
+            XCTAssertEqual(
+                verifier.ownership(of: agent, record: nil),
+                .notOwned(.noEvidence),
+                "\(agent.rawValue) pointing at a foreign local proxy must be left alone"
+            )
+        }
+    }
+
+    func testForeignLocalhostProxyIsNotOwnedEvenWhenAReceiptExistsForAnotherEndpoint() throws {
+        try writeClaudeConfig(baseURL: "http://localhost:4000", apiKey: "sk-my-own-litellm-key")
+
+        let record = AgentConfigOwnershipRecord(
+            agent: .claudeCode,
+            baseURL: quotioURL,
+            apiKey: quotioKey,
+            primaryConfigExisted: true
+        )
+
+        XCTAssertEqual(verifier.ownership(of: .claudeCode, record: record), .notOwned(.externallyModified))
+    }
+
+    func testFactoryDroidForeignLocalhostModelIsNotOwnedAlongsideAQuotioReceipt() throws {
+        // The default Factory Droid revert path strips *every* localhost custom
+        // model. Ownership must be decided per entry, not per host.
+        try writeFactoryConfig(entries: [(baseURL: "http://localhost:4000/v1", apiKey: "sk-user-key")])
+
+        let record = AgentConfigOwnershipRecord(
+            agent: .factoryDroid,
+            baseURL: quotioURL,
+            apiKey: quotioKey,
+            primaryConfigExisted: true
+        )
+
+        XCTAssertEqual(verifier.ownership(of: .factoryDroid, record: record), .notOwned(.externallyModified))
+    }
+
+    func testFactoryDroidIsOwnedWhenOneEntryMatchesTheReceipt() throws {
+        try writeFactoryConfig(entries: [
+            (baseURL: "http://localhost:4000/v1", apiKey: "sk-user-key"),
+            (baseURL: "\(quotioURL)/v1", apiKey: quotioKey)
+        ])
+
+        let record = AgentConfigOwnershipRecord(
+            agent: .factoryDroid,
+            baseURL: quotioURL,
+            apiKey: quotioKey,
+            primaryConfigExisted: true
+        )
+
+        XCTAssertEqual(verifier.ownership(of: .factoryDroid, record: record), .owned(.receipt))
+    }
+
+    // MARK: - External modification
+
+    func testRotatedAPIKeyMakesTheConfigExternallyModified() throws {
+        try writeClaudeConfig(baseURL: quotioURL, apiKey: "user-swapped-this-token")
+
+        let record = AgentConfigOwnershipRecord(
+            agent: .claudeCode,
+            baseURL: quotioURL,
+            apiKey: quotioKey,
+            primaryConfigExisted: true
+        )
+
+        XCTAssertEqual(verifier.ownership(of: .claudeCode, record: record), .notOwned(.externallyModified))
+    }
+
+    func testCodexAuthKeyReplacedOutsideQuotioIsNotOwnedByReceipt() throws {
+        // config.toml still points at the proxy but auth.json holds someone
+        // else's credential, so the pair no longer matches what Quotio wrote.
+        try writeCodexConfig(baseURL: quotioURL, apiKey: "sk-user-openai-key", withCliproxyProvider: true)
+
+        let record = AgentConfigOwnershipRecord(
+            agent: .codexCLI,
+            baseURL: quotioURL,
+            apiKey: quotioKey,
+            primaryConfigExisted: true
+        )
+
+        XCTAssertEqual(verifier.ownership(of: .codexCLI, record: record), .notOwned(.externallyModified))
+    }
+
+    // MARK: - Marker fallback for configs written before receipts existed
+
+    func testCodexCliproxyProviderIsAQuotioAuthoredMarker() throws {
+        try writeCodexConfig(baseURL: quotioURL, apiKey: quotioKey, withCliproxyProvider: true)
+
+        XCTAssertEqual(verifier.ownership(of: .codexCLI, record: nil), .owned(.authoredMarker))
+    }
+
+    func testCodexWithoutTheCliproxyProviderIsNotOwned() throws {
+        try writeCodexConfig(baseURL: "http://localhost:4000", apiKey: "sk-user", withCliproxyProvider: false)
+
+        XCTAssertEqual(verifier.ownership(of: .codexCLI, record: nil), .notOwned(.notConfigured))
+    }
+
+    func testOpenCodeQuotioProviderIsAQuotioAuthoredMarker() throws {
+        try writeOpenCodeConfig(baseURL: "\(quotioURL)/v1", apiKey: quotioKey)
+
+        XCTAssertEqual(verifier.ownership(of: .openCode, record: nil), .owned(.authoredMarker))
+    }
+
+    func testOpenCodeWithOnlyForeignProvidersIsNotOwned() throws {
+        let config: [String: Any] = [
+            "provider": ["myproxy": ["options": ["baseURL": "http://localhost:4000/v1", "apiKey": "sk-user"]]]
+        ]
+        try writeJSON(config, to: ".config/opencode/opencode.json")
+
+        XCTAssertEqual(verifier.ownership(of: .openCode, record: nil), .notOwned(.notConfigured))
+    }
+
+    // MARK: - Fixtures
+
+    private func writeClaudeConfig(baseURL: String, apiKey: String) throws {
+        try writeJSON(
+            ["env": ["ANTHROPIC_BASE_URL": baseURL, "ANTHROPIC_AUTH_TOKEN": apiKey]],
+            to: ".claude/settings.json"
+        )
+    }
+
+    private func writeCodexConfig(baseURL: String, apiKey: String, withCliproxyProvider: Bool) throws {
+        let toml: String
+        if withCliproxyProvider {
+            toml = """
+            # CLIProxyAPI Configuration for Codex CLI
+            model_provider = "cliproxyapi"
+            model = "gpt-5-codex"
+
+            [model_providers.cliproxyapi]
+            name = "cliproxyapi"
+            base_url = "\(baseURL)"
+            wire_api = "responses"
+            """
+        } else {
+            toml = """
+            model_provider = "myproxy"
+            model = "gpt-5"
+
+            [model_providers.myproxy]
+            base_url = "\(baseURL)"
+            """
+        }
+        try write(toml, to: ".codex/config.toml")
+        try writeJSON(["OPENAI_API_KEY": apiKey], to: ".codex/auth.json")
+    }
+
+    private func writeAmpConfig(baseURL: String, apiKey: String) throws {
+        try writeJSON(["amp.url": baseURL], to: ".config/amp/settings.json")
+        try writeJSON(["apiKey@\(baseURL)": apiKey], to: ".local/share/amp/secrets.json")
+    }
+
+    private func writeOpenCodeConfig(baseURL: String, apiKey: String) throws {
+        try writeJSON(
+            ["provider": ["quotio": ["name": "Quotio", "options": ["baseURL": baseURL, "apiKey": apiKey]]]],
+            to: ".config/opencode/opencode.json"
+        )
+    }
+
+    private func writeFactoryConfig(entries: [(baseURL: String, apiKey: String)]) throws {
+        let models: [[String: Any]] = entries.map {
+            ["model": "some-model", "base_url": $0.baseURL, "api_key": $0.apiKey, "provider": "openai"]
+        }
+        try writeJSON(["custom_models": models], to: ".factory/config.json")
+    }
+
+    private func writeJSON(_ object: [String: Any], to relativePath: String) throws {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted])
+        try write(String(decoding: data, as: UTF8.self), to: relativePath)
+    }
+
+    private func write(_ contents: String, to relativePath: String) throws {
+        let url = home.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func makeIsolatedDefaults(_ suiteName: String) throws -> UserDefaults {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/QuotioTests/AgentQuitRestoreTests.swift
+++ b/QuotioTests/AgentQuitRestoreTests.swift
@@ -1,0 +1,175 @@
+import XCTest
+@testable import Quotio
+
+// MARK: - Test Double
+
+private actor StubAgentConfigReverter: AgentConfigReverting {
+    enum Behavior: Sendable {
+        case succeeds
+        case fails(String)
+        case throwsError(String)
+    }
+
+    struct StubError: LocalizedError {
+        let message: String
+        var errorDescription: String? { message }
+    }
+
+    private let configuredAgents: Set<CLIAgent>
+    private let behaviors: [CLIAgent: Behavior]
+    private(set) var revertedAgents: [CLIAgent] = []
+
+    init(configuredAgents: Set<CLIAgent>, behaviors: [CLIAgent: Behavior] = [:]) {
+        self.configuredAgents = configuredAgents
+        self.behaviors = behaviors
+    }
+
+    func isConfiguredForQuotioProxy(agent: CLIAgent) -> Bool {
+        configuredAgents.contains(agent)
+    }
+
+    func revertToDefault(agent: CLIAgent) async throws -> AgentConfigResult {
+        revertedAgents.append(agent)
+
+        switch behaviors[agent] ?? .succeeds {
+        case .succeeds:
+            return .success(type: .file, mode: .automatic, instructions: "reverted", modelsConfigured: 0)
+        case .fails(let message):
+            return .failure(error: message)
+        case .throwsError(let message):
+            throw StubError(message: message)
+        }
+    }
+}
+
+// MARK: - Tests
+
+final class AgentQuitRestoreTests: XCTestCase {
+
+    // MARK: Setting round-trip
+
+    func testRestoreOnQuitSettingDefaultsToDisabled() throws {
+        let defaults = try makeIsolatedDefaults(#function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        XCTAssertFalse(AgentQuitRestoreSettings(defaults: defaults).isEnabled)
+    }
+
+    func testRestoreOnQuitSettingRoundTrips() throws {
+        let defaults = try makeIsolatedDefaults(#function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        let settings = AgentQuitRestoreSettings(defaults: defaults)
+        settings.isEnabled = true
+        XCTAssertTrue(AgentQuitRestoreSettings(defaults: defaults).isEnabled)
+        XCTAssertTrue(defaults.bool(forKey: AgentQuitRestoreSettings.storageKey))
+
+        settings.isEnabled = false
+        XCTAssertFalse(AgentQuitRestoreSettings(defaults: defaults).isEnabled)
+    }
+
+    // MARK: Orchestration
+
+    func testOnlyQuotioConfiguredAgentsAreReverted() async {
+        let reverter = StubAgentConfigReverter(configuredAgents: [.claudeCode, .openCode])
+        let service = AgentQuitRestoreService(reverter: reverter)
+
+        let outcome = await service.restoreConfiguredAgents(
+            agents: [.claudeCode, .codexCLI, .ampCLI, .openCode]
+        )
+
+        XCTAssertEqual(outcome.reverted, [.claudeCode, .openCode])
+        XCTAssertEqual(outcome.skipped, [.codexCLI, .ampCLI])
+        XCTAssertTrue(outcome.failures.isEmpty)
+
+        let touched = await reverter.revertedAgents
+        XCTAssertEqual(touched, [.claudeCode, .openCode])
+    }
+
+    func testNothingIsRevertedWhenNoAgentUsesTheProxy() async {
+        let reverter = StubAgentConfigReverter(configuredAgents: [])
+        let service = AgentQuitRestoreService(reverter: reverter)
+
+        let outcome = await service.restoreConfiguredAgents(agents: CLIAgent.allCases)
+
+        XCTAssertTrue(outcome.reverted.isEmpty)
+        XCTAssertTrue(outcome.failures.isEmpty)
+        XCTAssertEqual(outcome.skipped, CLIAgent.allCases)
+
+        let touched = await reverter.revertedAgents
+        XCTAssertTrue(touched.isEmpty)
+    }
+
+    func testAgentsAddedLaterAreCoveredByAllCases() async {
+        // The quit handler iterates CLIAgent.allCases, so a newly added agent is
+        // picked up without touching the orchestration.
+        let reverter = StubAgentConfigReverter(configuredAgents: Set(CLIAgent.allCases))
+        let service = AgentQuitRestoreService(reverter: reverter)
+
+        let outcome = await service.restoreConfiguredAgents()
+
+        XCTAssertEqual(Set(outcome.reverted), Set(CLIAgent.allCases))
+        XCTAssertTrue(outcome.skipped.isEmpty)
+    }
+
+    // MARK: Failure isolation
+
+    func testUnsuccessfulRevertDoesNotStopRemainingAgents() async {
+        let reverter = StubAgentConfigReverter(
+            configuredAgents: [.claudeCode, .codexCLI, .openCode],
+            behaviors: [.codexCLI: .fails("permission denied")]
+        )
+        let service = AgentQuitRestoreService(reverter: reverter)
+
+        let outcome = await service.restoreConfiguredAgents(
+            agents: [.claudeCode, .codexCLI, .openCode]
+        )
+
+        XCTAssertEqual(outcome.reverted, [.claudeCode, .openCode])
+        XCTAssertEqual(
+            outcome.failures,
+            [AgentQuitRestoreFailure(agent: .codexCLI, message: "permission denied")]
+        )
+
+        let touched = await reverter.revertedAgents
+        XCTAssertEqual(touched, [.claudeCode, .codexCLI, .openCode])
+    }
+
+    func testThrownRevertErrorIsRecordedAndOthersStillRun() async {
+        let reverter = StubAgentConfigReverter(
+            configuredAgents: [.claudeCode, .codexCLI, .factoryDroid],
+            behaviors: [.claudeCode: .throwsError("disk full")]
+        )
+        let service = AgentQuitRestoreService(reverter: reverter)
+
+        let outcome = await service.restoreConfiguredAgents(
+            agents: [.claudeCode, .codexCLI, .factoryDroid]
+        )
+
+        XCTAssertEqual(outcome.reverted, [.codexCLI, .factoryDroid])
+        XCTAssertEqual(outcome.failures.count, 1)
+        XCTAssertEqual(outcome.failures.first?.agent, .claudeCode)
+        XCTAssertEqual(outcome.failures.first?.message, "disk full")
+    }
+
+    func testSummaryReportsRevertedAndFailedAgents() async {
+        let reverter = StubAgentConfigReverter(
+            configuredAgents: [.claudeCode, .codexCLI],
+            behaviors: [.codexCLI: .fails("bad toml")]
+        )
+        let service = AgentQuitRestoreService(reverter: reverter)
+
+        let outcome = await service.restoreConfiguredAgents(agents: [.claudeCode, .codexCLI])
+
+        XCTAssertTrue(outcome.summary.contains("claude-code"))
+        XCTAssertTrue(outcome.summary.contains("codex: bad toml"))
+    }
+
+    // MARK: Helpers
+
+    private func makeIsolatedDefaults(_ suiteName: String) throws -> UserDefaults {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/QuotioTests/AgentQuitRestoreTests.swift
+++ b/QuotioTests/AgentQuitRestoreTests.swift
@@ -1,13 +1,15 @@
 import XCTest
 @testable import Quotio
 
-// MARK: - Test Double
+// MARK: - Test Doubles
 
 private actor StubAgentConfigReverter: AgentConfigReverting {
     enum Behavior: Sendable {
         case succeeds
         case fails(String)
         case throwsError(String)
+        /// Never returns, standing in for a wedged filesystem call.
+        case hangs
     }
 
     struct StubError: LocalizedError {
@@ -15,17 +17,11 @@ private actor StubAgentConfigReverter: AgentConfigReverting {
         var errorDescription: String? { message }
     }
 
-    private let configuredAgents: Set<CLIAgent>
     private let behaviors: [CLIAgent: Behavior]
     private(set) var revertedAgents: [CLIAgent] = []
 
-    init(configuredAgents: Set<CLIAgent>, behaviors: [CLIAgent: Behavior] = [:]) {
-        self.configuredAgents = configuredAgents
+    init(behaviors: [CLIAgent: Behavior] = [:]) {
         self.behaviors = behaviors
-    }
-
-    func isConfiguredForQuotioProxy(agent: CLIAgent) -> Bool {
-        configuredAgents.contains(agent)
     }
 
     func revertToDefault(agent: CLIAgent) async throws -> AgentConfigResult {
@@ -38,7 +34,25 @@ private actor StubAgentConfigReverter: AgentConfigReverting {
             return .failure(error: message)
         case .throwsError(let message):
             throw StubError(message: message)
+        case .hangs:
+            try await Task.sleep(for: .seconds(600))
+            return .failure(error: "unreachable")
         }
+    }
+}
+
+private struct StubOwnershipResolver: AgentConfigOwnershipResolving {
+    var decisions: [CLIAgent: AgentConfigOwnership] = [:]
+    var fallback: AgentConfigOwnership = .notOwned(.noEvidence)
+
+    func ownership(of agent: CLIAgent) -> AgentConfigOwnership {
+        decisions[agent] ?? fallback
+    }
+
+    static func owningAll(_ agents: [CLIAgent]) -> StubOwnershipResolver {
+        StubOwnershipResolver(
+            decisions: Dictionary(uniqueKeysWithValues: agents.map { ($0, .owned(.receipt)) })
+        )
     }
 }
 
@@ -68,43 +82,62 @@ final class AgentQuitRestoreTests: XCTestCase {
         XCTAssertFalse(AgentQuitRestoreSettings(defaults: defaults).isEnabled)
     }
 
-    // MARK: Orchestration
+    // MARK: Ownership gating
 
-    func testOnlyQuotioConfiguredAgentsAreReverted() async {
-        let reverter = StubAgentConfigReverter(configuredAgents: [.claudeCode, .openCode])
-        let service = AgentQuitRestoreService(reverter: reverter)
+    func testOnlyAgentsQuotioOwnsAreReverted() async {
+        let reverter = StubAgentConfigReverter()
+        let ownership = StubOwnershipResolver(
+            decisions: [
+                .claudeCode: .owned(.receipt),
+                .codexCLI: .notOwned(.externallyModified),
+                .ampCLI: .notOwned(.noEvidence),
+                .openCode: .owned(.authoredMarker)
+            ]
+        )
+        let service = AgentQuitRestoreService(reverter: reverter, ownership: ownership)
 
         let outcome = await service.restoreConfiguredAgents(
             agents: [.claudeCode, .codexCLI, .ampCLI, .openCode]
         )
 
         XCTAssertEqual(outcome.reverted, [.claudeCode, .openCode])
-        XCTAssertEqual(outcome.skipped, [.codexCLI, .ampCLI])
+        XCTAssertEqual(
+            outcome.skipped,
+            [
+                AgentQuitRestoreSkip(agent: .codexCLI, reason: .externallyModified),
+                AgentQuitRestoreSkip(agent: .ampCLI, reason: .noEvidence)
+            ]
+        )
         XCTAssertTrue(outcome.failures.isEmpty)
 
+        // The decisive assertion: an unowned config is never handed to the reverter.
         let touched = await reverter.revertedAgents
         XCTAssertEqual(touched, [.claudeCode, .openCode])
     }
 
-    func testNothingIsRevertedWhenNoAgentUsesTheProxy() async {
-        let reverter = StubAgentConfigReverter(configuredAgents: [])
-        let service = AgentQuitRestoreService(reverter: reverter)
+    func testNothingIsRevertedWhenOwnershipCannotBeProven() async {
+        let reverter = StubAgentConfigReverter()
+        let service = AgentQuitRestoreService(
+            reverter: reverter,
+            ownership: StubOwnershipResolver(fallback: .notOwned(.noEvidence))
+        )
 
         let outcome = await service.restoreConfiguredAgents(agents: CLIAgent.allCases)
 
         XCTAssertTrue(outcome.reverted.isEmpty)
         XCTAssertTrue(outcome.failures.isEmpty)
-        XCTAssertEqual(outcome.skipped, CLIAgent.allCases)
+        XCTAssertEqual(outcome.skipped.map(\.agent), CLIAgent.allCases)
 
         let touched = await reverter.revertedAgents
         XCTAssertTrue(touched.isEmpty)
     }
 
     func testAgentsAddedLaterAreCoveredByAllCases() async {
-        // The quit handler iterates CLIAgent.allCases, so a newly added agent is
-        // picked up without touching the orchestration.
-        let reverter = StubAgentConfigReverter(configuredAgents: Set(CLIAgent.allCases))
-        let service = AgentQuitRestoreService(reverter: reverter)
+        let reverter = StubAgentConfigReverter()
+        let service = AgentQuitRestoreService(
+            reverter: reverter,
+            ownership: StubOwnershipResolver.owningAll(CLIAgent.allCases)
+        )
 
         let outcome = await service.restoreConfiguredAgents()
 
@@ -115,11 +148,11 @@ final class AgentQuitRestoreTests: XCTestCase {
     // MARK: Failure isolation
 
     func testUnsuccessfulRevertDoesNotStopRemainingAgents() async {
-        let reverter = StubAgentConfigReverter(
-            configuredAgents: [.claudeCode, .codexCLI, .openCode],
-            behaviors: [.codexCLI: .fails("permission denied")]
+        let reverter = StubAgentConfigReverter(behaviors: [.codexCLI: .fails("permission denied")])
+        let service = AgentQuitRestoreService(
+            reverter: reverter,
+            ownership: StubOwnershipResolver.owningAll([.claudeCode, .codexCLI, .openCode])
         )
-        let service = AgentQuitRestoreService(reverter: reverter)
 
         let outcome = await service.restoreConfiguredAgents(
             agents: [.claudeCode, .codexCLI, .openCode]
@@ -136,11 +169,11 @@ final class AgentQuitRestoreTests: XCTestCase {
     }
 
     func testThrownRevertErrorIsRecordedAndOthersStillRun() async {
-        let reverter = StubAgentConfigReverter(
-            configuredAgents: [.claudeCode, .codexCLI, .factoryDroid],
-            behaviors: [.claudeCode: .throwsError("disk full")]
+        let reverter = StubAgentConfigReverter(behaviors: [.claudeCode: .throwsError("disk full")])
+        let service = AgentQuitRestoreService(
+            reverter: reverter,
+            ownership: StubOwnershipResolver.owningAll([.claudeCode, .codexCLI, .factoryDroid])
         )
-        let service = AgentQuitRestoreService(reverter: reverter)
 
         let outcome = await service.restoreConfiguredAgents(
             agents: [.claudeCode, .codexCLI, .factoryDroid]
@@ -152,17 +185,131 @@ final class AgentQuitRestoreTests: XCTestCase {
         XCTAssertEqual(outcome.failures.first?.message, "disk full")
     }
 
-    func testSummaryReportsRevertedAndFailedAgents() async {
-        let reverter = StubAgentConfigReverter(
-            configuredAgents: [.claudeCode, .codexCLI],
-            behaviors: [.codexCLI: .fails("bad toml")]
+    func testSummaryReportsRevertedSkippedAndFailedAgents() async {
+        let reverter = StubAgentConfigReverter(behaviors: [.codexCLI: .fails("bad toml")])
+        let service = AgentQuitRestoreService(
+            reverter: reverter,
+            ownership: StubOwnershipResolver(
+                decisions: [
+                    .claudeCode: .owned(.receipt),
+                    .codexCLI: .owned(.receipt),
+                    .ampCLI: .notOwned(.externallyModified)
+                ]
+            )
         )
-        let service = AgentQuitRestoreService(reverter: reverter)
 
-        let outcome = await service.restoreConfiguredAgents(agents: [.claudeCode, .codexCLI])
+        let outcome = await service.restoreConfiguredAgents(agents: [.claudeCode, .codexCLI, .ampCLI])
 
         XCTAssertTrue(outcome.summary.contains("claude-code"))
         XCTAssertTrue(outcome.summary.contains("codex: bad toml"))
+        XCTAssertTrue(outcome.summary.contains("amp: externallyModified"))
+    }
+
+    // MARK: Termination coordination
+
+    @MainActor
+    func testTerminationReplyWaitsForEveryAgentBeforeFiring() async {
+        let reverter = StubAgentConfigReverter()
+        let service = AgentQuitRestoreService(
+            reverter: reverter,
+            ownership: StubOwnershipResolver.owningAll(CLIAgent.allCases)
+        )
+
+        let replied = expectation(description: "reply delivered")
+        let results = ResultBox()
+
+        let coordinator = AgentQuitRestoreTerminationCoordinator(
+            timeout: .seconds(30),
+            restore: { progress in
+                await service.restoreConfiguredAgents(progress: progress)
+            },
+            onResolved: { result in
+                results.append(result)
+                replied.fulfill()
+            }
+        )
+        coordinator.begin()
+
+        await fulfillment(of: [replied], timeout: 10)
+
+        let recorded = results.all()
+        XCTAssertEqual(recorded.count, 1)
+        guard case .completed(let outcome) = recorded[0] else {
+            return XCTFail("expected completion, got \(recorded[0])")
+        }
+        // All agents finished *before* the reply that lets AppKit kill the process.
+        XCTAssertEqual(Set(outcome.reverted), Set(CLIAgent.allCases))
+    }
+
+    @MainActor
+    func testWedgedAgentStillRepliesOnTimeoutWithPartialProgress() async {
+        // claudeCode reverts, codexCLI never returns. Without a watchdog the app
+        // would sit in .terminateLater forever and need a force quit.
+        let reverter = StubAgentConfigReverter(behaviors: [.codexCLI: .hangs])
+        let service = AgentQuitRestoreService(
+            reverter: reverter,
+            ownership: StubOwnershipResolver.owningAll([.claudeCode, .codexCLI, .openCode])
+        )
+
+        let replied = expectation(description: "reply delivered")
+        let results = ResultBox()
+
+        let coordinator = AgentQuitRestoreTerminationCoordinator(
+            timeout: .milliseconds(300),
+            restore: { progress in
+                await service.restoreConfiguredAgents(
+                    agents: [.claudeCode, .codexCLI, .openCode],
+                    progress: progress
+                )
+            },
+            onResolved: { result in
+                results.append(result)
+                replied.fulfill()
+            }
+        )
+        coordinator.begin()
+
+        await fulfillment(of: [replied], timeout: 10)
+
+        let recorded = results.all()
+        XCTAssertEqual(recorded.count, 1)
+        guard case .timedOut(let partial) = recorded[0] else {
+            return XCTFail("expected timeout, got \(recorded[0])")
+        }
+        // The work completed before the wedge is reported, not discarded.
+        XCTAssertEqual(partial.reverted, [.claudeCode])
+    }
+
+    @MainActor
+    func testReplyIsDeliveredExactlyOnceEvenAfterTheTimeoutFires() async {
+        // A revert that finishes just after the deadline must not produce a
+        // second reply: replying twice to AppKit is undefined behaviour.
+        let reverter = StubAgentConfigReverter()
+        let service = AgentQuitRestoreService(
+            reverter: reverter,
+            ownership: StubOwnershipResolver.owningAll([.claudeCode])
+        )
+
+        let replied = expectation(description: "reply delivered")
+        let results = ResultBox()
+
+        let coordinator = AgentQuitRestoreTerminationCoordinator(
+            timeout: .zero,
+            restore: { progress in
+                await service.restoreConfiguredAgents(agents: [.claudeCode], progress: progress)
+            },
+            onResolved: { result in
+                results.append(result)
+                replied.fulfill()
+            }
+        )
+        coordinator.begin()
+
+        await fulfillment(of: [replied], timeout: 10)
+        // Give the losing path time to try to resolve as well.
+        try? await Task.sleep(for: .milliseconds(400))
+
+        XCTAssertEqual(results.all().count, 1, "reply(toApplicationShouldTerminate:) must fire exactly once")
     }
 
     // MARK: Helpers
@@ -171,5 +318,20 @@ final class AgentQuitRestoreTests: XCTestCase {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defaults.removePersistentDomain(forName: suiteName)
         return defaults
+    }
+}
+
+/// Collects every resolution the coordinator emits so a duplicate reply is
+/// visible as a count, not just a crash.
+private final class ResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var results: [AgentQuitRestoreTerminationResult] = []
+
+    func append(_ result: AgentQuitRestoreTerminationResult) {
+        lock.withLock { results.append(result) }
+    }
+
+    func all() -> [AgentQuitRestoreTerminationResult] {
+        lock.withLock { results }
     }
 }


### PR DESCRIPTION
## Motivation

Addresses the revert-on-quit half of #128. It does **not** close the issue — see [Scope](#scope-relative-to-128) below.

When Quotio quits, the configs it wrote stay behind. `~/.claude/settings.json` still carries `ANTHROPIC_BASE_URL` pointing at the (now dead) proxy plus Quotio's model overrides, so Claude Code starts in API mode against nothing and offers model names it cannot serve. The same applies to the other agents Quotio configures — Codex is the one called out in the issue comments.

Quotio already knows how to undo this: every agent has a "Default" setup path that strips Quotio's keys and preserves the user's own settings, backing the file up first. It was just never run at quit time.

## Design

**Opt-in, default OFF.** A forced revert on every quit would be wrong for the equally common workflow of quitting and relaunching Quotio. This ships as a switch on the Agents screen — "Restore agent configs when Quotio quits" — off by default, which keeps today's behaviour byte-for-byte for everyone who does not turn it on.

**Reuses the existing revert paths.** `AgentConfigurationService.swift` is not modified. `AgentQuitRestoreService` orchestrates the quit-time work and calls `generateConfiguration(..., setupMode: .defaultSetup, mode: .automatic)` — the exact call the per-agent "Default" button makes. Key removal, TOML/JSON merging and timestamped backups are not duplicated, so per-agent fixes to that path (e.g. #467, #477, #482) apply here automatically once they land.

### Ownership: only revert what Quotio can prove it wrote

A `localhost` base URL says an agent talks to *some* local proxy, not that the proxy is Quotio's. Users run their own local gateways, so keying off `isProxyConfigured` would delete configuration Quotio never authored.

Ownership is now established from something Quotio itself authored, in `Quotio/Services/AgentConfigOwnership.swift`:

1. **Receipt** — when Quotio writes an agent config, it records the endpoint plus a **SHA-256 fingerprint** of the API key it issued (the raw key is never persisted). At quit time the on-disk endpoint *and* key are compared against that receipt. Match ⇒ these are Quotio's bytes. Receipt present but no longer matching ⇒ the user changed it by hand ⇒ **leave it alone** (`.externallyModified`).
2. **Quotio-authored marker** — fallback for configs written before receipts existed, and only where a marker is genuinely unambiguous.
3. Neither ⇒ **skip**. Not reverting is recoverable; deleting a config Quotio did not write is not.

Per-agent evidence, from what setup actually writes:

| Agent | Files setup writes | Quotio-authored in-file marker | Key evidence used by receipt |
|---|---|---|---|
| Claude Code | `~/.claude/settings.json` (`env.ANTHROPIC_*`, `model`); shell profile when `shellOnly`/`both` | **none** — `ANTHROPIC_*` are Anthropic's own variable names | `env.ANTHROPIC_AUTH_TOKEN` |
| Codex CLI | `~/.codex/config.toml`, `~/.codex/auth.json` | **yes** — `model_provider = "cliproxyapi"` + `[model_providers.cliproxyapi]` (`AgentConfigurationService.swift:340-355`) | `auth.json` → `OPENAI_API_KEY` |
| Amp CLI | `~/.config/amp/settings.json` (`amp.url`), `~/.local/share/amp/secrets.json` | **none** — `amp.url` is Amp's own key | `secrets.json` → `apiKey@<amp.url>` |
| OpenCode | `~/.config/opencode/opencode.json` | **yes** — `provider.quotio` / `"name": "Quotio"` (`AgentConfigurationService.swift:1198-1224`) | `provider.quotio.options.apiKey` |
| Factory Droid | `~/.factory/config.json` (`custom_models[]`) | **none** — entries carry no Quotio field | `custom_models[].api_key` |

So Codex and OpenCode can be recognised even without a receipt; **Claude Code, Amp and Factory Droid cannot**, and without a receipt they are skipped rather than guessed at. This is the case you raised directly: Factory Droid's default revert filters *every* localhost `custom_models` entry, so with no receipt Quotio now declines to run it at all rather than removing a user's own local model.

### Termination: the decision is deferred until the revert finishes

`applicationWillTerminate` cannot hold termination open, so the old three-second detached wait could let AppKit kill the process mid-loop. The sequence is now:

1. User quits → `applicationShouldTerminate(_:)`.
2. Toggle off → `.terminateNow`, nothing else happens. Second quit while a restore is already in flight → `.terminateNow` (the user is waiting on us).
3. Otherwise `AgentQuitRestoreTerminationCoordinator.begin()` starts two `@MainActor` tasks — the serial revert, and a **5 s watchdog** — and returns **`.terminateLater`**.
4. Whichever finishes first calls `resolve(_:)`, guarded by a one-shot flag on the main actor, then `NSApp.reply(toApplicationShouldTerminate: true)`. Completion logs the outcome; timeout logs the agents that *did* complete, from a lock-protected progress snapshot, so a wedge is diagnosable.
5. AppKit proceeds → `applicationWillTerminate` → proxy/tunnel teardown as before.

`.terminateLater` makes AppKit wait indefinitely, so a missed reply would hang the app and force a Force Quit — worse than the bug being fixed. The watchdog is what makes the deferral safe, and it is covered by a test that wedges an agent. Both tasks capture the coordinator strongly so a dropped reference cannot swallow the reply. 5 s is chosen to stay inside the shorter OS budget for a logout/restart-initiated quit.

Restoration now runs **before** `CLIProxyManager.terminateProxyOnShutdown()` rather than racing it.

**Interaction with #476:** `AppResetService.relaunch()` calls `exit(0)`, bypassing every termination handler including this one. That is the correct outcome — a reset relaunches Quotio immediately, so its agent configs should stay in place. No line-level overlap either; #476 does not touch `QuotioApp.swift`.

## Scope relative to #128

Narrowing this explicitly rather than over-claiming. This PR covers "stop the agent pointing at a dead proxy". It does **not** yet implement:

- **Restore the original file / delete it if Quotio created it.** The receipt records `primaryConfigExisted`, but the revert still strips known keys rather than restoring the prior file. Byte-exact restore stays available through the existing per-agent backup list.
- **Persist and reapply Quotio's own agent settings on the next launch.**
- **Auxiliary/alternate write targets**, which are gaps in the shared revert path, not in this orchestration:
  - Claude `shellOnly`/`both` writes exports to the shell profile. `ShellProfileManager.removeFromProfile` exists (`ShellProfileManager.swift:62`) but **has no callers anywhere in the repo** — the per-agent "Default" button does not undo shell exports either. With `shellOnly` no JSON is written, so this PR reads no config and skips the agent; it does not make anything worse, and it does not help.
  - Codex `auth.json` — being fixed in #467, whose hunks land in `generateCodexDefaultConfig`, the exact path this PR calls.
  - Amp `secrets.json` — `generateAmpDefaultConfig` removes `amp.url` but leaves the `apiKey@<url>` entry. Inert once the URL is gone, but still untidy.

Happy to fold any of these in here or split them out — say which you prefer.

## Test evidence

`QuotioTests/AgentConfigOwnershipTests.swift` (14 tests) — every test runs against a **throwaway temp home directory**; nothing reads or writes real agent configs:

- receipt proves ownership for all five agents, across the `/v1` and trailing-slash forms each file format stores
- a foreign localhost proxy (`http://localhost:4000`, user's own key) is **not owned** for Claude Code, Amp and Factory Droid
- Factory Droid: a foreign localhost entry alongside a Quotio receipt is not owned; a matching entry among several is
- rotated `ANTHROPIC_AUTH_TOKEN`, and a Codex `auth.json` key replaced outside Quotio ⇒ `.externallyModified`
- `cliproxyapi` / `provider.quotio` markers recognised without a receipt; foreign providers are not
- receipt round-trip, and the raw API key is absent from the persisted blob

`QuotioTests/AgentQuitRestoreTests.swift` (11 tests):

- unowned agents are never handed to the reverter (the decisive assertion)
- **all agents complete before the reply fires**
- **a wedged agent hits the timeout, still replies, and reports partial progress**
- **the reply fires exactly once** even when the revert finishes just after the deadline
- failure isolation for an unsuccessful result and for a thrown error
- `CLIAgent.allCases` coverage; setting round-trip and default-OFF against an isolated `UserDefaults` suite

```
xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build   # BUILD SUCCEEDED
xcodebuild test  -project Quotio.xcodeproj -scheme Quotio -destination 'platform=macOS'
# TEST SUCCEEDED — 90 passed, 0 failed
```

Trial-merged in a throwaway worktree against `origin/master` and each of #476, #487, #467, #473, #477, #482 — **all clean, no conflicting hunks**. Merged with current `master` (4 commits ahead): **TEST SUCCEEDED, 96 passed, 0 failed**.

New localized strings are present for en / fr / vi / zh-Hans, and the UI note next to the toggle now states the ownership rule alongside the existing crash/force-quit limitation.
