### PR TITLE
refactor(quota): carry explicit bucket kinds from quota fetchers

### DIFF
--- a/Quotio/Models/MenuBarSettings.swift
+++ b/Quotio/Models/MenuBarSettings.swift
@@ -284,52 +284,18 @@ enum ModelAggregationMode: String, CaseIterable, Identifiable, Codable {
 // MARK: - Usage Calculation Helpers
 
 extension MenuBarSettingsManager {
-    /// Compute total usage percentage using session/extra logic
-    /// Treats extra-usage, codex-extra, on-demand as extra models; all others as session
-    func totalUsagePercent(models: [(name: String, percentage: Double)]) -> Double {
-        let extraModelNames: Set<String> = ["extra-usage", "codex-extra", "on-demand"]
-        
-        var sessionPercentages: [Double] = []
-        var extraPercentages: [Double] = []
-        
-        for model in models {
-            if extraModelNames.contains(model.name) {
-                extraPercentages.append(model.percentage)
-            } else {
-                sessionPercentages.append(model.percentage)
-            }
-        }
-        
-        let sessionRemaining = aggregateModelPercentages(sessionPercentages)
-        let extraRemaining = aggregateModelPercentages(extraPercentages)
-        
-        let hasExtraModels = !extraPercentages.isEmpty
-        
-        switch totalUsageMode {
-        case .sessionOnly:
-            if sessionRemaining >= 0 {
-                return sessionRemaining
-            }
-            if hasExtraModels {
-                return extraRemaining
-            }
-            return -1
-            
-        case .combined:
-            let session = sessionRemaining >= 0 ? sessionRemaining : -1
-            let extra = extraRemaining >= 0 ? extraRemaining : -1
-            
-            if session < 0 && extra < 0 {
-                return -1
-            }
-            if session < 0 {
-                return extra
-            }
-            if extra < 0 {
-                return session
-            }
-            return max(session, extra)
-        }
+    /// Compute total usage percentage using session/extra logic.
+    ///
+    /// A bucket counts as paid extra usage only when the fetcher that produced it
+    /// declared `billing == .paidOverage`. Buckets with no declared billing kind
+    /// stay in the subscription group, so an unclassified bucket is never dropped
+    /// from `.sessionOnly` totals.
+    func totalUsagePercent(models: [ModelQuota]) -> Double {
+        QuotaUsageCalculator.totalUsagePercent(
+            models: models,
+            totalMode: totalUsageMode,
+            aggregation: modelAggregationMode
+        )
     }
     
     func calculateTotalUsagePercent(sessionPercent: Double?, extraPercent: Double?) -> Double {
@@ -358,15 +324,7 @@ extension MenuBarSettingsManager {
     }
     
     func aggregateModelPercentages(_ percentages: [Double]) -> Double {
-        let validPercentages = percentages.filter { $0 >= 0 }
-        guard !validPercentages.isEmpty else { return -1 }
-        
-        switch modelAggregationMode {
-        case .lowest:
-            return validPercentages.min() ?? -1
-        case .average:
-            return validPercentages.reduce(0, +) / Double(validPercentages.count)
-        }
+        QuotaUsageCalculator.aggregate(percentages, mode: modelAggregationMode)
     }
 }
 

--- a/Quotio/Models/QuotaBucketKind.swift
+++ b/Quotio/Models/QuotaBucketKind.swift
@@ -1,0 +1,117 @@
+//
+//  QuotaBucketKind.swift
+//  Quotio
+//
+//  Explicit, fetcher-declared classification of a quota bucket.
+//
+
+import Foundation
+
+// MARK: - Quota Window
+
+/// The recurring window a quota bucket refills on.
+///
+/// This is set by the fetcher that produced the bucket, from evidence in the
+/// provider payload (a declared window length, a period type, an explicit
+/// limit type). It is deliberately never derived from `ModelQuota.name`:
+/// those strings are display/identifier slugs — several of them are built at
+/// runtime from provider fields (`codex-<metered feature>`,
+/// `antigravity-<group>-<period>`, `warp-bonus-<n>`) — so they carry no
+/// reliable domain meaning.
+///
+/// A bucket whose window the provider does not state keeps `nil`. Unknown
+/// stays unknown; it is never guessed.
+nonisolated enum QuotaWindow: String, Codable, Sendable, CaseIterable, Hashable {
+    /// Short rolling window (Codex/Claude five-hour, ClinePass five-hour, ...).
+    case session
+    case daily
+    case weekly
+    case monthly
+}
+
+// MARK: - Quota Billing
+
+/// How a quota bucket is paid for.
+///
+/// Like `QuotaWindow`, this is declared by the producing fetcher and never
+/// inferred from the bucket name. `nil` means the provider payload gives no
+/// billing signal, and is treated as "not paid overage" so an unclassified
+/// bucket keeps counting toward subscription totals.
+nonisolated enum QuotaBilling: String, Codable, Sendable, Hashable {
+    /// Included in the plan.
+    case subscription
+    /// Billed on top of the plan (extra usage credits, on-demand spend).
+    case paidOverage
+}
+
+// MARK: - Usage Calculation
+
+/// Pure quota math shared by the menu bar, the dashboard and the quota screen.
+///
+/// Kept free of `MenuBarSettingsManager` so the calculation can be exercised
+/// without mutating (and persisting to) the app's real preferences.
+nonisolated enum QuotaUsageCalculator {
+    /// Aggregate a set of remaining percentages, ignoring the `-1` "unknown"
+    /// sentinel that fetchers use for status/balance rows.
+    /// Returns `-1` when nothing is known.
+    static func aggregate(_ percentages: [Double], mode: ModelAggregationMode) -> Double {
+        let valid = percentages.filter { $0 >= 0 }
+        guard !valid.isEmpty else { return -1 }
+
+        switch mode {
+        case .lowest:
+            return valid.min() ?? -1
+        case .average:
+            return valid.reduce(0, +) / Double(valid.count)
+        }
+    }
+
+    /// Split buckets into subscription and paid-overage groups using the
+    /// billing kind each fetcher declared, then combine per `totalMode`.
+    static func totalUsagePercent(
+        models: [ModelQuota],
+        totalMode: TotalUsageMode,
+        aggregation: ModelAggregationMode
+    ) -> Double {
+        var sessionPercentages: [Double] = []
+        var extraPercentages: [Double] = []
+
+        for model in models {
+            if model.billing == .paidOverage {
+                extraPercentages.append(model.percentage)
+            } else {
+                sessionPercentages.append(model.percentage)
+            }
+        }
+
+        let sessionRemaining = aggregate(sessionPercentages, mode: aggregation)
+        let extraRemaining = aggregate(extraPercentages, mode: aggregation)
+        let hasExtraModels = !extraPercentages.isEmpty
+
+        switch totalMode {
+        case .sessionOnly:
+            if sessionRemaining >= 0 {
+                return sessionRemaining
+            }
+            if hasExtraModels {
+                return extraRemaining
+            }
+            return -1
+
+        case .combined:
+            let session = sessionRemaining >= 0 ? sessionRemaining : -1
+            let extra = extraRemaining >= 0 ? extraRemaining : -1
+
+            if session < 0 && extra < 0 {
+                return -1
+            }
+            if session < 0 {
+                return extra
+            }
+            if extra < 0 {
+                return session
+            }
+            return max(session, extra)
+        }
+    }
+}

--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -120,8 +120,7 @@ final class AppBootstrap {
                ) {
                 isForbidden = quotaData.isForbidden
                 if !quotaData.models.isEmpty {
-                    let models = quotaData.models.map { (name: $0.name, percentage: $0.percentage) }
-                    displayPercent = menuBarSettings.totalUsagePercent(models: models)
+                    displayPercent = menuBarSettings.totalUsagePercent(models: quotaData.models)
                 }
             }
 

--- a/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
+++ b/Quotio/Services/Antigravity/AntigravityQuotaFetcher.swift
@@ -140,6 +140,16 @@ nonisolated struct ModelQuota: Codable, Identifiable, Sendable {
     // Optional tooltip message (e.g., Warp bonus userFacingMessage)
     var tooltip: String?
 
+    /// Recurring window this bucket refills on, declared by the producing fetcher.
+    /// `nil` means the provider payload states no window (or the value was cached
+    /// by a build that predates this field). Never inferred from `name`.
+    var window: QuotaWindow?
+
+    /// How this bucket is paid for, declared by the producing fetcher.
+    /// `nil` means the provider payload gives no billing signal; it is treated as
+    /// "not paid overage". Never inferred from `name`.
+    var billing: QuotaBilling?
+
     init(
         name: String,
         percentage: Double,
@@ -148,7 +158,9 @@ nonisolated struct ModelQuota: Codable, Identifiable, Sendable {
         used: Int? = nil,
         limit: Int? = nil,
         remaining: Int? = nil,
-        tooltip: String? = nil
+        tooltip: String? = nil,
+        window: QuotaWindow? = nil,
+        billing: QuotaBilling? = nil
     ) {
         self.name = name
         self.percentage = percentage
@@ -158,6 +170,8 @@ nonisolated struct ModelQuota: Codable, Identifiable, Sendable {
         self.limit = limit
         self.remaining = remaining
         self.tooltip = tooltip
+        self.window = window
+        self.billing = billing
     }
 
     var id: String { name }
@@ -734,7 +748,13 @@ actor AntigravityQuotaFetcher {
                         // Clamp to 0-100 range (API can return remainingFraction > 1.0)
                         let percentage = min(100, max(0, (quotaInfo.remainingFraction ?? 0) * 100))
                         let resetTime = quotaInfo.resetTime ?? ""
-                        models.append(ModelQuota(name: name, percentage: percentage, resetTime: resetTime))
+                        // Per-model pools: the endpoint states no window, so it stays unknown.
+                        models.append(ModelQuota(
+                            name: name,
+                            percentage: percentage,
+                            resetTime: resetTime,
+                            billing: .subscription
+                        ))
                     }
                 }
 
@@ -819,10 +839,14 @@ actor AntigravityQuotaFetcher {
                     continue
                 }
 
+                // The period is parsed once here, from the provider's own bucket
+                // descriptor, and carried explicitly so no consumer re-parses the name.
                 models.append(ModelQuota(
                     name: "antigravity-\(groupID)-\(period.id)",
                     percentage: (remainingFraction.clamped(to: 0...1) * 100).clamped(to: 0...100),
-                    resetTime: trimmedString(bucket["resetTime"] ?? bucket["reset_time"] ?? bucket["resetAt"] ?? bucket["reset_at"]) ?? ""
+                    resetTime: trimmedString(bucket["resetTime"] ?? bucket["reset_time"] ?? bucket["resetAt"] ?? bucket["reset_at"]) ?? "",
+                    window: period.window,
+                    billing: .subscription
                 ))
             }
         }
@@ -867,13 +891,13 @@ actor AntigravityQuotaFetcher {
         return nil
     }
 
-    private static func quotaSummaryPeriod(from label: String) -> (id: String, displayName: String)? {
+    private static func quotaSummaryPeriod(from label: String) -> (id: String, displayName: String, window: QuotaWindow)? {
         let lower = label.lowercased()
         if lower.contains("week") || lower.contains("7d") || lower.contains("seven") {
-            return ("weekly", "Weekly")
+            return ("weekly", "Weekly", .weekly)
         }
         if lower.contains("session") || lower.contains("5") || lower.contains("hour") {
-            return ("session", "Session")
+            return ("session", "Session", .session)
         }
         return nil
     }

--- a/Quotio/Services/GLMQuotaFetcher.swift
+++ b/Quotio/Services/GLMQuotaFetcher.swift
@@ -177,11 +177,15 @@ actor GLMQuotaFetcher {
                let percentage = limit.percentage,
                let unit = limit.unit,
                let number = limit.number,
-               let windowName = tokenWindowName(unit: unit, number: number) {
+               let window = tokenWindow(unit: unit, number: number) {
+                // Both the name and the window come from the API's `unit`/`number`
+                // pair, so the window is derived from the payload, not the name.
                 models.append(ModelQuota(
-                    name: windowName,
+                    name: window.modelName,
                     percentage: max(0, min(100, 100 - percentage)),
-                    resetTime: resetTime
+                    resetTime: resetTime,
+                    window: window.quotaWindow,
+                    billing: .subscription
                 ))
             } else if kind == "TIME_LIMIT",
                       let used = limit.currentValue,
@@ -199,7 +203,8 @@ actor GLMQuotaFetcher {
                         unit: .searches
                     ),
                     used: Int(used),
-                    limit: Int(quotaLimit)
+                    limit: Int(quotaLimit),
+                    billing: .subscription
                 ))
             }
         }
@@ -207,18 +212,43 @@ actor GLMQuotaFetcher {
         return ProviderQuotaData(models: models, lastUpdated: Date(), planType: planName)
     }
 
-    private nonisolated static func tokenWindowName(unit: Double, number: Double) -> String? {
+    nonisolated enum GLMTokenWindow {
+        case session
+        case daily
+        case weekly
+        case monthly
+
+        var modelName: String {
+            switch self {
+            case .session: "zai-session"
+            case .daily: "zai-daily"
+            case .weekly: "zai-weekly"
+            case .monthly: "zai-monthly"
+            }
+        }
+
+        var quotaWindow: QuotaWindow {
+            switch self {
+            case .session: .session
+            case .daily: .daily
+            case .weekly: .weekly
+            case .monthly: .monthly
+            }
+        }
+    }
+
+    nonisolated static func tokenWindow(unit: Double, number: Double) -> GLMTokenWindow? {
         guard number > 0 else { return nil }
         switch unit {
         case 3:
-            return number < 24 ? "zai-session" : "zai-daily"
+            return number < 24 ? .session : .daily
         case 4:
-            if number <= 1 { return "zai-daily" }
-            return number < 28 ? "zai-weekly" : "zai-monthly"
+            if number <= 1 { return .daily }
+            return number < 28 ? .weekly : .monthly
         case 5:
-            return "zai-monthly"
+            return .monthly
         case 6:
-            return number < 4 ? "zai-weekly" : "zai-monthly"
+            return number < 4 ? .weekly : .monthly
         default: return nil
         }
     }

--- a/Quotio/Services/QuotaFetchers/AmpQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/AmpQuotaFetcher.swift
@@ -71,10 +71,13 @@ nonisolated enum AmpQuotaParser {
             #"(?im)^\s*Amp Free:\s*([\d.]+)%\s+remaining(?:\s+today)?(?:\s*\(resets\s+daily\))?"#,
             in: text
         ), let remaining = validPercentage(match[0]) {
+            // This shape is the "resets daily" free allowance.
             models.append(ModelQuota(
                 name: "amp-free",
                 percentage: remaining,
-                resetTime: nextMidnightUTC(after: now)
+                resetTime: nextMidnightUTC(after: now),
+                window: .daily,
+                billing: .subscription
             ))
         }
 
@@ -85,9 +88,10 @@ nonisolated enum AmpQuotaParser {
         ), let agent = validPercentage(subscription[1]),
            let orb = validPercentage(subscription[2]) {
             plan = subscription[0]
+            // Matched from the CLI's "Subscription <plan>: ..." line.
             let resetTime = relativeResetTime(value: subscription[3], unit: subscription[4], after: now)
-            models.append(ModelQuota(name: "amp-agent-usage", percentage: agent, resetTime: resetTime))
-            models.append(ModelQuota(name: "amp-orb-usage", percentage: orb, resetTime: resetTime))
+            models.append(ModelQuota(name: "amp-agent-usage", percentage: agent, resetTime: resetTime, billing: .subscription))
+            models.append(ModelQuota(name: "amp-orb-usage", percentage: orb, resetTime: resetTime, billing: .subscription))
         } else {
             for match in allCaptures(
                 #"(?im)^\s*(agent|other|orb)(?:\s+(?:usage|quota))?\s*:\s*([\d.]+)%"#,

--- a/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/ClaudeCodeQuotaFetcher.swift
@@ -541,20 +541,53 @@ actor ClaudeCodeQuotaFetcher {
 
     private func quotaData(from info: ClaudeCodeQuotaInfo) -> ProviderQuotaData? {
         var models: [ModelQuota] = []
+        // Window/billing come from which field of the Anthropic payload produced the
+        // bucket (`five_hour`, `seven_day*`, `extra_usage`), not from the bucket name.
         if let value = info.fiveHour {
-            models.append(ModelQuota(name: "five-hour-session", percentage: value.remaining, resetTime: value.resetsAt))
+            models.append(ModelQuota(
+                name: "five-hour-session",
+                percentage: value.remaining,
+                resetTime: value.resetsAt,
+                window: .session,
+                billing: .subscription
+            ))
         }
         if let value = info.sevenDay {
-            models.append(ModelQuota(name: "seven-day-weekly", percentage: value.remaining, resetTime: value.resetsAt))
+            models.append(ModelQuota(
+                name: "seven-day-weekly",
+                percentage: value.remaining,
+                resetTime: value.resetsAt,
+                window: .weekly,
+                billing: .subscription
+            ))
         }
         if let value = info.sevenDaySonnet {
-            models.append(ModelQuota(name: "seven-day-sonnet", percentage: value.remaining, resetTime: value.resetsAt))
+            models.append(ModelQuota(
+                name: "seven-day-sonnet",
+                percentage: value.remaining,
+                resetTime: value.resetsAt,
+                window: .weekly,
+                billing: .subscription
+            ))
         }
         if let value = info.sevenDayOpus {
-            models.append(ModelQuota(name: "seven-day-opus", percentage: value.remaining, resetTime: value.resetsAt))
+            models.append(ModelQuota(
+                name: "seven-day-opus",
+                percentage: value.remaining,
+                resetTime: value.resetsAt,
+                window: .weekly,
+                billing: .subscription
+            ))
         }
         if let extra = info.extraUsage, let remaining = extra.remaining {
-            var model = ModelQuota(name: "extra-usage", percentage: remaining, resetTime: "")
+            // `extra_usage` is the paid credit pool, capped by `monthly_limit`.
+            var model = ModelQuota(
+                name: "extra-usage",
+                percentage: remaining,
+                resetTime: "",
+                window: .monthly,
+                billing: .paidOverage
+            )
             if let used = extra.usedCredits, let limit = extra.monthlyLimit {
                 model.used = Int(used)
                 model.limit = Int(limit)

--- a/Quotio/Services/QuotaFetchers/ClinePassQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/ClinePassQuotaFetcher.swift
@@ -106,7 +106,9 @@ actor ClinePassQuotaFetcher {
             modelsByName[name] = ModelQuota(
                 name: name,
                 percentage: 100 - usedPercentage,
-                resetTime: try normalizedResetTime(limit.resetsAt)
+                resetTime: try normalizedResetTime(limit.resetsAt),
+                window: window(for: limit.type),
+                billing: .subscription
             )
         }
 
@@ -120,6 +122,16 @@ actor ClinePassQuotaFetcher {
         case "five_hour": return "clinepass-five-hour"
         case "weekly": return "clinepass-weekly"
         case "monthly": return "clinepass-monthly"
+        default: return nil
+        }
+    }
+
+    /// The window comes from the API's own `type` discriminator.
+    private func window(for limitType: String) -> QuotaWindow? {
+        switch limitType {
+        case "five_hour": return .session
+        case "weekly": return .weekly
+        case "monthly": return .monthly
         default: return nil
         }
     }

--- a/Quotio/Services/QuotaFetchers/CodexUsageMapper.swift
+++ b/Quotio/Services/QuotaFetchers/CodexUsageMapper.swift
@@ -26,12 +26,19 @@ nonisolated enum CodexUsageMapper {
         )
     }
 
-    private static func modelQuota(name: String, from snapshot: CodexUsageResponseV2.WindowSnapshot?) -> ModelQuota? {
+    private static func modelQuota(
+        name: String,
+        from snapshot: CodexUsageResponseV2.WindowSnapshot?,
+        window: QuotaWindow?,
+        billing: QuotaBilling?
+    ) -> ModelQuota? {
         guard let snapshot else { return nil }
         return ModelQuota(
             name: name,
             percentage: Double(100 - snapshot.usedPercent),
-            resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? ""
+            resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? "",
+            window: window,
+            billing: billing
         )
     }
 
@@ -46,7 +53,8 @@ nonisolated enum CodexUsageMapper {
             guard let snapshot else { return nil }
             let kind = standardWindowKind(for: snapshot, fallback: fallbackKind)
             guard usedKinds.insert(kind).inserted else { return nil }
-            return modelQuota(name: kind.id, from: snapshot)
+            // `rate_limit` is the plan's own rate limit, so the billing kind is known.
+            return modelQuota(name: kind.id, from: snapshot, window: kind.window, billing: .subscription)
         }
     }
 
@@ -74,12 +82,27 @@ nonisolated enum CodexUsageMapper {
             else {
                 return []
             }
+            // An `additional_rate_limits` entry carries no billing signal: the same
+            // collection holds model-specific *subscription* limits (Spark is one).
+            // Billing therefore stays nil (unknown, i.e. not paid overage) and the
+            // window comes only from the declared `limit_window_seconds`.
             return [ModelQuota(
                 name: id,
                 percentage: Double(100 - snapshot.usedPercent),
-                resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? ""
+                resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? "",
+                window: declaredWindow(for: snapshot),
+                billing: nil
             )]
         }
+    }
+
+    /// Window implied by the API's own `limit_window_seconds`, using the same
+    /// thresholds as `standardWindowKind`. Nil when the field is absent.
+    private static func declaredWindow(for snapshot: CodexUsageResponseV2.WindowSnapshot) -> QuotaWindow? {
+        guard let seconds = snapshot.limitWindowSeconds, seconds > 0 else { return nil }
+        if seconds >= 6 * 24 * 60 * 60 { return .weekly }
+        if seconds <= 24 * 60 * 60 { return .session }
+        return nil
     }
 
     private static func sparkModels(
@@ -91,10 +114,13 @@ nonisolated enum CodexUsageMapper {
             (limit.rateLimit?.secondaryWindow, sparkKind(for: limit.rateLimit?.secondaryWindow, fallback: .weekly))
         ].compactMap { snapshot, kind in
             guard let snapshot, usedIDs.insert(kind.id).inserted else { return nil }
+            // Spark is a model-specific limit included in the plan, not paid overage.
             return ModelQuota(
                 name: kind.id,
                 percentage: Double(100 - snapshot.usedPercent),
-                resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? ""
+                resetTime: snapshot.resetDate.map { ISO8601DateFormatter().string(from: $0) } ?? "",
+                window: kind.window,
+                billing: .subscription
             )
         }
     }
@@ -204,6 +230,13 @@ nonisolated enum CodexUsageMapper {
             case .weekly: "codex-spark-weekly"
             }
         }
+
+        var window: QuotaWindow {
+            switch self {
+            case .fiveHour: .session
+            case .weekly: .weekly
+            }
+        }
     }
 
     private enum StandardWindowKind {
@@ -214,6 +247,13 @@ nonisolated enum CodexUsageMapper {
             switch self {
             case .session: "codex-session"
             case .weekly: "codex-weekly"
+            }
+        }
+
+        var window: QuotaWindow {
+            switch self {
+            case .session: .session
+            case .weekly: .weekly
             }
         }
     }

--- a/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
@@ -431,13 +431,17 @@ actor CopilotQuotaFetcher {
         var models: [ModelQuota] = []
         let resetTimeString = entitlement.resetDate?.ISO8601Format() ?? ""
 
+        // Copilot entitlement quotas are monthly: both shapes are capped by
+        // `monthly_quotas` and reset on `quota_reset_date` / `quota_reset_date_utc`.
         // Method 1: Parse quota_snapshots (used by some plans)
         if let snapshots = entitlement.quotaSnapshots {
             if let chat = snapshots.chat, chat.unlimited != true {
                 models.append(ModelQuota(
                     name: "copilot-chat",
                     percentage: chat.calculatePercent(defaultTotal: 50),
-                    resetTime: resetTimeString
+                    resetTime: resetTimeString,
+                    window: .monthly,
+                    billing: .subscription
                 ))
             }
 
@@ -445,7 +449,9 @@ actor CopilotQuotaFetcher {
                 models.append(ModelQuota(
                     name: "copilot-completions",
                     percentage: completions.calculatePercent(defaultTotal: 2000),
-                    resetTime: resetTimeString
+                    resetTime: resetTimeString,
+                    window: .monthly,
+                    billing: .subscription
                 ))
             }
 
@@ -453,7 +459,9 @@ actor CopilotQuotaFetcher {
                 models.append(ModelQuota(
                     name: "copilot-premium",
                     percentage: premium.calculatePercent(defaultTotal: 50),
-                    resetTime: resetTimeString
+                    resetTime: resetTimeString,
+                    window: .monthly,
+                    billing: .subscription
                 ))
             }
         }
@@ -468,7 +476,9 @@ actor CopilotQuotaFetcher {
                 models.append(ModelQuota(
                     name: "copilot-chat",
                     percentage: percentage,
-                    resetTime: resetTimeString
+                    resetTime: resetTimeString,
+                    window: .monthly,
+                    billing: .subscription
                 ))
             }
 
@@ -478,7 +488,9 @@ actor CopilotQuotaFetcher {
                 models.append(ModelQuota(
                     name: "copilot-completions",
                     percentage: percentage,
-                    resetTime: resetTimeString
+                    resetTime: resetTimeString,
+                    window: .monthly,
+                    billing: .subscription
                 ))
             }
         }

--- a/Quotio/Services/QuotaFetchers/CursorQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CursorQuotaFetcher.swift
@@ -341,10 +341,13 @@ actor CursorQuotaFetcher {
                 resetTimeStr = ""
             }
             
+            // Cursor states no window length, only a billing cycle boundary, so the
+            // window stays unknown. The billing kind is known: this is plan quota.
             var planModel = ModelQuota(
                 name: "plan-usage",
                 percentage: plan.remainingPercentage,
-                resetTime: resetTimeStr
+                resetTime: resetTimeStr,
+                billing: .subscription
             )
             planModel.used = plan.used
             planModel.limit = plan.limit
@@ -362,10 +365,12 @@ actor CursorQuotaFetcher {
                 percentage = 100 // Unlimited or no limit set
             }
             
+            // `individualUsage.onDemand` is spend billed on top of the plan.
             var onDemandModel = ModelQuota(
                 name: "on-demand",
                 percentage: percentage,
-                resetTime: ""
+                resetTime: "",
+                billing: .paidOverage
             )
             onDemandModel.used = onDemand.used
             onDemandModel.limit = onDemand.limit
@@ -378,7 +383,8 @@ actor CursorQuotaFetcher {
             models.append(ModelQuota(
                 name: "cursor-usage",
                 percentage: info.isUnlimited ? 100 : -1,
-                resetTime: ""
+                resetTime: "",
+                billing: .subscription
             ))
         }
         

--- a/Quotio/Services/QuotaFetchers/DevinQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/DevinQuotaFetcher.swift
@@ -24,23 +24,30 @@ nonisolated enum DevinQuotaMapper {
             models.append(ModelQuota(
                 name: "devin-daily",
                 percentage: clamp(dailyRemaining),
-                resetTime: dailyReset
+                resetTime: dailyReset,
+                window: .daily,
+                billing: .subscription
             ))
         }
         if let weeklyRemaining {
             models.append(ModelQuota(
                 name: "devin-weekly",
                 percentage: clamp(weeklyRemaining),
-                resetTime: weeklyReset
+                resetTime: weeklyReset,
+                window: .weekly,
+                billing: .subscription
             ))
         } else if hideDaily, let dailyRemaining {
             models.append(ModelQuota(
                 name: "devin-weekly",
                 percentage: clamp(dailyRemaining),
-                resetTime: weeklyReset
+                resetTime: weeklyReset,
+                window: .weekly,
+                billing: .subscription
             ))
         }
         if let micros = number(planStatus["overageBalanceMicros"]) {
+            // `overageBalanceMicros` is spend billed beyond the plan.
             models.append(ModelQuota(
                 name: "devin-extra-balance",
                 percentage: -1,
@@ -49,7 +56,8 @@ nonisolated enum DevinQuotaMapper {
                     value: max(0, micros) / 1_000_000,
                     unit: .usd,
                     semantics: .balance
-                )
+                ),
+                billing: .paidOverage
             ))
         }
 

--- a/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
@@ -197,6 +197,7 @@ nonisolated enum FactoryDroidQuotaMapper {
         append(pool: response.limits?.core, prefix: "factory-core", now: now, to: &models)
 
         if let cents = response.extraUsageBalanceCents {
+            // `extra_usage_balance_cents` is prepaid spend on top of the plan.
             models.append(ModelQuota(
                 name: "factory-extra-balance",
                 percentage: -1,
@@ -205,7 +206,8 @@ nonisolated enum FactoryDroidQuotaMapper {
                     value: max(0, cents) / 100,
                     unit: .usd,
                     semantics: .balance
-                )
+                ),
+                billing: .paidOverage
             ))
         }
 
@@ -219,17 +221,20 @@ nonisolated enum FactoryDroidQuotaMapper {
         to models: inout [ModelQuota]
     ) {
         guard let pool else { return }
-        for (suffix, window) in [
-            ("five-hour", pool.fiveHour),
-            ("weekly", pool.weekly),
-            ("monthly", pool.monthly),
+        // The window is the pool field the entry came from, not the name suffix.
+        for (suffix, quotaWindow, window) in [
+            ("five-hour", QuotaWindow.session, pool.fiveHour),
+            ("weekly", QuotaWindow.weekly, pool.weekly),
+            ("monthly", QuotaWindow.monthly, pool.monthly),
         ] {
             guard let window else { continue }
             let usedPercent = isExpired(window.windowEnd, now: now) ? 0 : window.usedPercent
             models.append(ModelQuota(
                 name: prefix + "-" + suffix,
                 percentage: max(0, min(100, 100 - usedPercent)),
-                resetTime: window.windowEnd ?? ""
+                resetTime: window.windowEnd ?? "",
+                window: quotaWindow,
+                billing: .subscription
             ))
         }
     }

--- a/Quotio/Services/QuotaFetchers/GrokQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/GrokQuotaFetcher.swift
@@ -27,10 +27,13 @@ nonisolated enum GrokQuotaMapper {
            let endString = period["end"] as? String,
            parseDate(endString) != nil {
             let used = number(config["creditUsagePercent"]) ?? 0
+            // Guarded above on `config.currentPeriod.type == USAGE_PERIOD_TYPE_WEEKLY`.
             models.append(ModelQuota(
                 name: "grok-weekly",
                 percentage: max(0, min(100, 100 - used)),
-                resetTime: ISO8601DateFormatter().string(from: parseDate(endString)!)
+                resetTime: ISO8601DateFormatter().string(from: parseDate(endString)!),
+                window: .weekly,
+                billing: .subscription
             ))
         }
 
@@ -38,11 +41,13 @@ nonisolated enum GrokQuotaMapper {
         let status = cap > 0
             ? String(format: "grok.status.cap".localizedStatic(), formatUnits(cap))
             : "grok.status.disabled".localizedStatic()
+        // `config.onDemandCap` is the paid on-demand allowance beyond the plan.
         models.append(ModelQuota(
             name: "grok-extra-usage",
             percentage: -1,
             resetTime: "",
-            presentation: .status(text: status)
+            presentation: .status(text: status),
+            billing: .paidOverage
         ))
         return ProviderQuotaData(models: models, lastUpdated: Date(), planType: plan)
     }

--- a/Quotio/Services/QuotaFetchers/WarpQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/WarpQuotaFetcher.swift
@@ -188,13 +188,16 @@ actor WarpQuotaFetcher {
                 percentage = 0
             }
 
+            // Warp reports only `nextRefreshTime`, never the refresh period, so the
+            // window stays unknown; the billing kind is known (plan request quota).
             models.append(ModelQuota(
                 name: "warp-usage",
                 percentage: percentage,
                 resetTime: stripMilliseconds(from: info.nextRefreshTime) ?? "",
                 used: used,
                 limit: limit,
-                remaining: remaining
+                remaining: remaining,
+                billing: .subscription
             ))
 
             let dateFormatter = ISO8601DateFormatter()

--- a/Quotio/Views/Screens/DashboardScreen.swift
+++ b/Quotio/Views/Screens/DashboardScreen.swift
@@ -54,8 +54,7 @@ struct DashboardScreen: View {
         
         for (_, accountQuotas) in viewModel.providerQuotas {
             for (_, quotaData) in accountQuotas {
-                let models = quotaData.models.map { (name: $0.name, percentage: $0.percentage) }
-                let total = settings.totalUsagePercent(models: models)
+                let total = settings.totalUsagePercent(models: quotaData.models)
                 if total >= 0 {
                     allTotals.append(total)
                 }

--- a/Quotio/Views/Screens/QuotaScreen.swift
+++ b/Quotio/Views/Screens/QuotaScreen.swift
@@ -57,8 +57,7 @@ struct QuotaScreen: View {
         
         var allTotals: [Double] = []
         for (_, quotaData) in accounts {
-            let models = quotaData.models.map { (name: $0.name, percentage: $0.percentage) }
-            let total = settings.totalUsagePercent(models: models)
+            let total = settings.totalUsagePercent(models: quotaData.models)
             if total >= 0 {
                 allTotals.append(total)
             }

--- a/QuotioTests/QuotaBucketKindTests.swift
+++ b/QuotioTests/QuotaBucketKindTests.swift
@@ -1,0 +1,274 @@
+import XCTest
+@testable import Quotio
+
+/// Covers the fetcher-declared bucket kinds and the total-usage math that reads them.
+///
+/// Every fixture below is a provider payload run through the real mapper, so the
+/// classification under test is the one the app actually produces at runtime.
+/// Nothing here mutates `MenuBarSettingsManager.shared`: the calculation is a pure
+/// function that takes the two display modes as arguments.
+final class QuotaBucketKindTests: XCTestCase {
+
+    // MARK: - Codex: additional_rate_limits carry no billing signal
+
+    /// `CodexUsageMapper.extraModels` names `additional_rate_limits` entries
+    /// `codex-<metered_feature/limit_name slug>`. That slug is provider text, so it
+    /// cannot decide billing: the same collection holds model-specific *subscription*
+    /// limits. This payload contains one whose slug ends in `on-demand`, which a
+    /// suffix rule would misread as paid overage and drop from session totals.
+    func testCodexAdditionalRateLimitsAreNeverClassifiedAsPaidOverage() throws {
+        let data = Self.codexUsagePayload()
+        let quota = try CodexUsageMapper.map(data: data)
+
+        let names = quota.models.map(\.name)
+        XCTAssertEqual(
+            names,
+            ["codex-session", "codex-weekly", "codex-spark", "codex-spark-weekly", "codex-code-review-on-demand"]
+        )
+
+        for model in quota.models {
+            XCTAssertNotEqual(
+                model.billing,
+                .paidOverage,
+                "\(model.name) is a rate limit, not paid overage"
+            )
+        }
+
+        let dynamicLimit = try XCTUnwrap(quota.models.first { $0.name == "codex-code-review-on-demand" })
+        XCTAssertNil(dynamicLimit.billing, "an additional rate limit states no billing kind")
+    }
+
+    /// The subscription bucket above must keep counting toward `.sessionOnly` totals.
+    func testSessionOnlyTotalKeepsCodexAdditionalRateLimits() throws {
+        let quota = try CodexUsageMapper.map(data: Self.codexUsagePayload())
+
+        let total = QuotaUsageCalculator.totalUsagePercent(
+            models: quota.models,
+            totalMode: .sessionOnly,
+            aggregation: .lowest
+        )
+
+        // codex-code-review-on-demand is the lowest bucket at 5% remaining.
+        XCTAssertEqual(total, 5, accuracy: 0.001)
+    }
+
+    /// Codex maps the Spark five-hour window to `codex-spark`, whose name contains
+    /// none of `session`, `five-hour` or `5h`. The window must come from the payload's
+    /// `limit_window_seconds`, not from the name.
+    func testCodexDeclaresWindowsFromThePayloadNotTheName() throws {
+        let quota = try CodexUsageMapper.map(data: Self.codexUsagePayload())
+        let windows = Dictionary(uniqueKeysWithValues: quota.models.map { ($0.name, $0.window) })
+
+        XCTAssertEqual(windows["codex-session"], .session)
+        XCTAssertEqual(windows["codex-weekly"], .weekly)
+        XCTAssertEqual(windows["codex-spark"], .session)
+        XCTAssertEqual(windows["codex-spark-weekly"], .weekly)
+        XCTAssertEqual(windows["codex-code-review-on-demand"], .session)
+    }
+
+    /// Codex paid credits are an analytics row (`CodexUsageMapper.analytics`), not a
+    /// `ModelQuota`, so no Codex bucket may be treated as paid overage.
+    func testCodexPaidCreditsRemainAnAnalyticsRow() throws {
+        let quota = try CodexUsageMapper.map(data: Self.codexUsagePayload())
+
+        XCTAssertTrue(quota.models.allSatisfy { $0.billing != .paidOverage })
+        XCTAssertEqual(
+            quota.analytics?.rows.first(where: { $0.id == "codex-extra-usage" })?.title,
+            "Extra Usage"
+        )
+    }
+
+    // MARK: - Providers that really do emit a paid bucket
+
+    func testFactoryDeclaresPoolWindowsAndPaidBalance() throws {
+        let response = try JSONDecoder().decode(
+            FactoryDroidQuotaResponse.self,
+            from: Self.factoryQuotaPayload()
+        )
+        let quota = FactoryDroidQuotaMapper.map(response, now: Date(timeIntervalSince1970: 0))
+        let byName = Dictionary(uniqueKeysWithValues: quota.models.map { ($0.name, $0) })
+
+        XCTAssertEqual(byName["factory-standard-five-hour"]?.window, .session)
+        XCTAssertEqual(byName["factory-standard-weekly"]?.window, .weekly)
+        XCTAssertEqual(byName["factory-core-monthly"]?.window, .monthly)
+        XCTAssertEqual(byName["factory-standard-five-hour"]?.billing, .subscription)
+
+        let balance = try XCTUnwrap(byName["factory-extra-balance"])
+        XCTAssertEqual(balance.billing, .paidOverage)
+        XCTAssertNil(balance.window, "a prepaid balance refills on no schedule")
+    }
+
+    func testGrokDeclaresWeeklyWindowAndOnDemandCap() throws {
+        let quota = try XCTUnwrap(GrokQuotaMapper.mapBilling(Self.grokBillingPayload(), plan: "SuperGrok"))
+        let byName = Dictionary(uniqueKeysWithValues: quota.models.map { ($0.name, $0) })
+
+        // Guarded on config.currentPeriod.type == USAGE_PERIOD_TYPE_WEEKLY.
+        XCTAssertEqual(byName["grok-weekly"]?.window, .weekly)
+        XCTAssertEqual(byName["grok-weekly"]?.billing, .subscription)
+        XCTAssertEqual(byName["grok-extra-usage"]?.billing, .paidOverage)
+    }
+
+    // MARK: - Total usage math
+
+    func testSessionOnlyTotalExcludesDeclaredPaidOverage() {
+        let models = [
+            ModelQuota(name: "five-hour-session", percentage: 55, resetTime: "", window: .session, billing: .subscription),
+            ModelQuota(name: "seven-day-weekly", percentage: 70, resetTime: "", window: .weekly, billing: .subscription),
+            ModelQuota(name: "extra-usage", percentage: 0, resetTime: "", window: .monthly, billing: .paidOverage)
+        ]
+
+        let total = QuotaUsageCalculator.totalUsagePercent(
+            models: models,
+            totalMode: .sessionOnly,
+            aggregation: .lowest
+        )
+        XCTAssertEqual(total, 55, accuracy: 0.001)
+    }
+
+    /// A bucket with no declared billing kind is *not* paid overage, so it must stay
+    /// in the subscription group rather than silently vanishing from the total.
+    func testSessionOnlyTotalKeepsUnclassifiedBuckets() {
+        let models = [
+            ModelQuota(name: "codex-session", percentage: 42, resetTime: "", window: .session, billing: .subscription),
+            ModelQuota(name: "codex-some-overage", percentage: 12, resetTime: "")
+        ]
+
+        let total = QuotaUsageCalculator.totalUsagePercent(
+            models: models,
+            totalMode: .sessionOnly,
+            aggregation: .lowest
+        )
+        XCTAssertEqual(total, 12, accuracy: 0.001)
+    }
+
+    func testCombinedTotalCountsPaidOverage() {
+        let models = [
+            ModelQuota(name: "plan-usage", percentage: 10, resetTime: "", billing: .subscription),
+            ModelQuota(name: "on-demand", percentage: 80, resetTime: "", billing: .paidOverage)
+        ]
+
+        let total = QuotaUsageCalculator.totalUsagePercent(
+            models: models,
+            totalMode: .combined,
+            aggregation: .lowest
+        )
+        XCTAssertEqual(total, 80, accuracy: 0.001)
+    }
+
+    func testSessionOnlyFallsBackToPaidOverageWhenNoSubscriptionValueIsKnown() {
+        let models = [
+            ModelQuota(name: "on-demand", percentage: 25, resetTime: "", billing: .paidOverage)
+        ]
+
+        let total = QuotaUsageCalculator.totalUsagePercent(
+            models: models,
+            totalMode: .sessionOnly,
+            aggregation: .lowest
+        )
+        XCTAssertEqual(total, 25, accuracy: 0.001)
+    }
+
+    func testUnknownPercentagesAreIgnoredByAggregation() {
+        // Status/balance rows use -1 as the "unknown" sentinel.
+        let models = [
+            ModelQuota(name: "grok-weekly", percentage: 30, resetTime: "", window: .weekly, billing: .subscription),
+            ModelQuota(name: "grok-extra-usage", percentage: -1, resetTime: "", billing: .paidOverage)
+        ]
+
+        XCTAssertEqual(
+            QuotaUsageCalculator.totalUsagePercent(models: models, totalMode: .combined, aggregation: .lowest),
+            30,
+            accuracy: 0.001
+        )
+    }
+
+    // MARK: - Persistence compatibility
+
+    /// `ProviderQuotaData` is cached to disk. Data written before the bucket kinds
+    /// existed must still decode, with both kinds left unknown.
+    func testQuotaDataCachedBeforeBucketKindsStillDecodes() throws {
+        let legacy = Data("""
+        {
+          "models": [
+            { "name": "codex-session", "percentage": 40, "resetTime": "" }
+          ],
+          "lastUpdated": 0,
+          "isForbidden": false
+        }
+        """.utf8)
+
+        let decoded = try JSONDecoder().decode(ProviderQuotaData.self, from: legacy)
+        let model = try XCTUnwrap(decoded.models.first)
+        XCTAssertNil(model.window)
+        XCTAssertNil(model.billing)
+    }
+
+    // MARK: - Fixtures
+
+    /// Shaped after `GET /backend-api/wham/usage`: a plan rate limit plus
+    /// `additional_rate_limits` holding the Spark windows and one other
+    /// model-specific limit.
+    private static func codexUsagePayload() -> Data {
+        Data("""
+        {
+          "plan_type": "pro",
+          "rate_limit": {
+            "limit_reached": false,
+            "primary_window": { "used_percent": 20, "reset_at": 1800000000, "limit_window_seconds": 18000 },
+            "secondary_window": { "used_percent": 35, "reset_at": 1800500000, "limit_window_seconds": 604800 }
+          },
+          "additional_rate_limits": [
+            {
+              "limit_name": "codex_spark",
+              "metered_feature": "spark",
+              "rate_limit": {
+                "primary_window": { "used_percent": 90, "reset_at": 1800000000, "limit_window_seconds": 18000 },
+                "secondary_window": { "used_percent": 50, "reset_at": 1800500000, "limit_window_seconds": 604800 }
+              }
+            },
+            {
+              "limit_name": "code_review_on_demand",
+              "metered_feature": "code review on-demand",
+              "rate_limit": {
+                "primary_window": { "used_percent": 95, "reset_at": 1800000000, "limit_window_seconds": 18000 }
+              }
+            }
+          ],
+          "credits": { "balance": 12.5 }
+        }
+        """.utf8)
+    }
+
+    private static func factoryQuotaPayload() -> Data {
+        Data("""
+        {
+          "usesTokenRateLimitsBilling": true,
+          "limits": {
+            "standard": {
+              "fiveHour": { "usedPercent": 25, "windowEnd": "2999-01-01T00:00:00Z" },
+              "weekly": { "usedPercent": 40, "windowEnd": "2999-01-02T00:00:00Z" }
+            },
+            "core": {
+              "monthly": { "usedPercent": 10, "windowEnd": "2999-02-01T00:00:00Z" }
+            }
+          },
+          "extraUsageBalanceCents": 750
+        }
+        """.utf8)
+    }
+
+    private static func grokBillingPayload() -> Data {
+        Data("""
+        {
+          "config": {
+            "currentPeriod": {
+              "type": "USAGE_PERIOD_TYPE_WEEKLY",
+              "end": "2999-01-08T00:00:00Z"
+            },
+            "creditUsagePercent": 60,
+            "onDemandCap": { "val": 2500 }
+          }
+        }
+        """.utf8)
+    }
+}


### PR DESCRIPTION
## What changed

Reworked per review: the classification is no longer derived from `ModelQuota.name`. Each fetcher now declares the bucket kind at construction, from the payload field the bucket came from.

```swift
nonisolated enum QuotaWindow: String, Codable, Sendable, CaseIterable { case session, daily, weekly, monthly }
nonisolated enum QuotaBilling: String, Codable, Sendable { case subscription, paidOverage }

// on ModelQuota
var window: QuotaWindow?    // nil = the provider states no window
var billing: QuotaBilling?  // nil = the provider gives no billing signal
```

Both are optional, and `nil` means unknown rather than a guess. `nil` billing stays in the subscription group, so an unclassified bucket is never dropped from `.sessionOnly` totals. Because `ProviderQuotaData` is cached to disk, optional fields also keep old caches decodable (covered by a test).

The total-usage math moved to a pure `QuotaUsageCalculator`, and `totalUsagePercent` now takes `[ModelQuota]` instead of `(name, percentage)` tuples so callers stop discarding the kinds.

## Scope correction (please read before the diff)

Investigating point 2 showed the PR's premise was wrong, so I retitled it from `fix` to `refactor` and removed the Codex claim.

- Codex never emits a paid-overage `ModelQuota`. Paid credits are the analytics row built in `CodexUsageMapper.analytics` (`CodexUsageMapper.swift:124-143`), not a bucket consumed by `totalUsagePercent`. `codex-extra` in the old literal set is dead — no fetcher has ever produced it. The suffix rule is gone.
- With today's producers this changes **no displayed number**. The old literal set already covered the only two paid buckets that carry a percentage (`extra-usage`, `on-demand`). `grok-extra-usage`, `devin-extra-balance` and `factory-extra-balance` were on the wrong side of the split, but all three emit `percentage: -1` and `aggregateModelPercentages` filters those, so totals were unaffected.

What the change buys is that billing/window semantics are grounded at the producer instead of in a display slug, and that #474 has a correct window signal to select on.

## Bucket-kind inventory (every producer, as of this branch)

| Producer | Bucket | window | billing | Evidence |
|---|---|---|---|---|
| ClaudeCodeQuotaFetcher | `five-hour-session` | session | subscription | `info.fiveHour` |
| | `seven-day-weekly` / `-sonnet` / `-opus` | weekly | subscription | `info.sevenDay*` |
| | `extra-usage` | monthly | **paidOverage** | `extraUsage.monthlyLimit` |
| CodexUsageMapper | `codex-session` | session | subscription | `rate_limit.primary_window`, `limit_window_seconds` ≤ 24h |
| | `codex-weekly` | weekly | subscription | `limit_window_seconds` ≥ 6d |
| | `codex-spark` | session | subscription | Spark window ≤ 6h |
| | `codex-spark-weekly` | weekly | subscription | Spark window ≥ 6d |
| | `codex-<metered feature slug>` | from `limit_window_seconds`, else nil | **nil** | `additional_rate_limits` carries no billing signal |
| CopilotQuotaFetcher | `copilot-chat` / `-completions` / `-premium` | monthly | subscription | `monthly_quotas`, `quota_reset_date(_utc)` |
| ClinePassQuotaFetcher | `clinepass-five-hour` / `-weekly` / `-monthly` | session / weekly / monthly | subscription | API `limit.type` |
| FactoryDroidQuotaMapper | `factory-{standard,core}-{five-hour,weekly,monthly}` | session / weekly / monthly | subscription | pool field the entry came from |
| | `factory-extra-balance` | nil | **paidOverage** | `extraUsageBalanceCents` (pct −1) |
| | `factory-billing-mode` | nil | nil | status row (pct −1) |
| CursorQuotaFetcher | `plan-usage` | nil | subscription | only a `billingCycleEnd` boundary, no period |
| | `on-demand` | nil | **paidOverage** | `individualUsage.onDemand` |
| | `cursor-usage` | nil | subscription | placeholder |
| GrokQuotaMapper | `grok-weekly` | weekly | subscription | `currentPeriod.type == USAGE_PERIOD_TYPE_WEEKLY` |
| | `grok-extra-usage` | nil | **paidOverage** | `config.onDemandCap` (pct −1) |
| DevinQuotaFetcher | `devin-daily` | daily | subscription | daily fields |
| | `devin-weekly` | weekly | subscription | weekly fields |
| | `devin-extra-balance` | nil | **paidOverage** | `overageBalanceMicros` (pct −1) |
| GLMQuotaFetcher (Z.ai) | `zai-session` / `-daily` / `-weekly` / `-monthly` | matching | subscription | `TOKENS_LIMIT` `unit` + `number` |
| | `zai-web-searches` | nil | subscription | `TIME_LIMIT` |
| AntigravityQuotaFetcher | `antigravity-<group>-session` / `-weekly` | session / weekly | subscription | quota-summary bucket descriptor, parsed once at the producer |
| | per-model (`gemini-3-pro-high`, `claude-…`) | nil | subscription | models endpoint states no window |
| AmpQuotaFetcher | `amp-free` (percent form) | daily | subscription | "resets daily" / next UTC midnight |
| | `amp-free` (dollar form) | nil | nil | replenishes hourly, not a window |
| | `amp-agent-usage` / `amp-orb-usage` | nil | subscription | matched from the `Subscription <plan>:` line |
| | `amp-individual-credits` / `amp-workspace-<id>` | nil | nil | prepaid balances (pct −1) |
| WarpQuotaFetcher | `warp-usage` | nil | subscription | only `nextRefreshTime`, no period |
| | `warp-bonus-<n>` | nil | nil | expiring grant |
| OpenRouterQuotaFetcher | `openrouter-credits` / `-key-limit` / balances | nil | nil | pay-as-you-go, no plan window |
| TraeQuotaFetcher | `premium-fast` / `premium-slow` / `advanced-model` / `auto-completion` / `trae-usage` | nil | nil | only a `resetTime`, no period |
| KiroQuotaFetcher | `<displayName>` / `Bonus <displayName>` / `kiro-standard` / `Error` | nil | nil | provider display names |

Nine producers state no window at all; they stay `nil` rather than being guessed.

## Testability

`QuotaUsageCalculator` is `nonisolated` and takes `TotalUsageMode` / `ModelAggregationMode` as arguments, so no test touches `MenuBarSettingsManager.shared` or `UserDefaults`. The old `withUsageModes` helper is gone.

## Verification

```
xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build   ** BUILD SUCCEEDED **
xcodebuild test -project Quotio.xcodeproj -scheme Quotio -destination 'platform=macOS'  ** TEST SUCCEEDED **  (83 tests)
```

`QuotioTests/QuotaBucketKindTests.swift` (12 tests) runs real payloads through `CodexUsageMapper.map`, `FactoryDroidQuotaMapper.map` and `GrokQuotaMapper.mapBilling`, including a Codex payload whose `additional_rate_limits` holds Spark plus a non-Spark limit slugged `codex-code-review-on-demand`.

Failing-without-the-fix check, run by temporarily editing the tree and reverting:

- Swapping `model.billing == .paidOverage` back for the suffix rule → `testSessionOnlyTotalKeepsUnclassifiedBuckets` and `testSessionOnlyTotalKeepsCodexAdditionalRateLimits` fail (the subscription bucket is dropped from the session total). Exactly the defect you described.
- Stripping the Codex window annotations → `testCodexDeclaresWindowsFromThePayloadNotTheName` fails.

## Merge note for #474

Both PRs are branched on current `master` and contain the byte-identical foundation commit `refactor(quota): carry explicit bucket kinds from quota fetchers` (verified: same tree SHA in both branches), so it merges as a no-op for whichever lands second. Trial-merged in throwaway worktrees in both orders; the only conflict is one hunk in `Quotio/QuotioApp.swift`:

```
<<<<<<<  (#474 side)
    displayPercent = MenuBarBucketResolver.percent(
        models: quotaData.models,
        selection: selectedItem.resolvedBucketSelection,
        aggregation: menuBarSettings.modelAggregationMode
    ) ?? menuBarSettings.totalUsagePercent(models: quotaData.models)
=======  (#485 side)
    displayPercent = menuBarSettings.totalUsagePercent(models: quotaData.models)
>>>>>>>
```

Resolution in either order: keep the #474 side — it already calls `totalUsagePercent(models: quotaData.models)` as its fallback. I verified that resolution builds and all tests pass. #470, #475 and #487 trial-merge cleanly with both branches.
