### PR TITLE
fix(quota): refresh imported Cursor and Trae quotas on global refresh

### DIFF
--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -198,7 +198,9 @@ final class QuotaViewModel {
     // MARK: - IDE Quota Persistence Keys
 
     private static let ideQuotasKey = "persisted.ideQuotas"
-    private static let ideProvidersToSave: Set<AIProvider> = [.cursor, .trae]
+    /// Providers whose quota is imported from a local IDE database and persisted
+    /// separately (Cursor, Trae). Also drives `refreshImportedIDEQuotas()`.
+    nonisolated static let ideProvidersToSave: Set<AIProvider> = [.cursor, .trae]
 
     /// Key for tracking when auth files last changed (for model cache invalidation)
     static let authFilesChangedKey = "quotio.authFiles.lastChanged"
@@ -750,6 +752,11 @@ final class QuotaViewModel {
         providerQuotas[.openRouter] = await openRouter
         providerQuotas[.amp] = await amp
         providerQuotas = providerQuotas.filter { !$0.value.isEmpty }
+
+        // Refresh (not re-import) Cursor/Trae accounts the user already scanned in,
+        // before the snapshot is persisted, so the menu bar refresh shows the same
+        // numbers as the Providers screen (#163).
+        await refreshImportedIDEQuotas()
 
         monitorAccounts = await coordinator.discoverAccounts(merging: providerQuotas)
         removeDisabledMonitorQuotas()
@@ -1594,6 +1601,10 @@ final class QuotaViewModel {
             async let clinePass: () = refreshClinePassQuotasInternal()
 
             _ = await (antigravity, openai, copilot, claudeCode, glm, warp, kiro, clinePass)
+
+            // Refresh (not re-import) Cursor/Trae accounts the user already scanned in,
+            // so the menu bar refresh shows the same numbers as the Providers screen (#163).
+            await refreshImportedIDEQuotas()
         }
 
         checkQuotaNotifications()
@@ -1636,6 +1647,10 @@ final class QuotaViewModel {
         async let clinePass: () = refreshClinePassQuotasInternal()
 
         _ = await (antigravity, codex, copilot, claudeCode, glm, warp, kiro, clinePass)
+
+        // Refresh (not re-import) Cursor/Trae accounts the user already scanned in,
+        // so the menu bar refresh shows the same numbers as the Providers screen (#163).
+        await refreshImportedIDEQuotas()
 
         checkQuotaNotifications()
         pruneMenuBarItems()
@@ -2012,6 +2027,70 @@ final class QuotaViewModel {
         
         for provider in autoDetectedProviders {
             await refreshQuotaForProvider(provider)
+        }
+    }
+    
+    /// Merge freshly read IDE quota data into the accounts that are already imported.
+    ///
+    /// Cursor and Trae accounts only exist once the user has explicitly run
+    /// "Scan for IDEs" (issue #29), and they can be deleted (issue #213). A global
+    /// refresh must therefore update the quota of the accounts that are currently
+    /// imported without importing any account key that is not already present —
+    /// otherwise a deleted account would resurrect on the next refresh.
+    ///
+    /// - Parameters:
+    ///   - fetched: everything the IDE fetcher could read from the local database.
+    ///   - existing: the account keys currently imported into `providerQuotas`.
+    /// - Returns: `existing`, with fresh data applied to the keys it already holds.
+    ///   Keys present only in `fetched` are dropped; keys the fetcher could not read
+    ///   this time keep their previous value instead of disappearing from the UI.
+    nonisolated static func mergeImportedIDEQuotas(
+        fetched: [String: ProviderQuotaData],
+        into existing: [String: ProviderQuotaData]
+    ) -> [String: ProviderQuotaData] {
+        guard !existing.isEmpty else { return existing }
+
+        var merged = existing
+        for (accountKey, quota) in fetched where existing[accountKey] != nil {
+            merged[accountKey] = quota
+        }
+        return merged
+    }
+
+    /// Refresh the quota of already-imported IDE-derived accounts (Cursor, Trae).
+    ///
+    /// This is the piece the global refresh actions were missing: `refreshAllQuotas`,
+    /// `refreshQuotasUnified` and `refreshQuotasDirectly` all skip Cursor/Trae, so the
+    /// menu bar refresh never updated them (issues #163, #257). Unlike the per-provider
+    /// re-import in `refreshQuota(for:)`, this only touches account keys that are
+    /// already imported, so it never re-imports from the IDE databases.
+    private func refreshImportedIDEQuotas() async {
+        var didRefresh = false
+
+        for provider in Self.ideProvidersToSave {
+            let existing = providerQuotas[provider] ?? [:]
+            // Nothing imported for this provider: respect the explicit-scan consent
+            // model (issue #29) and do not pull anything in.
+            guard !existing.isEmpty else { continue }
+            // A scoped refresh for this provider is already in flight; let it win.
+            guard !activeRefreshProviders.contains(provider) else { continue }
+
+            let fetched: [String: ProviderQuotaData]
+            switch provider {
+            case .cursor:
+                fetched = await cursorFetcher.fetchAsProviderQuota()
+            case .trae:
+                fetched = await traeFetcher.fetchAsProviderQuota()
+            default:
+                continue
+            }
+
+            providerQuotas[provider] = Self.mergeImportedIDEQuotas(fetched: fetched, into: existing)
+            didRefresh = true
+        }
+
+        if didRefresh {
+            savePersistedIDEQuotas()
         }
     }
     

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -753,9 +753,8 @@ final class QuotaViewModel {
         providerQuotas[.amp] = await amp
         providerQuotas = providerQuotas.filter { !$0.value.isEmpty }
 
-        // Refresh (not re-import) Cursor/Trae accounts the user already scanned in,
-        // before the snapshot is persisted, so the menu bar refresh shows the same
-        // numbers as the Providers screen (#163).
+        // Refresh (not re-import) already-imported Cursor/Trae accounts before the
+        // snapshot is persisted, so the menu bar matches the Providers screen (#163).
         await refreshImportedIDEQuotas()
 
         monitorAccounts = await coordinator.discoverAccounts(merging: providerQuotas)
@@ -1602,8 +1601,7 @@ final class QuotaViewModel {
 
             _ = await (antigravity, openai, copilot, claudeCode, glm, warp, kiro, clinePass)
 
-            // Refresh (not re-import) Cursor/Trae accounts the user already scanned in,
-            // so the menu bar refresh shows the same numbers as the Providers screen (#163).
+            // Refresh (not re-import) already-imported Cursor/Trae accounts (#163).
             await refreshImportedIDEQuotas()
         }
 
@@ -1648,8 +1646,7 @@ final class QuotaViewModel {
 
         _ = await (antigravity, codex, copilot, claudeCode, glm, warp, kiro, clinePass)
 
-        // Refresh (not re-import) Cursor/Trae accounts the user already scanned in,
-        // so the menu bar refresh shows the same numbers as the Providers screen (#163).
+        // Refresh (not re-import) already-imported Cursor/Trae accounts (#163).
         await refreshImportedIDEQuotas()
 
         checkQuotaNotifications()
@@ -2064,36 +2061,76 @@ final class QuotaViewModel {
     /// menu bar refresh never updated them (issues #163, #257). Unlike the per-provider
     /// re-import in `refreshQuota(for:)`, this only touches account keys that are
     /// already imported, so it never re-imports from the IDE databases.
-    private func refreshImportedIDEQuotas() async {
-        var didRefresh = false
-
-        for provider in Self.ideProvidersToSave {
-            let existing = providerQuotas[provider] ?? [:]
-            // Nothing imported for this provider: respect the explicit-scan consent
-            // model (issue #29) and do not pull anything in.
-            guard !existing.isEmpty else { continue }
-            // A scoped refresh for this provider is already in flight; let it win.
-            guard !activeRefreshProviders.contains(provider) else { continue }
-
-            let fetched: [String: ProviderQuotaData]
-            switch provider {
-            case .cursor:
-                fetched = await cursorFetcher.fetchAsProviderQuota()
-            case .trae:
-                fetched = await traeFetcher.fetchAsProviderQuota()
-            default:
-                continue
-            }
-
-            providerQuotas[provider] = Self.mergeImportedIDEQuotas(fetched: fetched, into: existing)
-            didRefresh = true
-        }
-
-        if didRefresh {
-            savePersistedIDEQuotas()
+    ///
+    /// Internal rather than private so the reentrancy regression tests can drive this
+    /// path directly instead of going through a global refresh that hits the network.
+    func refreshImportedIDEQuotas() async {
+        // `Set` iteration order is unspecified; sort so the sequence of suspension
+        // points is deterministic (and therefore testable).
+        for provider in Self.ideProvidersToSave.sorted(by: { $0.rawValue < $1.rawValue }) {
+            await refreshImportedIDEQuotas(for: provider)
         }
     }
-    
+
+    /// Refresh a single IDE-derived provider while holding its refresh-coordination slot.
+    ///
+    /// `QuotaViewModel` is `@MainActor`, but a main actor is *reentrant*: the `await` on
+    /// the IDE fetcher below is a suspension point at which any other main-actor work can
+    /// run — a scoped refresh, an account deletion (issue #213), a re-scan. The previous
+    /// version of this method sampled `providerQuotas` and `activeRefreshProviders`
+    /// before that await and then wrote the resulting merge unconditionally, so anything
+    /// that changed while the fetch was suspended got clobbered by the stale snapshot.
+    ///
+    /// Two things close that window:
+    /// 1. The provider's slot in `activeRefreshProviders` is held for the *whole*
+    ///    fetch/write, so a scoped refresh cannot start midway through it (and if one is
+    ///    already running, this refresh yields to it instead of racing).
+    /// 2. `providerQuotas` is re-read *after* the await and the merge is applied to the
+    ///    keys that still exist at write time, so an account removed during the fetch
+    ///    stays removed instead of being resurrected from the pre-await snapshot.
+    private func refreshImportedIDEQuotas(for provider: AIProvider) async {
+        // Nothing imported for this provider: respect the explicit-scan consent model
+        // (issue #29) and do not pull anything in. No await between this read and the
+        // slot acquisition below, so the check cannot go stale.
+        guard providerQuotas[provider]?.isEmpty == false else { return }
+        // Claims the same slot `refreshQuota(for:)` uses, for the full fetch/write.
+        // Fails if a scoped refresh for this provider is already in flight — that one wins.
+        guard beginBatchRefresh(providers: [provider]) else { return }
+        defer { endBatchRefresh(providers: [provider]) }
+
+        let fetched = await fetchImportedIDEQuotas(for: provider)
+
+        // Re-read after the suspension point: the account may have been deleted, or the
+        // whole provider removed, while the fetch was in flight.
+        guard let current = providerQuotas[provider], !current.isEmpty else { return }
+        providerQuotas[provider] = Self.mergeImportedIDEQuotas(fetched: fetched, into: current)
+        // Persisted synchronously with the write so the saved snapshot cannot capture a
+        // half-applied state from a concurrent mutation.
+        savePersistedIDEQuotas()
+    }
+
+    #if DEBUG
+    /// Test seam: replaces the IDE database read so a test can suspend *inside* the fetch
+    /// and drive main-actor reentrancy deterministically. Never set outside tests.
+    @ObservationIgnored var ideQuotaFetchHookForTesting: (@MainActor (AIProvider) async -> [String: ProviderQuotaData])?
+    #endif
+
+    private func fetchImportedIDEQuotas(for provider: AIProvider) async -> [String: ProviderQuotaData] {
+        #if DEBUG
+        if let hook = ideQuotaFetchHookForTesting {
+            return await hook(provider)
+        }
+        #endif
+        switch provider {
+        case .cursor:
+            return await cursorFetcher.fetchAsProviderQuota()
+        case .trae:
+            return await traeFetcher.fetchAsProviderQuota()
+        default:
+            return [:]
+        }
+    }
+
     func startOAuth(for provider: AIProvider, authMethod: AuthCommand? = nil, launchMode: OAuthLaunchMode = .manual) async {
         if modeManager.isMonitorMode {
             await startMonitorOAuth(for: provider)

--- a/QuotioTests/IDEQuotaRefreshTests.swift
+++ b/QuotioTests/IDEQuotaRefreshTests.swift
@@ -77,3 +77,222 @@ final class IDEQuotaRefreshTests: XCTestCase {
         }
     }
 }
+
+/// A gate a test can suspend the injected IDE fetch on, so the interleaved main-actor
+/// work (a deletion, a competing refresh) happens exactly while the fetch is in flight.
+@MainActor
+private final class IDEFetchGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isOpen = false
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { self.continuation = $0 }
+    }
+
+    func open() {
+        isOpen = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+/// Exercises the *reentrant* behaviour of `refreshImportedIDEQuotas()`.
+///
+/// `QuotaViewModel` is `@MainActor`, which serialises its state but does **not** make a
+/// method atomic: every `await` is a suspension point at which other main-actor work
+/// runs. These tests suspend inside the IDE fetch, mutate the view model from the test
+/// body (i.e. exactly as a user action would), resume, and assert the refresh honours
+/// the state as it is at write time rather than the snapshot it took before the await.
+final class IDEQuotaRefreshReentrancyTests: XCTestCase {
+    private static let persistedIDEQuotasKey = "persisted.ideQuotas"
+
+    private func quota(_ percentage: Double, lastUpdated: Date) -> ProviderQuotaData {
+        ProviderQuotaData(
+            models: [ModelQuota(name: "cursor-fast", percentage: percentage, resetTime: "")],
+            lastUpdated: lastUpdated
+        )
+    }
+
+    /// The refresh persists to `UserDefaults.standard`; keep the developer's real data.
+    private func withPersistedIDEQuotasRestored(_ body: () async -> Void) async {
+        let saved = UserDefaults.standard.data(forKey: Self.persistedIDEQuotasKey)
+        await body()
+        if let saved {
+            UserDefaults.standard.set(saved, forKey: Self.persistedIDEQuotasKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.persistedIDEQuotasKey)
+        }
+    }
+
+    private func persistedIDEQuotas() -> [String: [String: ProviderQuotaData]] {
+        guard let data = UserDefaults.standard.data(forKey: Self.persistedIDEQuotasKey),
+              let decoded = try? JSONDecoder().decode(
+                  [String: [String: ProviderQuotaData]].self, from: data
+              ) else { return [:] }
+        return decoded
+    }
+
+    /// The regression the review called out: an account deleted (issue #213 / PR #472)
+    /// while the IDE fetch is suspended must not be restored by the write that follows.
+    /// A pre-await snapshot of `providerQuotas` would resurrect it — both in memory and
+    /// in the persisted snapshot the next launch reads.
+    @MainActor
+    func testGlobalRefreshDoesNotResurrectAccountDeletedWhileFetchIsSuspended() async {
+        await withPersistedIDEQuotasRestored {
+            let viewModel = QuotaViewModel()
+            let kept = "kept@example.com"
+            let deleted = "deleted@example.com"
+            let stale = quota(10, lastUpdated: Date(timeIntervalSince1970: 1_000))
+            let fresh = quota(75, lastUpdated: Date(timeIntervalSince1970: 2_000))
+
+            viewModel.providerQuotas = [.cursor: [kept: stale, deleted: stale]]
+
+            let gate = IDEFetchGate()
+            let suspendedInFetch = expectation(description: "IDE fetch suspended")
+            viewModel.ideQuotaFetchHookForTesting = { provider in
+                guard provider == .cursor else { return [:] }
+                suspendedInFetch.fulfill()
+                await gate.wait()
+                // The IDE database still knows about both accounts.
+                return [kept: fresh, deleted: fresh]
+            }
+
+            let refresh = Task { await viewModel.refreshImportedIDEQuotas() }
+            await fulfillment(of: [suspendedInFetch], timeout: 5)
+
+            // Reentrant main-actor work: the user deletes the imported account while the
+            // fetch is still awaiting.
+            viewModel.providerQuotas[.cursor]?.removeValue(forKey: deleted)
+
+            gate.open()
+            await refresh.value
+
+            XCTAssertNil(
+                viewModel.providerQuotas[.cursor]?[deleted],
+                "An account deleted during the fetch must not be restored from the pre-await snapshot"
+            )
+            XCTAssertNil(
+                persistedIDEQuotas()[AIProvider.cursor.rawValue]?[deleted],
+                "The resurrected account must not reach the persisted snapshot either"
+            )
+            XCTAssertEqual(
+                viewModel.providerQuotas[.cursor]?[kept]?.models.first?.percentage,
+                75,
+                "The surviving account still receives the fresh quota (issue #163)"
+            )
+        }
+    }
+
+    /// The whole provider disappearing mid-fetch (the last imported account deleted) must
+    /// not re-create the provider entry from the snapshot taken before the await.
+    @MainActor
+    func testGlobalRefreshDoesNotRestoreProviderRemovedWhileFetchIsSuspended() async {
+        await withPersistedIDEQuotasRestored {
+            let viewModel = QuotaViewModel()
+            let account = "only@example.com"
+            viewModel.providerQuotas = [
+                .cursor: [account: quota(10, lastUpdated: Date(timeIntervalSince1970: 1_000))]
+            ]
+
+            let gate = IDEFetchGate()
+            let suspendedInFetch = expectation(description: "IDE fetch suspended")
+            viewModel.ideQuotaFetchHookForTesting = { _ in
+                suspendedInFetch.fulfill()
+                await gate.wait()
+                return [account: self.quota(90, lastUpdated: Date(timeIntervalSince1970: 2_000))]
+            }
+
+            let refresh = Task { await viewModel.refreshImportedIDEQuotas() }
+            await fulfillment(of: [suspendedInFetch], timeout: 5)
+
+            viewModel.providerQuotas.removeValue(forKey: .cursor)
+
+            gate.open()
+            await refresh.value
+
+            XCTAssertNil(
+                viewModel.providerQuotas[.cursor],
+                "Removing the provider during the fetch must survive the refresh write"
+            )
+        }
+    }
+
+    /// The IDE refresh holds the provider's refresh-coordination slot for the *whole*
+    /// fetch/write, so a scoped refresh cannot start midway through it and be clobbered.
+    /// `isRefreshBlocked(for:)` reads the same set `beginScopedRefresh` inserts into, so
+    /// this is also what disables the per-account refresh button in `QuotaScreen` and
+    /// `StatusBarMenuBuilder` while the fetch is in flight.
+    @MainActor
+    func testScopedRefreshIsBlockedWhileImportedIDEFetchIsSuspended() async {
+        await withPersistedIDEQuotasRestored {
+            let viewModel = QuotaViewModel()
+            let account = "user@example.com"
+            let stale = quota(10, lastUpdated: Date(timeIntervalSince1970: 1_000))
+            let fresh = quota(60, lastUpdated: Date(timeIntervalSince1970: 2_000))
+            viewModel.providerQuotas = [.cursor: [account: stale]]
+
+            let accountID = QuotaAccountID(provider: .cursor, accountKey: account)
+            XCTAssertFalse(viewModel.isRefreshBlocked(for: accountID))
+
+            let gate = IDEFetchGate()
+            let suspendedInFetch = expectation(description: "IDE fetch suspended")
+            var fetchCount = 0
+            viewModel.ideQuotaFetchHookForTesting = { _ in
+                fetchCount += 1
+                suspendedInFetch.fulfill()
+                await gate.wait()
+                return [account: fresh]
+            }
+
+            let refresh = Task { await viewModel.refreshImportedIDEQuotas() }
+            await fulfillment(of: [suspendedInFetch], timeout: 5)
+
+            XCTAssertTrue(
+                viewModel.isRefreshBlocked(for: accountID),
+                "The coordination slot must be held across the fetch, not only before it"
+            )
+            XCTAssertTrue(viewModel.isRefreshing(provider: .cursor))
+
+            // A scoped refresh requested now is rejected by the slot instead of racing the
+            // in-flight write: it performs no fetch and leaves the quota untouched.
+            await viewModel.refreshQuota(for: .cursor)
+            XCTAssertEqual(
+                viewModel.providerQuotas[.cursor]?[account]?.lastUpdated,
+                stale.lastUpdated,
+                "A scoped refresh must not run while the global IDE refresh holds the slot"
+            )
+
+            // A second global refresh is rejected by the same slot and issues no fetch.
+            await viewModel.refreshImportedIDEQuotas()
+            XCTAssertEqual(fetchCount, 1, "The slot must serialise overlapping IDE refreshes")
+
+            gate.open()
+            await refresh.value
+
+            XCTAssertFalse(viewModel.isRefreshBlocked(for: accountID), "The slot must be released")
+            XCTAssertEqual(viewModel.providerQuotas[.cursor]?[account]?.models.first?.percentage, 60)
+        }
+    }
+
+    /// With nothing imported the refresh must not acquire the slot, fetch, or import —
+    /// Cursor/Trae stay explicit-scan only (issue #29).
+    @MainActor
+    func testGlobalRefreshDoesNotFetchWhenNothingIsImported() async {
+        await withPersistedIDEQuotasRestored {
+            let viewModel = QuotaViewModel()
+            viewModel.providerQuotas = [:]
+
+            var fetchCount = 0
+            viewModel.ideQuotaFetchHookForTesting = { _ in
+                fetchCount += 1
+                return ["user@example.com": self.quota(50, lastUpdated: Date())]
+            }
+
+            await viewModel.refreshImportedIDEQuotas()
+
+            XCTAssertEqual(fetchCount, 0, "A refresh must not read the IDE databases without an explicit scan")
+            XCTAssertTrue(viewModel.providerQuotas.isEmpty)
+        }
+    }
+}

--- a/QuotioTests/IDEQuotaRefreshTests.swift
+++ b/QuotioTests/IDEQuotaRefreshTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import Quotio
+
+/// Covers the quota refresh applied to IDE-derived providers (Cursor, Trae) by the
+/// global refresh actions — the path the menu bar "Refresh" uses (issues #163, #257).
+final class IDEQuotaRefreshTests: XCTestCase {
+    private func quota(_ percentage: Double, lastUpdated: Date) -> ProviderQuotaData {
+        ProviderQuotaData(
+            models: [ModelQuota(name: "cursor-fast", percentage: percentage, resetTime: "")],
+            lastUpdated: lastUpdated
+        )
+    }
+
+    /// The global refresh must actually update an imported Cursor account, instead of
+    /// leaving the stale snapshot the menu bar was showing (issue #163).
+    func testMergeImportedIDEQuotasUpdatesImportedAccount() {
+        let stale = quota(10, lastUpdated: Date(timeIntervalSince1970: 1_000))
+        let fresh = quota(75, lastUpdated: Date(timeIntervalSince1970: 2_000))
+
+        let merged = QuotaViewModel.mergeImportedIDEQuotas(
+            fetched: ["user@example.com": fresh],
+            into: ["user@example.com": stale]
+        )
+
+        XCTAssertEqual(merged.count, 1)
+        XCTAssertEqual(merged["user@example.com"]?.models.first?.percentage, 75)
+        XCTAssertEqual(merged["user@example.com"]?.lastUpdated, Date(timeIntervalSince1970: 2_000))
+    }
+
+    /// Guards the invariant introduced by the "delete imported Cursor/Trae account"
+    /// fix (issue #213): a global refresh reads the IDE database, but it must never
+    /// re-import an account key the user removed, or the account resurrects.
+    func testMergeImportedIDEQuotasDoesNotResurrectDeletedAccount() {
+        let kept = quota(10, lastUpdated: Date(timeIntervalSince1970: 1_000))
+        let fresh = quota(80, lastUpdated: Date(timeIntervalSince1970: 2_000))
+        let resurrected = quota(42, lastUpdated: Date(timeIntervalSince1970: 2_000))
+
+        let merged = QuotaViewModel.mergeImportedIDEQuotas(
+            fetched: ["kept@example.com": fresh, "deleted@example.com": resurrected],
+            into: ["kept@example.com": kept]
+        )
+
+        XCTAssertNil(merged["deleted@example.com"], "Deleted IDE account must not be re-imported by a refresh")
+        XCTAssertEqual(merged["kept@example.com"]?.models.first?.percentage, 80)
+    }
+
+    /// With nothing imported, a refresh must not pull accounts in: Cursor/Trae are
+    /// import-on-explicit-scan only (issue #29).
+    func testMergeImportedIDEQuotasImportsNothingWhenProviderNotScanned() {
+        let merged = QuotaViewModel.mergeImportedIDEQuotas(
+            fetched: ["user@example.com": quota(50, lastUpdated: Date())],
+            into: [:]
+        )
+
+        XCTAssertTrue(merged.isEmpty, "A refresh must not import IDE accounts without an explicit scan")
+    }
+
+    /// A transiently unreadable IDE database must not wipe the imported account from
+    /// the menu bar; the previous value stays until a scan removes it.
+    func testMergeImportedIDEQuotasKeepsAccountMissingFromFetch() {
+        let stale = quota(10, lastUpdated: Date(timeIntervalSince1970: 1_000))
+
+        let merged = QuotaViewModel.mergeImportedIDEQuotas(fetched: [:], into: ["user@example.com": stale])
+
+        XCTAssertEqual(merged.count, 1)
+        XCTAssertEqual(merged["user@example.com"]?.models.first?.percentage, 10)
+    }
+
+    /// The refresh path covers exactly the IDE-derived providers, which are also the
+    /// ones excluded from the generic auto-detected re-import.
+    func testIDEQuotaRefreshCoversBrowserAuthProviders() {
+        XCTAssertEqual(QuotaViewModel.ideProvidersToSave, [.cursor, .trae])
+
+        for provider in QuotaViewModel.ideProvidersToSave {
+            XCTAssertTrue(provider.usesBrowserAuth, "\(provider.rawValue) is an IDE-derived provider")
+            XCTAssertFalse(provider.supportsManualAuth, "\(provider.rawValue) cannot be added manually")
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Cursor quota shown in the menu bar never updates. Refreshing from the menu bar does nothing; the user has to open the main window and refresh from the **Providers** screen to get fresh numbers (#163).

## Root cause — the asymmetry

Every global refresh action funnels into one of three methods in `QuotaViewModel`, and **none of them touch Cursor or Trae**:

| Path | Cursor/Trae refreshed? |
|---|---|
| `refreshAllQuotas()` — Full Mode with proxy running | no (`// Note: Cursor and Trae removed from auto-refresh`) |
| `refreshQuotasUnified()` — Quota-Only Mode | no (`// Note: Cursor and Trae removed - require explicit scan`) |
| `refreshQuotasDirectly()` — Monitor Mode | no (its provider set omits them) |

The menu bar refresh button (`MenuActionsView` → `manualRefresh()`) and the legacy `MenuActionHandler.refresh()` (→ `refreshQuotasUnified()`) only ever reach those three, so the menu bar can never update a Cursor account.

The main window's **Providers** toolbar refresh does one extra thing:

```swift
if !modeManager.isMonitorMode {
    await viewModel.refreshAutoDetectedProviders()
}
```

`refreshAutoDetectedProviders()` iterates `AIProvider.allCases.filter { !$0.supportsManualAuth }`, which includes `.cursor` and `.trae`, and calls the scoped `refreshQuota(for:)` — the only global entry point that hits `refreshCursorQuotasInternal()`. That is exactly the "I have to open the UI and refresh from there" workaround the reporter describes.

## Fix

New `refreshImportedIDEQuotas()`, called from all three global refresh methods, refreshes the quota of Cursor/Trae accounts that are **already imported**:

- For each IDE-derived provider that currently has entries in `providerQuotas`, read the local IDE database and apply the fresh values.
- `mergeImportedIDEQuotas(fetched:into:)` merges **only into account keys that are already present**. Keys that exist only in the freshly-read data are dropped; keys the fetcher could not read this time keep their previous value rather than vanishing from the menu bar.
- If a provider has nothing imported, the fetcher is not even called, so an unscanned Cursor install is never pulled in.
- Skips a provider whose scoped refresh is already in flight, then persists via the existing `savePersistedIDEQuotas()`.

In Monitor Mode the call is placed before `discoverAccounts(merging:)` / `coordinator.finish(quotas:)`, so the refreshed values land in the Monitor snapshot too. All three methods already end with `notifyQuotaDataChanged()`, which is what drives the menu bar redraw, so the menu bar picks the new numbers up in the same pass.

## Composition with #472

#472 removes `.cursor`/`.trae` from `refreshAutoDetectedProviders()` because that path **re-imports** them from the local IDE databases wholesale, which both bypasses the explicit "Scan for IDEs" consent model (#29) and resurrects accounts the user deleted (#213). This PR is the complement and does not undo that:

- It never calls `refreshCursorQuotasInternal()` / `refreshTraeQuotasInternal()` and never goes through `refreshAutoDetectedProviders()`. It uses the same "read, then keep only the already-known account keys" shape as the scoped per-account path (`refreshQuota(for account:)`), which #472 explicitly preserves.
- Import remains gated on an explicit scan: with `providerQuotas[provider]` empty, `refreshImportedIDEQuotas()` returns without fetching.
- Deleted accounts stay deleted: after #472's `deleteAutoDetectedAccount` / `deleteMonitorAccount` clear the entry, the key is no longer in `providerQuotas`, so the merge drops it out of the freshly-read data. `testMergeImportedIDEQuotasDoesNotResurrectDeletedAccount` asserts this directly, so #472's guarantee is protected by a test.

The two PRs are independent (no shared hunks) and together give: no re-import on a generic refresh, but a working quota refresh for whatever is imported.

## Relation to #257

#257 ("Refresh not working from menu bar", Quota-Only Mode) reports the same symptom from the same code path — the menu bar refresh reaching `refreshQuotasUnified()`, which skips Cursor/Trae. It is very likely the same root cause and should be fixed by this change, but since #257 does not name a provider I am only claiming #163 here.

## Scope

Touches only `Quotio/ViewModels/QuotaViewModel.swift` — no overlap with the menu bar rewrite in #449 (`StatusBarMenuBuilder.swift`, `QuotaScreen.swift`, `Localizable.xcstrings`).

## Tests

New `QuotioTests/IDEQuotaRefreshTests.swift`:

- `testMergeImportedIDEQuotasUpdatesImportedAccount` — the stale Cursor snapshot the menu bar was showing is actually replaced.
- `testMergeImportedIDEQuotasDoesNotResurrectDeletedAccount` — an account key present in the IDE database but not imported is **not** added back (#213 / #472 guarantee).
- `testMergeImportedIDEQuotasImportsNothingWhenProviderNotScanned` — nothing is imported without an explicit scan (#29).
- `testMergeImportedIDEQuotasKeepsAccountMissingFromFetch` — a transiently unreadable IDE database does not wipe the account from the menu bar.
- `testIDEQuotaRefreshCoversBrowserAuthProviders` — the refresh set is exactly the IDE-derived (`usesBrowserAuth`, non-manual-auth) providers.

```
xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build   # ** BUILD SUCCEEDED **
xcodebuild test -project Quotio.xcodeproj -scheme Quotio -configuration Debug \
  -destination 'platform=macOS'                                                  # ** TEST SUCCEEDED **
```

Fixes #163
