### PR TITLE
feat(refresh): add opt-in adaptive quota refresh cadence

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -18821,6 +18821,64 @@
         }
       }
     },
+    "settings.refresh.adaptive" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adaptive refresh"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualisation adaptative"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Làm mới thích ứng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自适应刷新"
+          }
+        }
+      }
+    },
+    "settings.refresh.adaptive.help" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keeps the interval above while usage is changing, then doubles it while you are idle, up to 30 minutes. Never refreshes more often than the interval above."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conserve l’intervalle ci-dessus tant que la consommation évolue, puis le double pendant l’inactivité, jusqu’à 30 minutes. N’actualise jamais plus souvent que l’intervalle ci-dessus."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giữ nguyên khoảng thời gian ở trên khi mức sử dụng thay đổi, sau đó tăng gấp đôi khi bạn không hoạt động, tối đa 30 phút. Không bao giờ làm mới thường xuyên hơn khoảng thời gian ở trên."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用量变化时保持上面的刷新间隔；闲置时按倍数退避，最长 30 分钟。刷新频率不会高于上面设置的间隔。"
+          }
+        }
+      }
+    },
     "settings.refresh.cadence" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Models/MenuBarSettings.swift
+++ b/Quotio/Models/MenuBarSettings.swift
@@ -380,7 +380,8 @@ final class RefreshSettingsManager {
     
     private let defaults = UserDefaults.standard
     private let refreshCadenceKey = "refreshCadence"
-    
+    private let adaptiveRefreshKey = "adaptiveRefreshEnabled"
+
     /// Current refresh cadence
     var refreshCadence: RefreshCadence {
         didSet {
@@ -388,13 +389,32 @@ final class RefreshSettingsManager {
             onRefreshCadenceChanged?(refreshCadence)
         }
     }
-    
+
+    /// Opt-in adaptive cadence: keep `refreshCadence` while usage is moving and
+    /// back off progressively while it is idle (issue #172). Off by default, so
+    /// the cadence above behaves exactly as before unless enabled.
+    var adaptiveRefreshEnabled: Bool {
+        didSet {
+            guard adaptiveRefreshEnabled != oldValue else { return }
+            defaults.set(adaptiveRefreshEnabled, forKey: adaptiveRefreshKey)
+            onRefreshCadenceChanged?(refreshCadence)
+        }
+    }
+
+    /// Backoff bounds for adaptive refresh, derived from the chosen cadence.
+    /// `nil` when there is no automatic refresh to adapt (manual cadence).
+    var adaptiveBounds: AdaptiveRefreshBounds? {
+        guard let seconds = refreshCadence.intervalSeconds else { return nil }
+        return AdaptiveRefreshBounds(cadenceInterval: seconds)
+    }
+
     /// Callback when refresh cadence changes (for ViewModel to restart timer)
     var onRefreshCadenceChanged: ((RefreshCadence) -> Void)?
     
     private init() {
         let saved = defaults.string(forKey: refreshCadenceKey) ?? RefreshCadence.tenMinutes.rawValue
         self.refreshCadence = RefreshCadence(rawValue: saved) ?? .tenMinutes
+        self.adaptiveRefreshEnabled = defaults.bool(forKey: adaptiveRefreshKey)
     }
 }
 

--- a/Quotio/Services/AdaptiveRefreshPlanner.swift
+++ b/Quotio/Services/AdaptiveRefreshPlanner.swift
@@ -1,0 +1,219 @@
+//
+//  AdaptiveRefreshPlanner.swift
+//  Quotio - Adaptive Quota Refresh Cadence
+//
+//  A fixed refresh cadence has to trade freshness against API pressure: a
+//  10 minute cadence can miss a quota going 0% -> 100% while the user is
+//  actively coding, while a 1 minute cadence keeps hammering provider APIs
+//  overnight when nothing is happening (issue #172).
+//
+//  Adaptive refresh keeps the user's chosen cadence as the *fast* interval and
+//  only backs off when no usage activity is observed, doubling the interval up
+//  to a documented ceiling and snapping back to the fast cadence the moment
+//  usage moves again.
+//
+//  Everything in this file is pure and timer-free so the cadence decision can
+//  be unit tested without waiting on wall-clock time.
+//
+
+import Foundation
+
+// MARK: - Bounds
+
+/// Tunables for the adaptive backoff curve.
+nonisolated struct AdaptiveRefreshBounds: Sendable, Equatable {
+    /// Interval used while the user is active. This is the cadence picked in
+    /// Settings, so adaptive mode never refreshes *more* often than the fixed
+    /// mode would - it can only slow down.
+    var fastInterval: TimeInterval
+
+    /// How long the fast interval is held after the last observed activity
+    /// before backoff starts.
+    var idleGrace: TimeInterval
+
+    /// Growth factor applied per idle refresh.
+    var multiplier: Double
+
+    /// Upper bound for the backed-off interval.
+    var maxInterval: TimeInterval
+
+    /// Ceiling for the whole backoff schedule, in seconds.
+    static let defaultMaxInterval: TimeInterval = 1800  // 30 minutes
+
+    /// Doubling backoff.
+    static let defaultMultiplier: Double = 2
+
+    init(
+        fastInterval: TimeInterval,
+        idleGrace: TimeInterval,
+        multiplier: Double = AdaptiveRefreshBounds.defaultMultiplier,
+        maxInterval: TimeInterval = AdaptiveRefreshBounds.defaultMaxInterval
+    ) {
+        self.fastInterval = fastInterval
+        self.idleGrace = idleGrace
+        self.multiplier = multiplier
+        self.maxInterval = maxInterval
+    }
+
+    /// Bounds derived from the cadence the user picked in Settings.
+    ///
+    /// The fast interval is the chosen cadence, the grace window is two of
+    /// those intervals (so a single quiet poll does not immediately slow things
+    /// down), and the ceiling is 30 minutes - never shorter than the chosen
+    /// cadence, so picking the 15 minute cadence still yields 15 -> 30 minutes.
+    init(cadenceInterval: TimeInterval) {
+        self.init(
+            fastInterval: cadenceInterval,
+            idleGrace: cadenceInterval * 2,
+            multiplier: AdaptiveRefreshBounds.defaultMultiplier,
+            maxInterval: max(cadenceInterval, AdaptiveRefreshBounds.defaultMaxInterval)
+        )
+    }
+
+    /// Effective ceiling, clamped so it can never fall below the fast interval.
+    var ceiling: TimeInterval {
+        max(fastInterval, maxInterval)
+    }
+}
+
+// MARK: - Interval Decision
+
+/// Pure cadence decision for adaptive refresh.
+nonisolated enum AdaptiveRefreshPlanner {
+
+    /// Interval to wait before the next automatic refresh.
+    ///
+    /// - Parameters:
+    ///   - current: Interval used for the refresh that just completed.
+    ///   - timeSinceLastActivity: Seconds since usage was last observed to move.
+    ///   - bounds: Backoff tunables derived from the user's cadence.
+    /// - Returns: The fast interval while the user is (recently) active,
+    ///   otherwise the current interval grown by `multiplier` and clamped to
+    ///   `[fastInterval, ceiling]`.
+    static func nextInterval(
+        current: TimeInterval,
+        timeSinceLastActivity: TimeInterval,
+        bounds: AdaptiveRefreshBounds
+    ) -> TimeInterval {
+        let fast = max(0, bounds.fastInterval)
+        let ceiling = max(fast, bounds.maxInterval)
+
+        // Active (or only briefly quiet): stay at the user's cadence.
+        guard timeSinceLastActivity >= bounds.idleGrace else { return fast }
+
+        let grown = max(current, fast) * max(1, bounds.multiplier)
+        return min(ceiling, max(fast, grown))
+    }
+}
+
+// MARK: - Activity Signal
+
+/// Snapshot of the usage numbers Quotio already fetches for every account.
+///
+/// Comparing two consecutive snapshots is the activity signal for adaptive
+/// refresh: if any account's consumption moved between polls, the user is
+/// working. Timestamps are deliberately excluded so an unchanged quota that was
+/// merely re-fetched does not look like activity.
+nonisolated struct QuotaUsageSignature: Sendable, Equatable {
+    /// `provider|account|model` -> consumption value.
+    let entries: [String: Double]
+
+    static let empty = QuotaUsageSignature(entries: [:])
+
+    init(entries: [String: Double]) {
+        self.entries = entries
+    }
+
+    /// Build a signature from the view model's quota map.
+    init(quotas: [AIProvider: [String: ProviderQuotaData]]) {
+        var entries: [String: Double] = [:]
+        for (provider, accounts) in quotas {
+            for (accountKey, data) in accounts {
+                for model in data.models {
+                    let key = "\(provider.rawValue)|\(accountKey)|\(model.name)"
+                    // `used` is an absolute counter where providers expose it;
+                    // otherwise fall back to the consumed percentage.
+                    entries[key] = model.used.map(Double.init) ?? model.usedPercentage
+                }
+            }
+        }
+        self.entries = entries
+    }
+
+    var isEmpty: Bool { entries.isEmpty }
+}
+
+// MARK: - Tracker
+
+/// Timer-free state machine that turns a stream of quota snapshots into the
+/// interval the refresh loop should sleep for.
+///
+/// The owning view model drives it: it feeds every completed refresh into
+/// `observe(...)` and asks for `interval` before the next sleep.
+nonisolated struct AdaptiveRefreshTracker: Sendable {
+
+    /// Interval to use for the next automatic refresh.
+    private(set) var interval: TimeInterval
+
+    /// When usage was last observed to change.
+    private(set) var lastActivityAt: Date
+
+    /// Last observed usage snapshot, `nil` until the first observation.
+    private var signature: QuotaUsageSignature?
+
+    init(bounds: AdaptiveRefreshBounds, now: Date = Date()) {
+        self.interval = max(0, bounds.fastInterval)
+        self.lastActivityAt = now
+        self.signature = nil
+    }
+
+    /// Snap back to the fast cadence, e.g. after the cadence setting changes or
+    /// the refresh loop is restarted.
+    mutating func reset(bounds: AdaptiveRefreshBounds, now: Date = Date()) {
+        interval = max(0, bounds.fastInterval)
+        lastActivityAt = now
+        signature = nil
+    }
+
+    /// Feed a completed refresh into the tracker.
+    ///
+    /// - Returns: `true` when usage moved since the previous snapshot.
+    @discardableResult
+    mutating func observe(
+        signature newSignature: QuotaUsageSignature,
+        at now: Date,
+        bounds: AdaptiveRefreshBounds
+    ) -> Bool {
+        defer { signature = newSignature }
+
+        // First observation only seeds the baseline; there is nothing to
+        // compare against yet, so stay at the fast cadence.
+        guard let previous = signature else {
+            lastActivityAt = now
+            interval = max(0, bounds.fastInterval)
+            return true
+        }
+
+        let didChange = previous != newSignature
+        if didChange {
+            lastActivityAt = now
+        }
+
+        interval = AdaptiveRefreshPlanner.nextInterval(
+            current: interval,
+            timeSinceLastActivity: now.timeIntervalSince(lastActivityAt),
+            bounds: bounds
+        )
+        return didChange
+    }
+
+    /// Convenience overload for the view model's quota map.
+    @discardableResult
+    mutating func observe(
+        quotas: [AIProvider: [String: ProviderQuotaData]],
+        at now: Date = Date(),
+        bounds: AdaptiveRefreshBounds
+    ) -> Bool {
+        observe(signature: QuotaUsageSignature(quotas: quotas), at: now, bounds: bounds)
+    }
+}

--- a/Quotio/Services/AdaptiveRefreshPlanner.swift
+++ b/Quotio/Services/AdaptiveRefreshPlanner.swift
@@ -106,6 +106,35 @@ nonisolated enum AdaptiveRefreshPlanner {
     }
 }
 
+// MARK: - Refresh Outcome
+
+/// What one automatic quota refresh actually proved about user activity.
+///
+/// This is a *typed* result rather than something inferred from the quota
+/// values, because the three states below are indistinguishable by value: a
+/// batch refresh that returned early (another refresh already owns those
+/// providers), a provider round-trip that failed (the coordinator keeps the
+/// previous snapshot), and a mode with no local quota source all leave
+/// `providerQuotas` looking exactly like "usage did not change". Treating any
+/// of them as idleness is what makes the cadence back off - and stay backed off
+/// at 30 minutes - precisely when the app needs to retry (issue #172).
+nonisolated enum QuotaRefreshOutcome: Sendable, Equatable {
+    /// A refresh ran to completion and produced a usable quota snapshot.
+    /// This is the only outcome that is evidence about user activity.
+    case sample
+
+    /// No refresh ran: it was coalesced against an in-flight refresh, it was
+    /// not due yet, or the active mode has no local quota source. Says nothing
+    /// either way, so the cadence and the comparison baseline are left alone.
+    case skipped
+
+    /// A refresh ran but produced no usable data (transport/auth failure, or a
+    /// provider-level issue reported by the Monitor coordinator). Not evidence
+    /// of idleness: the cadence recovers to the user's interval so the app
+    /// retries promptly instead of sitting on a backed-off delay.
+    case failed
+}
+
 // MARK: - Activity Signal
 
 /// Snapshot of the usage numbers Quotio already fetches for every account.
@@ -131,13 +160,41 @@ nonisolated struct QuotaUsageSignature: Sendable, Equatable {
             for (accountKey, data) in accounts {
                 for model in data.models {
                     let key = "\(provider.rawValue)|\(accountKey)|\(model.name)"
-                    // `used` is an absolute counter where providers expose it;
-                    // otherwise fall back to the consumed percentage.
-                    entries[key] = model.used.map(Double.init) ?? model.usedPercentage
+                    entries[key] = Self.consumption(of: model)
                 }
             }
         }
         self.entries = entries
+    }
+
+    /// The number that moves when the user spends quota on one row.
+    ///
+    /// The typed `QuotaMetricPresentation` wins over the legacy `Int` fields
+    /// because several providers only populate the typed value:
+    ///
+    /// - `.amount` rows (Amp / OpenRouter balances, Factory Droid, Devin) are
+    ///   built with `percentage: -1` and no `used`, so reading the legacy
+    ///   fields collapsed every one of them to the constant `usedPercentage`
+    ///   `100 - (-1) == 101` and their real consumption was invisible.
+    ///   The value is used as-is: a `.balance` falls and a `.spent` rises, and
+    ///   the signature only tests for inequality, so either direction reads as
+    ///   activity.
+    /// - `.progress` rows carry Double-valued `used`/`limit` (dollars for Amp,
+    ///   OpenRouter and GLM) that the optional legacy `Int` does not mirror.
+    ///
+    /// `.status` rows are textual state rather than consumption, so they keep
+    /// the legacy path and contribute no activity signal of their own.
+    static func consumption(of model: ModelQuota) -> Double {
+        switch model.presentation {
+        case .progress(let used, _, _):
+            return used
+        case .amount(let value, _, _):
+            return value
+        case .status, .none:
+            // `used` is an absolute counter where providers expose it;
+            // otherwise fall back to the consumed percentage.
+            return model.used.map(Double.init) ?? model.usedPercentage
+        }
     }
 
     var isEmpty: Bool { entries.isEmpty }
@@ -175,15 +232,35 @@ nonisolated struct AdaptiveRefreshTracker: Sendable {
         signature = nil
     }
 
-    /// Feed a completed refresh into the tracker.
+    /// Feed the result of one automatic refresh into the tracker.
     ///
-    /// - Returns: `true` when usage moved since the previous snapshot.
+    /// Only `.sample` is treated as evidence about the user. A `.skipped` poll
+    /// changes nothing at all, and a `.failed` poll recovers the cadence to the
+    /// user's interval instead of backing off further - in both cases the
+    /// comparison baseline is left untouched, so the next real sample is
+    /// compared against the last real sample rather than against data that was
+    /// never refreshed (issue #172).
+    ///
+    /// - Returns: `true` when usage moved since the previous *sample*.
     @discardableResult
     mutating func observe(
+        outcome: QuotaRefreshOutcome,
         signature newSignature: QuotaUsageSignature,
         at now: Date,
         bounds: AdaptiveRefreshBounds
     ) -> Bool {
+        switch outcome {
+        case .skipped:
+            // Nothing was measured, so nothing is known.
+            return false
+        case .failed:
+            // A failure is not idleness. Retry at the user's cadence.
+            interval = max(0, bounds.fastInterval)
+            return false
+        case .sample:
+            break
+        }
+
         defer { signature = newSignature }
 
         // First observation only seeds the baseline; there is nothing to
@@ -208,12 +285,21 @@ nonisolated struct AdaptiveRefreshTracker: Sendable {
     }
 
     /// Convenience overload for the view model's quota map.
+    ///
+    /// The signature is only built for `.sample`; the other outcomes ignore it,
+    /// and building one from a map that was never refreshed would be misleading.
     @discardableResult
     mutating func observe(
+        outcome: QuotaRefreshOutcome,
         quotas: [AIProvider: [String: ProviderQuotaData]],
         at now: Date = Date(),
         bounds: AdaptiveRefreshBounds
     ) -> Bool {
-        observe(signature: QuotaUsageSignature(quotas: quotas), at: now, bounds: bounds)
+        let newSignature = outcome == .sample ? QuotaUsageSignature(quotas: quotas) : .empty
+        return observe(outcome: outcome, signature: newSignature, at: now, bounds: bounds)
     }
+
+    /// Last usage snapshot the tracker compared against, for tests and
+    /// diagnostics. `nil` until the first `.sample` observation.
+    var observedSignature: QuotaUsageSignature? { signature }
 }

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -173,6 +173,10 @@ final class QuotaViewModel {
     let antigravitySwitcher = AntigravityAccountSwitcher.shared
     
     @ObservationIgnored private var refreshTask: Task<Void, Never>?
+    /// Handle for the quota refresh `refreshData()` starts in the background,
+    /// so the automatic loop can await the refresh whose result it records
+    /// instead of snapshotting the previous poll's numbers (issue #172).
+    @ObservationIgnored private var quotaRefreshTask: Task<QuotaRefreshOutcome, Never>?
     /// Adaptive refresh state (issue #172). `nil` while adaptive refresh is off.
     @ObservationIgnored private var adaptiveTracker: AdaptiveRefreshTracker?
     @ObservationIgnored private var warmupTask: Task<Void, Never>?
@@ -584,12 +588,20 @@ final class QuotaViewModel {
     
     /// Refresh quotas directly without proxy (for Quota-Only Mode)
     /// Note: Cursor and Trae are NOT auto-refreshed - user must use "Scan for IDEs" (issue #29)
-    func refreshQuotasDirectly(force: Bool = false) async {
+    ///
+    /// - Returns: whether this call produced a usable quota sample. Callers that
+    ///   only want the side effect can ignore it; the automatic refresh loop
+    ///   needs it so a coalesced or failed refresh is not mistaken for the user
+    ///   being idle (issue #172).
+    @discardableResult
+    func refreshQuotasDirectly(force: Bool = false) async -> QuotaRefreshOutcome {
         let providers: Set<AIProvider> = [
             .codex, .claude, .copilot, .kiro, .glm, .clinePass, .warp,
             .antigravity, .factoryDroid, .devin, .grok, .openRouter, .amp,
         ]
-        guard beginBatchRefresh(providers: providers) else { return }
+        // Another refresh already owns these providers: this call fetches
+        // nothing, so it is not evidence about user activity.
+        guard beginBatchRefresh(providers: providers) else { return .skipped }
         defer { endBatchRefresh(providers: providers) }
 
         lastQuotaRefreshTime = Date()
@@ -765,6 +777,27 @@ final class QuotaViewModel {
         autoSelectMenuBarItems()
 
         notifyQuotaDataChanged()
+
+        // `monitorIssues` was just re-read from the coordinator above, so it
+        // describes this refresh: any provider it flags fell back to the
+        // previous snapshot, which must not be read as unchanged usage.
+        return completedRefreshOutcome(issues: monitorIssues)
+    }
+
+    /// Classify a batch refresh that ran to completion.
+    ///
+    /// A refresh that produced no quota data at all, or whose providers the
+    /// Monitor coordinator flagged as failed/partial, kept the previous
+    /// snapshot on screen. That is a failure to sample, not proof the user was
+    /// idle, so it must not feed the adaptive backoff (issue #172).
+    ///
+    /// Must be called without an intervening suspension point after the refresh
+    /// finished writing `providerQuotas`, so it classifies that write.
+    private func completedRefreshOutcome(
+        issues: [AIProvider: MonitorRefreshIssue] = [:]
+    ) -> QuotaRefreshOutcome {
+        guard issues.isEmpty else { return .failed }
+        return providerQuotas.isEmpty ? .failed : .sample
     }
 
     private func autoSelectMenuBarItems() {
@@ -980,8 +1013,10 @@ final class QuotaViewModel {
             while !Task.isCancelled {
                 await sleepUntilNextRefresh(fixedNanoseconds: intervalNs)
                 _ = await kiroFetcher.refreshAllTokensIfNeeded()
-                await refreshQuotasDirectly()
-                recordAdaptiveObservation()
+                // Record the outcome of the refresh that just completed, not a
+                // guess derived from the quota values afterwards (issue #172).
+                let outcome = await refreshQuotasDirectly()
+                recordAdaptiveObservation(outcome)
             }
         }
     }
@@ -998,10 +1033,12 @@ final class QuotaViewModel {
         refreshTask = Task {
             while !Task.isCancelled {
                 await sleepUntilNextRefresh(fixedNanoseconds: intervalNs)
+                // When the proxy is running this iteration refreshes nothing,
+                // so no observation is recorded at all (issue #172).
                 if !proxyManager.proxyStatus.running {
                     _ = await kiroFetcher.refreshAllTokensIfNeeded()
-                    await refreshQuotasUnified()
-                    recordAdaptiveObservation()
+                    let outcome = await refreshQuotasUnified()
+                    recordAdaptiveObservation(outcome)
                 }
             }
         }
@@ -1460,23 +1497,126 @@ final class QuotaViewModel {
             adaptiveTracker = nil
             return
         }
-        adaptiveTracker = AdaptiveRefreshTracker(bounds: bounds)
+        adaptiveTracker = AdaptiveRefreshTracker(bounds: bounds, now: adaptiveNow())
     }
 
-    /// Feed the quota snapshot produced by a completed automatic refresh into
-    /// the adaptive tracker, so the next sleep either stays fast (usage moved)
-    /// or backs off (nothing changed).
-    private func recordAdaptiveObservation() {
+    /// Clock the adaptive tracker is driven by. Overridable in tests so the
+    /// backoff curve can be exercised without waiting on wall-clock time.
+    @ObservationIgnored private var adaptiveNow: @Sendable () -> Date = { Date() }
+
+    /// Feed the result of a completed automatic refresh into the adaptive
+    /// tracker, so the next sleep either stays fast (usage moved) or backs off
+    /// (nothing changed).
+    ///
+    /// Deliberately synchronous and called with the outcome of a refresh that
+    /// has already finished: it reads `providerQuotas` at call time, after the
+    /// refresh has written it, rather than from a snapshot taken before an
+    /// `await`. `outcome` decides whether that read counts at all — only
+    /// `.sample` is evidence about the user (issue #172).
+    private func recordAdaptiveObservation(_ outcome: QuotaRefreshOutcome) {
         guard refreshSettings.adaptiveRefreshEnabled,
               let bounds = refreshSettings.adaptiveBounds else {
             adaptiveTracker = nil
             return
         }
+        let now = adaptiveNow()
         if adaptiveTracker == nil {
-            adaptiveTracker = AdaptiveRefreshTracker(bounds: bounds)
+            adaptiveTracker = AdaptiveRefreshTracker(bounds: bounds, now: now)
         }
-        adaptiveTracker?.observe(quotas: providerQuotas, bounds: bounds)
+        adaptiveTracker?.observe(outcome: outcome, quotas: providerQuotas, at: now, bounds: bounds)
     }
+
+    /// Start the quota refresh that `refreshData()` schedules, keeping a handle
+    /// to it.
+    ///
+    /// `refreshData()` intentionally does not await this task: the auth files,
+    /// usage stats and API keys it just fetched must reach the UI without
+    /// waiting on the slower provider round-trips, and the manual refresh path
+    /// drives `refreshAllQuotas()` itself. Only the automatic loop awaits the
+    /// handle, through `refreshDataAwaitingQuotas()` (issue #172).
+    func scheduleBackgroundQuotaRefresh() {
+        quotaRefreshTask = Task { await refreshAllQuotas() }
+    }
+
+    /// Run one automatic full-mode refresh and report what it actually sampled.
+    ///
+    /// This is the fix for the ordering bug: `refreshData()` returns as soon as
+    /// the management API round-trips are done, while the quota refresh it
+    /// scheduled is still in flight. Observing `providerQuotas` at that point
+    /// snapshots the *previous* poll's numbers, which is one poll late at best
+    /// and records a false idle observation at worst. Awaiting the handle makes
+    /// the loop observe the refresh whose result it records (issue #172).
+    private func refreshDataAwaitingQuotas() async -> QuotaRefreshOutcome {
+        #if DEBUG
+        if let hook = refreshDataHookForTesting {
+            await hook()
+            return await awaitScheduledQuotaRefresh()
+        }
+        #endif
+        // Drop any handle an earlier caller left behind, so a refresh that
+        // completed before this iteration cannot be mistaken for this one's.
+        quotaRefreshTask = nil
+        await refreshData()
+        return await awaitScheduledQuotaRefresh()
+    }
+
+    /// Await the quota refresh `refreshData()` scheduled, if it scheduled one.
+    private func awaitScheduledQuotaRefresh() async -> QuotaRefreshOutcome {
+        // Reentrancy: `refreshData()` suspends several times, so the handle and
+        // the error state are read here, after it returned, never from before.
+        guard let task = quotaRefreshTask else {
+            // No quota refresh was due, or the management API call failed
+            // before one could be scheduled. A failure is not idleness.
+            return errorMessage == nil ? .skipped : .failed
+        }
+        let outcome = await task.value
+        // Re-read after the await: a newer refresh may already own the slot.
+        if quotaRefreshTask == task {
+            quotaRefreshTask = nil
+        }
+        return outcome
+    }
+
+    /// The full body of `startAutoRefresh()`'s loop between two sleeps: refresh,
+    /// then record what that refresh proved. Factored out so the ordering can be
+    /// driven directly by the integration test (issue #172).
+    @discardableResult
+    func performAutomaticRefresh() async -> QuotaRefreshOutcome {
+        let outcome = await refreshDataAwaitingQuotas()
+        recordAdaptiveObservation(outcome)
+        return outcome
+    }
+
+    #if DEBUG
+    /// Test seam standing in for `refreshData()`, whose `ManagementAPIClient`
+    /// needs a live proxy. Like `refreshData()`, it may call
+    /// `scheduleBackgroundQuotaRefresh()`. Never set outside tests.
+    @ObservationIgnored var refreshDataHookForTesting: (@MainActor () async -> Void)?
+
+    /// Test seam replacing the provider round-trips of `refreshAllQuotas()`, so
+    /// a test can suspend *inside* the quota refresh. Never set outside tests.
+    @ObservationIgnored var quotaRefreshHookForTesting: (@MainActor () async -> QuotaRefreshOutcome)?
+
+    /// Interval the adaptive tracker would sleep for next, `nil` when adaptive
+    /// refresh is off.
+    var adaptiveIntervalForTesting: TimeInterval? { adaptiveTracker?.interval }
+
+    /// Usage snapshot the adaptive tracker last compared against.
+    var adaptiveSignatureForTesting: QuotaUsageSignature? { adaptiveTracker?.observedSignature }
+
+    /// Arm the adaptive tracker exactly as a refresh loop start would.
+    func resetAdaptiveRefreshForTesting() { resetAdaptiveRefresh() }
+
+    /// Drive adaptive observations from a test-controlled clock.
+    func setAdaptiveClockForTesting(_ clock: @escaping @Sendable () -> Date) { adaptiveNow = clock }
+
+    /// Nanoseconds `sleepUntilNextRefresh(fixedNanoseconds:)` would actually
+    /// wait for, without waiting. Lets the disabled-mode test assert timer
+    /// parity instead of only reading enum constants.
+    func nextRefreshSleepNanosecondsForTesting(fixedNanoseconds: UInt64) -> UInt64 {
+        nextRefreshSleepNanoseconds(fixed: fixedNanoseconds)
+    }
+    #endif
 
     /// Sleep before the next automatic refresh.
     ///
@@ -1484,13 +1624,18 @@ final class QuotaViewModel {
     /// the interval can only grow, never drop below the chosen cadence, so the
     /// providers' APIs are never polled harder than in fixed mode.
     private func sleepUntilNextRefresh(fixedNanoseconds: UInt64) async {
+        try? await Task.sleep(nanoseconds: nextRefreshSleepNanoseconds(fixed: fixedNanoseconds))
+    }
+
+    /// How long the next automatic refresh waits. Pure, so the disabled-mode
+    /// test can assert timer parity without waiting on wall-clock time.
+    private func nextRefreshSleepNanoseconds(fixed fixedNanoseconds: UInt64) -> UInt64 {
         guard refreshSettings.adaptiveRefreshEnabled,
               let interval = adaptiveTracker?.interval,
               interval > 0 else {
-            try? await Task.sleep(nanoseconds: fixedNanoseconds)
-            return
+            return fixedNanoseconds
         }
-        try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+        return UInt64(interval * 1_000_000_000)
     }
 
     /// Interval currently driving automatic refreshes, used for staleness copy.
@@ -1514,9 +1659,10 @@ final class QuotaViewModel {
             
             while !Task.isCancelled {
                 await sleepUntilNextRefresh(fixedNanoseconds: intervalNs)
-                
-                await refreshData()
-                recordAdaptiveObservation()
+
+                // Awaits the quota refresh `refreshData()` schedules before
+                // recording what it sampled (issue #172).
+                await performAutomaticRefresh()
 
                 if errorMessage != nil {
                     consecutiveFailures += 1
@@ -1603,9 +1749,7 @@ final class QuotaViewModel {
             }
             
             if refreshQuotas && isQuotaRefreshDue && !isLoadingQuotas {
-                Task {
-                    await refreshAllQuotas()
-                }
+                scheduleBackgroundQuotaRefresh()
             }
         } catch {
             if !Task.isCancelled {
@@ -1628,13 +1772,21 @@ final class QuotaViewModel {
         }
     }
     
-    func refreshAllQuotas() async {
+    /// - Returns: whether this call produced a usable quota sample, for the
+    ///   automatic refresh loop's adaptive cadence (issue #172).
+    @discardableResult
+    func refreshAllQuotas() async -> QuotaRefreshOutcome {
+        #if DEBUG
+        if let hook = quotaRefreshHookForTesting {
+            return await hook()
+        }
+        #endif
         if modeManager.isMonitorMode {
-            await refreshQuotasDirectly()
-            return
+            return await refreshQuotasDirectly()
         }
         let providers: Set<AIProvider> = [.antigravity, .codex, .copilot, .claude, .glm, .warp, .kiro, .clinePass]
-        guard beginBatchRefresh(providers: providers) else { return }
+        // Another refresh already owns these providers: nothing is fetched here.
+        guard beginBatchRefresh(providers: providers) else { return .skipped }
         defer { endBatchRefresh(providers: providers) }
 
         lastQuotaRefresh = Date()
@@ -1642,7 +1794,8 @@ final class QuotaViewModel {
 
         // In remote mode, skip local filesystem fetchers — only show data from the remote proxy
         // (auth files, usage stats, API keys are already fetched by refreshData())
-        if !modeManager.isRemoteProxyMode {
+        let hasLocalQuotaSource = !modeManager.isRemoteProxyMode
+        if hasLocalQuotaSource {
             // Note: Cursor and Trae removed from auto-refresh (issue #29)
             // User must use "Scan for IDEs" to detect these
             async let antigravity: () = refreshAntigravityQuotasInternal()
@@ -1662,6 +1815,11 @@ final class QuotaViewModel {
         autoSelectMenuBarItems()
 
         notifyQuotaDataChanged()
+
+        // Remote mode has no local quota source here: the block above is
+        // skipped and `providerQuotas` is not populated by `refreshData()`
+        // either, so this poll says nothing about the user (issue #172).
+        return hasLocalQuotaSource ? completedRefreshOutcome() : .skipped
     }
 
     /// Unified quota refresh - works in both Full Mode and Quota-Only Mode
@@ -1669,17 +1827,22 @@ final class QuotaViewModel {
     /// In Quota-Only Mode: uses direct fetchers + CLI fetchers
     /// In Remote Mode: skips local fetchers (data comes from remote proxy)
     /// Note: Cursor and Trae require explicit user scan (issue #29)
-    func refreshQuotasUnified() async {
+    ///
+    /// - Returns: whether this call produced a usable quota sample, for the
+    ///   automatic refresh loop's adaptive cadence (issue #172).
+    @discardableResult
+    func refreshQuotasUnified() async -> QuotaRefreshOutcome {
         if modeManager.isMonitorMode {
-            await refreshQuotasDirectly()
-            return
+            return await refreshQuotasDirectly()
         }
-        guard !modeManager.isRemoteProxyMode else { return }
+        // Remote mode fetches nothing locally, so there is no sample to take.
+        guard !modeManager.isRemoteProxyMode else { return .skipped }
 
         let providers: Set<AIProvider> = [
             .antigravity, .codex, .copilot, .claude, .glm, .warp, .kiro, .clinePass,
         ]
-        guard beginBatchRefresh(providers: providers) else { return }
+        // Another refresh already owns these providers: nothing is fetched here.
+        guard beginBatchRefresh(providers: providers) else { return .skipped }
         defer { endBatchRefresh(providers: providers) }
 
         lastQuotaRefreshTime = Date()
@@ -1703,6 +1866,8 @@ final class QuotaViewModel {
         autoSelectMenuBarItems()
 
         notifyQuotaDataChanged()
+
+        return completedRefreshOutcome()
     }
 
     private func refreshAntigravityQuotasInternal() async {

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -123,7 +123,9 @@ final class QuotaViewModel {
             return ("outdated", issue.message)
         }
         guard let updated else { return (nil, nil) }
-        let staleAfter = refreshSettings.refreshCadence.intervalSeconds ?? 600
+        // Use the interval actually in effect: with adaptive refresh backed off,
+        // a slightly older timestamp is expected and not "outdated" (issue #172).
+        let staleAfter = effectiveRefreshInterval ?? 600
         if Date().timeIntervalSince(updated) > staleAfter {
             return (
                 "outdated",
@@ -171,6 +173,8 @@ final class QuotaViewModel {
     let antigravitySwitcher = AntigravityAccountSwitcher.shared
     
     @ObservationIgnored private var refreshTask: Task<Void, Never>?
+    /// Adaptive refresh state (issue #172). `nil` while adaptive refresh is off.
+    @ObservationIgnored private var adaptiveTracker: AdaptiveRefreshTracker?
     @ObservationIgnored private var warmupTask: Task<Void, Never>?
     @ObservationIgnored private var isStartingProxyFlow = false
     @ObservationIgnored private var lastLogTimestamp: Int?
@@ -965,7 +969,8 @@ final class QuotaViewModel {
     /// Start auto-refresh for quota-only mode
     private func startQuotaOnlyAutoRefresh() {
         refreshTask?.cancel()
-        
+        resetAdaptiveRefresh()
+
         guard let intervalNs = refreshSettings.refreshCadence.intervalNanoseconds else {
             // Manual mode - no auto-refresh
             return
@@ -973,9 +978,10 @@ final class QuotaViewModel {
         
         refreshTask = Task {
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: intervalNs)
+                await sleepUntilNextRefresh(fixedNanoseconds: intervalNs)
                 _ = await kiroFetcher.refreshAllTokensIfNeeded()
                 await refreshQuotasDirectly()
+                recordAdaptiveObservation()
             }
         }
     }
@@ -983,17 +989,19 @@ final class QuotaViewModel {
     /// Start auto-refresh for quota when proxy is not running (Full Mode)
     private func startQuotaAutoRefreshWithoutProxy() {
         refreshTask?.cancel()
-        
+        resetAdaptiveRefresh()
+
         guard let intervalNs = refreshSettings.refreshCadence.intervalNanoseconds else {
             return
         }
         
         refreshTask = Task {
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: intervalNs)
+                await sleepUntilNextRefresh(fixedNanoseconds: intervalNs)
                 if !proxyManager.proxyStatus.running {
                     _ = await kiroFetcher.refreshAllTokensIfNeeded()
                     await refreshQuotasUnified()
+                    recordAdaptiveObservation()
                 }
             }
         }
@@ -1441,9 +1449,61 @@ final class QuotaViewModel {
         )
     }
     
+    // MARK: - Adaptive Refresh (issue #172)
+
+    /// Reset adaptive state. Called whenever a refresh loop (re)starts so a new
+    /// loop always begins at the user's chosen cadence instead of inheriting a
+    /// backed-off interval.
+    private func resetAdaptiveRefresh() {
+        guard refreshSettings.adaptiveRefreshEnabled,
+              let bounds = refreshSettings.adaptiveBounds else {
+            adaptiveTracker = nil
+            return
+        }
+        adaptiveTracker = AdaptiveRefreshTracker(bounds: bounds)
+    }
+
+    /// Feed the quota snapshot produced by a completed automatic refresh into
+    /// the adaptive tracker, so the next sleep either stays fast (usage moved)
+    /// or backs off (nothing changed).
+    private func recordAdaptiveObservation() {
+        guard refreshSettings.adaptiveRefreshEnabled,
+              let bounds = refreshSettings.adaptiveBounds else {
+            adaptiveTracker = nil
+            return
+        }
+        if adaptiveTracker == nil {
+            adaptiveTracker = AdaptiveRefreshTracker(bounds: bounds)
+        }
+        adaptiveTracker?.observe(quotas: providerQuotas, bounds: bounds)
+    }
+
+    /// Sleep before the next automatic refresh.
+    ///
+    /// With adaptive refresh off this is exactly the fixed cadence; with it on
+    /// the interval can only grow, never drop below the chosen cadence, so the
+    /// providers' APIs are never polled harder than in fixed mode.
+    private func sleepUntilNextRefresh(fixedNanoseconds: UInt64) async {
+        guard refreshSettings.adaptiveRefreshEnabled,
+              let interval = adaptiveTracker?.interval,
+              interval > 0 else {
+            try? await Task.sleep(nanoseconds: fixedNanoseconds)
+            return
+        }
+        try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+    }
+
+    /// Interval currently driving automatic refreshes, used for staleness copy.
+    private var effectiveRefreshInterval: TimeInterval? {
+        guard let fixed = refreshSettings.refreshCadence.intervalSeconds else { return nil }
+        guard refreshSettings.adaptiveRefreshEnabled, let tracker = adaptiveTracker else { return fixed }
+        return max(fixed, tracker.interval)
+    }
+
     private func startAutoRefresh() {
         refreshTask?.cancel()
-        
+        resetAdaptiveRefresh()
+
         guard let intervalNs = refreshSettings.refreshCadence.intervalNanoseconds else {
             return
         }
@@ -1453,10 +1513,11 @@ final class QuotaViewModel {
             let maxFailuresBeforeRecovery = max(3, Int(180_000_000_000 / intervalNs))
             
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: intervalNs)
+                await sleepUntilNextRefresh(fixedNanoseconds: intervalNs)
                 
                 await refreshData()
-                
+                recordAdaptiveObservation()
+
                 if errorMessage != nil {
                     consecutiveFailures += 1
                     Log.quota("Refresh failed, consecutive failures: \(consecutiveFailures)")

--- a/Quotio/Views/Screens/SettingsScreen.swift
+++ b/Quotio/Views/Screens/SettingsScreen.swift
@@ -989,7 +989,14 @@ struct RefreshCadenceSettingsSection: View {
             set: { refreshSettings.refreshCadence = $0 }
         )
     }
-    
+
+    private var adaptiveBinding: Binding<Bool> {
+        Binding(
+            get: { refreshSettings.adaptiveRefreshEnabled },
+            set: { refreshSettings.adaptiveRefreshEnabled = $0 }
+        )
+    }
+
     var body: some View {
         Section {
             Picker("settings.refresh.cadence".localized(), selection: cadenceBinding) {
@@ -997,7 +1004,15 @@ struct RefreshCadenceSettingsSection: View {
                     Text(cadence.localizationKey.localized()).tag(cadence)
                 }
             }
-            
+
+            if refreshSettings.refreshCadence != .manual {
+                Toggle("settings.refresh.adaptive".localized(), isOn: adaptiveBinding)
+
+                Text("settings.refresh.adaptive.help".localized())
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             if refreshSettings.refreshCadence == .manual {
                 Button {
                     Task {

--- a/Quotio/Views/Screens/SettingsScreen.swift
+++ b/Quotio/Views/Screens/SettingsScreen.swift
@@ -982,7 +982,8 @@ struct QuotaDisplaySettingsSection: View {
 struct RefreshCadenceSettingsSection: View {
     @Environment(QuotaViewModel.self) private var viewModel
     @State private var refreshSettings = RefreshSettingsManager.shared
-    
+    @State private var modeManager = OperatingModeManager.shared
+
     private var cadenceBinding: Binding<RefreshCadence> {
         Binding(
             get: { refreshSettings.refreshCadence },
@@ -997,6 +998,14 @@ struct RefreshCadenceSettingsSection: View {
         )
     }
 
+    /// Adaptive refresh reads its activity signal from locally fetched quota
+    /// data. Remote mode has no local quota source — `refreshAllQuotas()` skips
+    /// the local fetchers there — so the toggle is hidden rather than offered
+    /// as a setting that would do nothing (issue #172).
+    private var supportsAdaptiveRefresh: Bool {
+        refreshSettings.refreshCadence != .manual && !modeManager.isRemoteProxyMode
+    }
+
     var body: some View {
         Section {
             Picker("settings.refresh.cadence".localized(), selection: cadenceBinding) {
@@ -1005,7 +1014,7 @@ struct RefreshCadenceSettingsSection: View {
                 }
             }
 
-            if refreshSettings.refreshCadence != .manual {
+            if supportsAdaptiveRefresh {
                 Toggle("settings.refresh.adaptive".localized(), isOn: adaptiveBinding)
 
                 Text("settings.refresh.adaptive.help".localized())

--- a/QuotioTests/AdaptiveRefreshIntegrationTests.swift
+++ b/QuotioTests/AdaptiveRefreshIntegrationTests.swift
@@ -1,0 +1,268 @@
+import XCTest
+@testable import Quotio
+
+/// Runtime integration coverage for adaptive refresh (issue #172).
+///
+/// The pure cadence maths lives in `AdaptiveRefreshPlannerTests`. What is
+/// covered here is the part that has to be driven through `QuotaViewModel`:
+/// that one iteration of the automatic refresh loop observes the quota refresh
+/// it started — not the previous poll's numbers — and that with the feature off
+/// (the default) the loop behaves exactly as it did before.
+@MainActor
+final class AdaptiveRefreshIntegrationTests: XCTestCase {
+
+    private let settings = RefreshSettingsManager.shared
+    private var savedCadence: RefreshCadence = .tenMinutes
+    private var savedAdaptive = false
+
+    override func setUp() {
+        super.setUp()
+        // `RefreshSettingsManager` is a singleton backed by UserDefaults.
+        savedCadence = settings.refreshCadence
+        savedAdaptive = settings.adaptiveRefreshEnabled
+    }
+
+    override func tearDown() {
+        settings.refreshCadence = savedCadence
+        settings.adaptiveRefreshEnabled = savedAdaptive
+        super.tearDown()
+    }
+
+    private func quotas(used: Int) -> [AIProvider: [String: ProviderQuotaData]] {
+        [
+            .claude: ["user@example.com": ProviderQuotaData(
+                models: [ModelQuota(name: "sonnet", percentage: 50, resetTime: "", used: used, limit: 100)]
+            )]
+        ]
+    }
+
+    /// Test-controlled clock, so the backoff curve can be driven without
+    /// waiting on wall-clock time.
+    private final class TestClock: @unchecked Sendable {
+        private(set) var now: Date
+        init(now: Date) { self.now = now }
+        func advance(by seconds: TimeInterval) { now = now.addingTimeInterval(seconds) }
+    }
+
+    /// A gate the test opens by hand, so the quota refresh can be held
+    /// suspended while the test inspects what the loop has recorded so far.
+    private final class Gate {
+        private var continuation: CheckedContinuation<Void, Never>?
+        private var opened = false
+
+        func wait() async {
+            if opened { return }
+            await withCheckedContinuation { continuation = $0 }
+        }
+
+        func open() {
+            opened = true
+            continuation?.resume()
+            continuation = nil
+        }
+    }
+
+    // MARK: - Blocker 1: observe the refresh you started
+
+    /// `refreshData()` schedules `refreshAllQuotas()` on a new unstructured
+    /// `Task` and returns immediately, so recording the adaptive observation
+    /// right after it snapshots the *previous* poll's quotas while the real
+    /// refresh is still in flight — one poll late at best, and a false idle
+    /// observation at worst.
+    ///
+    /// This test suspends inside the quota refresh to prove the ordering: while
+    /// the fetch is held, nothing has been observed yet; once it completes and
+    /// has written `providerQuotas`, the recorded signature is the *new* value.
+    func testAutomaticRefreshObservesTheQuotaRefreshItStarted() async {
+        settings.refreshCadence = .oneMinute
+        settings.adaptiveRefreshEnabled = true
+
+        let viewModel = QuotaViewModel()
+        viewModel.providerQuotas = quotas(used: 10)
+        viewModel.resetAdaptiveRefreshForTesting()
+
+        let gate = Gate()
+        let fetchStarted = expectation(description: "quota fetch started")
+
+        // Stands in for refreshData(): schedules the quota refresh in the
+        // background and returns without awaiting it, exactly as it does.
+        viewModel.refreshDataHookForTesting = { @MainActor [weak viewModel] in
+            viewModel?.scheduleBackgroundQuotaRefresh()
+        }
+
+        // Stands in for the provider round-trips inside refreshAllQuotas():
+        // suspends mid-flight, then writes the fresh quota snapshot.
+        viewModel.quotaRefreshHookForTesting = { @MainActor [weak viewModel] in
+            fetchStarted.fulfill()
+            await gate.wait()
+            viewModel?.providerQuotas = self.quotas(used: 55)
+            return .sample
+        }
+
+        let iteration = Task { @MainActor in await viewModel.performAutomaticRefresh() }
+
+        await fulfillment(of: [fetchStarted], timeout: 5)
+
+        // The refresh is suspended: the loop must still be waiting on it, so no
+        // observation of the stale snapshot can have been recorded.
+        XCTAssertNil(
+            viewModel.adaptiveSignatureForTesting,
+            "the observation must not be recorded while the quota refresh is still in flight"
+        )
+        XCTAssertEqual(viewModel.providerQuotas[.claude]?["user@example.com"]?.models.first?.used, 10)
+
+        gate.open()
+        let outcome = await iteration.value
+
+        XCTAssertEqual(outcome, .sample)
+        XCTAssertEqual(
+            viewModel.adaptiveSignatureForTesting?.entries["claude|user@example.com|sonnet"],
+            55,
+            "the observation must snapshot the refresh that just completed, not the previous poll"
+        )
+    }
+
+    // MARK: - Blocker 2: only a real sample is evidence
+
+    /// `refreshAllQuotas()` returns early when another refresh already owns the
+    /// providers. That poll fetched nothing, so it must leave the cadence and
+    /// the baseline alone instead of counting as "usage did not change".
+    func testCoalescedRefreshDoesNotBackOff() async {
+        settings.refreshCadence = .oneMinute
+        settings.adaptiveRefreshEnabled = true
+
+        let clock = TestClock(now: Date(timeIntervalSince1970: 0))
+        let viewModel = QuotaViewModel()
+        viewModel.setAdaptiveClockForTesting { clock.now }
+        viewModel.providerQuotas = quotas(used: 10)
+        viewModel.resetAdaptiveRefreshForTesting()
+
+        viewModel.refreshDataHookForTesting = { @MainActor [weak viewModel] in
+            viewModel?.scheduleBackgroundQuotaRefresh()
+        }
+        viewModel.quotaRefreshHookForTesting = { .sample }
+        await viewModel.performAutomaticRefresh()
+        XCTAssertEqual(viewModel.adaptiveIntervalForTesting, 60)
+
+        // Every following poll is coalesced away. The clock advances well past
+        // the idle grace window, so identical `.sample` polls would have backed
+        // off to the 30 minute ceiling by now.
+        viewModel.quotaRefreshHookForTesting = { .skipped }
+        for _ in 0..<8 {
+            clock.advance(by: 600)
+            let outcome = await viewModel.performAutomaticRefresh()
+            XCTAssertEqual(outcome, .skipped)
+        }
+
+        XCTAssertEqual(
+            viewModel.adaptiveIntervalForTesting,
+            60,
+            "a coalesced refresh proves nothing about activity and must not back off"
+        )
+    }
+
+    /// A failing refresh keeps the previous snapshot on screen, which looks
+    /// identical to unchanged usage. It must pull the cadence back to the
+    /// user's interval instead of sitting on a backed-off delay.
+    func testFailedRefreshRecoversTheRetryCadence() async {
+        settings.refreshCadence = .oneMinute
+        settings.adaptiveRefreshEnabled = true
+
+        let clock = TestClock(now: Date(timeIntervalSince1970: 0))
+        let viewModel = QuotaViewModel()
+        viewModel.setAdaptiveClockForTesting { clock.now }
+        viewModel.providerQuotas = quotas(used: 10)
+        viewModel.resetAdaptiveRefreshForTesting()
+
+        viewModel.refreshDataHookForTesting = { @MainActor [weak viewModel] in
+            viewModel?.scheduleBackgroundQuotaRefresh()
+        }
+        // Idle: back off to the ceiling, advancing the clock by whatever the
+        // loop would have slept for between iterations.
+        viewModel.quotaRefreshHookForTesting = { .sample }
+        for _ in 0..<8 {
+            await viewModel.performAutomaticRefresh()
+            clock.advance(by: viewModel.adaptiveIntervalForTesting ?? 0)
+        }
+        XCTAssertEqual(viewModel.adaptiveIntervalForTesting, 1800)
+
+        viewModel.quotaRefreshHookForTesting = { .failed }
+        let outcome = await viewModel.performAutomaticRefresh()
+
+        XCTAssertEqual(outcome, .failed)
+        XCTAssertEqual(
+            viewModel.adaptiveIntervalForTesting,
+            60,
+            "a failure must recover to the retry cadence, not keep the 30 minute delay"
+        )
+    }
+
+    /// With no quota refresh scheduled and no error, the poll is `.skipped`:
+    /// `refreshData()` gates the quota refresh on it being due, and a poll that
+    /// deliberately fetched no quotas is not evidence of idleness either.
+    func testRefreshWithoutScheduledQuotaRefreshIsSkipped() async {
+        settings.refreshCadence = .oneMinute
+        settings.adaptiveRefreshEnabled = true
+
+        let viewModel = QuotaViewModel()
+        viewModel.providerQuotas = quotas(used: 10)
+        viewModel.resetAdaptiveRefreshForTesting()
+
+        viewModel.refreshDataHookForTesting = { }
+        let outcome = await viewModel.performAutomaticRefresh()
+
+        XCTAssertEqual(outcome, .skipped)
+        XCTAssertNil(viewModel.adaptiveSignatureForTesting)
+        XCTAssertEqual(viewModel.adaptiveIntervalForTesting, 60)
+    }
+
+    // MARK: - Opt-out parity (adaptive refresh is off by default)
+
+    /// With adaptive refresh off — the default — no tracker is armed and the
+    /// loop sleeps on exactly the fixed cadence, for every cadence value.
+    func testDisabledAdaptiveRefreshSleepsOnTheFixedCadence() async {
+        settings.adaptiveRefreshEnabled = false
+
+        let viewModel = QuotaViewModel()
+        viewModel.providerQuotas = quotas(used: 10)
+
+        for cadence in RefreshCadence.allCases {
+            settings.refreshCadence = cadence
+            viewModel.resetAdaptiveRefreshForTesting()
+
+            XCTAssertNil(
+                viewModel.adaptiveIntervalForTesting,
+                "no tracker may be armed while adaptive refresh is off (\(cadence))"
+            )
+            guard let fixed = cadence.intervalNanoseconds else { continue }
+            XCTAssertEqual(
+                viewModel.nextRefreshSleepNanosecondsForTesting(fixedNanoseconds: fixed),
+                fixed,
+                "disabled adaptive refresh must sleep the fixed cadence (\(cadence))"
+            )
+        }
+    }
+
+    /// Even after refreshes that would have backed a tracker off, the disabled
+    /// loop keeps sleeping on the fixed cadence and arms no tracker.
+    func testDisabledAdaptiveRefreshNeverBacksOff() async {
+        settings.refreshCadence = .oneMinute
+        settings.adaptiveRefreshEnabled = false
+
+        let viewModel = QuotaViewModel()
+        viewModel.providerQuotas = quotas(used: 10)
+        viewModel.resetAdaptiveRefreshForTesting()
+
+        viewModel.refreshDataHookForTesting = { @MainActor [weak viewModel] in
+            viewModel?.scheduleBackgroundQuotaRefresh()
+        }
+        viewModel.quotaRefreshHookForTesting = { .sample }
+
+        let fixed = RefreshCadence.oneMinute.intervalNanoseconds!
+        for _ in 0..<10 {
+            await viewModel.performAutomaticRefresh()
+            XCTAssertNil(viewModel.adaptiveIntervalForTesting)
+            XCTAssertEqual(viewModel.nextRefreshSleepNanosecondsForTesting(fixedNanoseconds: fixed), fixed)
+        }
+    }
+}

--- a/QuotioTests/AdaptiveRefreshPlannerTests.swift
+++ b/QuotioTests/AdaptiveRefreshPlannerTests.swift
@@ -114,14 +114,14 @@ final class AdaptiveRefreshPlannerTests: XCTestCase {
         var tracker = AdaptiveRefreshTracker(bounds: bounds, now: start)
 
         // Seed the baseline.
-        XCTAssertTrue(tracker.observe(quotas: quotas(used: 10), at: start, bounds: bounds))
+        XCTAssertTrue(tracker.observe(outcome: .sample, quotas: quotas(used: 10), at: start, bounds: bounds))
         XCTAssertEqual(tracker.interval, oneMinute)
 
         var now = start
         var observed: [TimeInterval] = []
         for _ in 0..<6 {
             now = now.addingTimeInterval(tracker.interval)
-            XCTAssertFalse(tracker.observe(quotas: quotas(used: 10), at: now, bounds: bounds))
+            XCTAssertFalse(tracker.observe(outcome: .sample, quotas: quotas(used: 10), at: now, bounds: bounds))
             observed.append(tracker.interval)
         }
 
@@ -133,18 +133,18 @@ final class AdaptiveRefreshPlannerTests: XCTestCase {
         let start = Date(timeIntervalSince1970: 0)
         var tracker = AdaptiveRefreshTracker(bounds: bounds, now: start)
 
-        tracker.observe(quotas: quotas(used: 10), at: start, bounds: bounds)
+        tracker.observe(outcome: .sample, quotas: quotas(used: 10), at: start, bounds: bounds)
 
         var now = start
         for _ in 0..<5 {
             now = now.addingTimeInterval(tracker.interval)
-            tracker.observe(quotas: quotas(used: 10), at: now, bounds: bounds)
+            tracker.observe(outcome: .sample, quotas: quotas(used: 10), at: now, bounds: bounds)
         }
         XCTAssertGreaterThan(tracker.interval, oneMinute)
 
         // The user starts coding again: usage moves, cadence snaps back immediately.
         now = now.addingTimeInterval(tracker.interval)
-        XCTAssertTrue(tracker.observe(quotas: quotas(used: 42), at: now, bounds: bounds))
+        XCTAssertTrue(tracker.observe(outcome: .sample, quotas: quotas(used: 42), at: now, bounds: bounds))
         XCTAssertEqual(tracker.interval, oneMinute)
         XCTAssertEqual(tracker.lastActivityAt, now)
     }
@@ -154,11 +154,11 @@ final class AdaptiveRefreshPlannerTests: XCTestCase {
         let start = Date(timeIntervalSince1970: 0)
         var tracker = AdaptiveRefreshTracker(bounds: bounds, now: start)
 
-        tracker.observe(quotas: quotas(used: 10), at: start, bounds: bounds)
+        tracker.observe(outcome: .sample, quotas: quotas(used: 10), at: start, bounds: bounds)
         var now = start
         for _ in 0..<4 {
             now = now.addingTimeInterval(tracker.interval)
-            tracker.observe(quotas: quotas(used: 10), at: now, bounds: bounds)
+            tracker.observe(outcome: .sample, quotas: quotas(used: 10), at: now, bounds: bounds)
         }
         XCTAssertGreaterThan(tracker.interval, oneMinute)
 
@@ -211,13 +211,184 @@ final class AdaptiveRefreshPlannerTests: XCTestCase {
         XCTAssertNotEqual(single, QuotaUsageSignature(quotas: expanded))
     }
 
+    // MARK: - Typed metric values (issue #172 review, blocker 3)
+
+    private func amountQuota(_ value: Double) -> [AIProvider: [String: ProviderQuotaData]] {
+        // Built exactly like AmpQuotaFetcher / OpenRouterQuotaFetcher /
+        // DevinQuotaFetcher build a balance row: percentage -1, no legacy `used`.
+        [
+            .amp: ["key": ProviderQuotaData(
+                models: [ModelQuota(
+                    name: "amp-balance",
+                    percentage: -1,
+                    resetTime: "",
+                    presentation: .amount(value: value, unit: .usd, semantics: .balance)
+                )]
+            )]
+        ]
+    }
+
+    /// Regression: `.amount` rows carry `percentage == -1`, so reading only the
+    /// legacy fields turned every balance into the constant `100 - (-1) == 101`
+    /// and a user burning through credits looked permanently idle.
+    func testSignatureTracksAmountMetricValues() {
+        let before = QuotaUsageSignature(quotas: amountQuota(20))
+        let after = QuotaUsageSignature(quotas: amountQuota(12.5))
+
+        XCTAssertNotEqual(before, after)
+        XCTAssertEqual(before.entries["amp|key|amp-balance"], 20)
+        XCTAssertEqual(after.entries["amp|key|amp-balance"], 12.5)
+        // The legacy path would have produced 101 for both.
+        XCTAssertNotEqual(before.entries["amp|key|amp-balance"], 101)
+    }
+
+    /// A backed-off tracker must snap back when a `.amount` balance moves.
+    func testTrackerReactsToAmountMetricMovement() {
+        let bounds = self.bounds(fast: oneMinute)
+        let start = Date(timeIntervalSince1970: 0)
+        var tracker = AdaptiveRefreshTracker(bounds: bounds, now: start)
+
+        tracker.observe(outcome: .sample, quotas: amountQuota(20), at: start, bounds: bounds)
+        var now = start
+        for _ in 0..<5 {
+            now = now.addingTimeInterval(tracker.interval)
+            tracker.observe(outcome: .sample, quotas: amountQuota(20), at: now, bounds: bounds)
+        }
+        XCTAssertGreaterThan(tracker.interval, oneMinute)
+
+        now = now.addingTimeInterval(tracker.interval)
+        XCTAssertTrue(tracker.observe(outcome: .sample, quotas: amountQuota(19), at: now, bounds: bounds))
+        XCTAssertEqual(tracker.interval, oneMinute)
+    }
+
+    /// Regression: `.progress` rows carry Double-valued used/limit that the
+    /// optional legacy `Int` does not mirror, so sub-unit spend (dollars for
+    /// Amp/OpenRouter/GLM) has to come from the typed presentation.
+    func testSignatureTracksProgressMetricValues() {
+        func progressQuota(used: Double) -> [AIProvider: [String: ProviderQuotaData]] {
+            [
+                .openRouter: ["key": ProviderQuotaData(
+                    models: [ModelQuota(
+                        name: "openrouter-credits",
+                        percentage: 50,
+                        resetTime: "",
+                        presentation: .progress(used: used, limit: 10, unit: .usd)
+                    )]
+                )]
+            ]
+        }
+
+        let before = QuotaUsageSignature(quotas: progressQuota(used: 4.25))
+        let after = QuotaUsageSignature(quotas: progressQuota(used: 4.75))
+
+        XCTAssertEqual(before.entries["openrouter|key|openrouter-credits"], 4.25)
+        XCTAssertEqual(after.entries["openrouter|key|openrouter-credits"], 4.75)
+        // Both rows report percentage 50, so the legacy path saw no movement.
+        XCTAssertNotEqual(before, after)
+    }
+
+    // MARK: - Outcome gating (issue #172 review, blocker 2)
+
+    /// A refresh that never ran (coalesced against an in-flight refresh, not
+    /// due, or a mode with no local quota source) must leave the cadence and
+    /// the comparison baseline exactly as they were.
+    func testSkippedRefreshChangesNothing() {
+        let bounds = self.bounds(fast: oneMinute)
+        let start = Date(timeIntervalSince1970: 0)
+        var tracker = AdaptiveRefreshTracker(bounds: bounds, now: start)
+
+        tracker.observe(outcome: .sample, quotas: quotas(used: 10), at: start, bounds: bounds)
+        let baseline = tracker.observedSignature
+
+        var now = start
+        for _ in 0..<10 {
+            now = now.addingTimeInterval(oneMinute)
+            XCTAssertFalse(tracker.observe(outcome: .skipped, quotas: [:], at: now, bounds: bounds))
+        }
+
+        XCTAssertEqual(tracker.interval, oneMinute, "a skipped poll must not back off")
+        XCTAssertEqual(tracker.lastActivityAt, start)
+        XCTAssertEqual(tracker.observedSignature, baseline, "baseline must survive a skipped poll")
+    }
+
+    /// Skipped polls must not be able to hide real activity: the next sample is
+    /// compared against the last *sample*, not against an empty snapshot.
+    func testSkippedRefreshDoesNotCorruptTheBaseline() {
+        let bounds = self.bounds(fast: oneMinute)
+        let start = Date(timeIntervalSince1970: 0)
+        var tracker = AdaptiveRefreshTracker(bounds: bounds, now: start)
+
+        tracker.observe(outcome: .sample, quotas: quotas(used: 10), at: start, bounds: bounds)
+        tracker.observe(outcome: .skipped, quotas: [:], at: start.addingTimeInterval(60), bounds: bounds)
+
+        // Same usage as the last real sample: still idle, despite the empty
+        // snapshot that the skipped poll carried.
+        XCTAssertFalse(tracker.observe(
+            outcome: .sample,
+            quotas: quotas(used: 10),
+            at: start.addingTimeInterval(120),
+            bounds: bounds
+        ))
+    }
+
+    /// A failed refresh keeps the previous snapshot on screen, which looks
+    /// exactly like "unchanged usage". It must not back off, and it must pull a
+    /// previously backed-off cadence back to the user's interval so the app
+    /// retries promptly.
+    func testFailedRefreshRecoversToTheFastCadence() {
+        let bounds = self.bounds(fast: oneMinute)
+        let start = Date(timeIntervalSince1970: 0)
+        var tracker = AdaptiveRefreshTracker(bounds: bounds, now: start)
+
+        tracker.observe(outcome: .sample, quotas: quotas(used: 10), at: start, bounds: bounds)
+        var now = start
+        for _ in 0..<6 {
+            now = now.addingTimeInterval(tracker.interval)
+            tracker.observe(outcome: .sample, quotas: quotas(used: 10), at: now, bounds: bounds)
+        }
+        XCTAssertEqual(tracker.interval, 1800, "precondition: backed off to the ceiling")
+
+        now = now.addingTimeInterval(tracker.interval)
+        XCTAssertFalse(tracker.observe(outcome: .failed, quotas: quotas(used: 10), at: now, bounds: bounds))
+        XCTAssertEqual(tracker.interval, oneMinute, "a failure must not keep the 30 minute delay")
+
+        // Repeated failures stay at the retry cadence rather than growing.
+        for _ in 0..<5 {
+            now = now.addingTimeInterval(tracker.interval)
+            tracker.observe(outcome: .failed, quotas: [:], at: now, bounds: bounds)
+            XCTAssertEqual(tracker.interval, oneMinute)
+        }
+    }
+
+    /// A failure must not overwrite the baseline with data that was never
+    /// refreshed, or the first sample after it would look like a change.
+    func testFailedRefreshKeepsTheComparisonBaseline() {
+        let bounds = self.bounds(fast: oneMinute)
+        let start = Date(timeIntervalSince1970: 0)
+        var tracker = AdaptiveRefreshTracker(bounds: bounds, now: start)
+
+        tracker.observe(outcome: .sample, quotas: quotas(used: 10), at: start, bounds: bounds)
+        tracker.observe(outcome: .failed, quotas: [:], at: start.addingTimeInterval(60), bounds: bounds)
+
+        XCTAssertFalse(tracker.observe(
+            outcome: .sample,
+            quotas: quotas(used: 10),
+            at: start.addingTimeInterval(120),
+            bounds: bounds
+        ))
+        XCTAssertTrue(tracker.observe(
+            outcome: .sample,
+            quotas: quotas(used: 11),
+            at: start.addingTimeInterval(180),
+            bounds: bounds
+        ))
+    }
+
     // MARK: - Opt-out parity
 
+    /// The fixed cadences themselves are untouched by this feature.
     @MainActor
-    func testDisabledAdaptiveModeUsesExactlyTheFixedCadence() {
-        // When adaptive refresh is off the view model sleeps on
-        // `RefreshCadence.intervalNanoseconds`; assert those values are the
-        // untouched fixed cadences.
+    func testFixedCadenceConstantsAreUnchanged() {
         XCTAssertNil(RefreshCadence.manual.intervalSeconds)
         XCTAssertEqual(RefreshCadence.oneMinute.intervalSeconds, 60)
         XCTAssertEqual(RefreshCadence.twoMinutes.intervalSeconds, 120)

--- a/QuotioTests/AdaptiveRefreshPlannerTests.swift
+++ b/QuotioTests/AdaptiveRefreshPlannerTests.swift
@@ -1,0 +1,241 @@
+import XCTest
+@testable import Quotio
+
+final class AdaptiveRefreshPlannerTests: XCTestCase {
+
+    private let oneMinute: TimeInterval = 60
+
+    private func bounds(
+        fast: TimeInterval = 60,
+        grace: TimeInterval? = nil,
+        multiplier: Double = 2,
+        ceiling: TimeInterval = 1800
+    ) -> AdaptiveRefreshBounds {
+        AdaptiveRefreshBounds(
+            fastInterval: fast,
+            idleGrace: grace ?? fast * 2,
+            multiplier: multiplier,
+            maxInterval: ceiling
+        )
+    }
+
+    private func quotas(used: Int) -> [AIProvider: [String: ProviderQuotaData]] {
+        [
+            .claude: [
+                "user@example.com": ProviderQuotaData(
+                    models: [ModelQuota(name: "sonnet", percentage: 50, resetTime: "", used: used, limit: 100)]
+                )
+            ]
+        ]
+    }
+
+    // MARK: - Pure interval decision
+
+    func testActivityKeepsFastInterval() {
+        let bounds = self.bounds(fast: oneMinute)
+
+        // Just refreshed after activity: still the chosen cadence.
+        XCTAssertEqual(
+            AdaptiveRefreshPlanner.nextInterval(current: oneMinute, timeSinceLastActivity: 0, bounds: bounds),
+            oneMinute
+        )
+        // Inside the grace window: still the chosen cadence.
+        XCTAssertEqual(
+            AdaptiveRefreshPlanner.nextInterval(current: oneMinute, timeSinceLastActivity: 90, bounds: bounds),
+            oneMinute
+        )
+    }
+
+    func testIncreasingIdleBacksOffAndStopsAtCeiling() {
+        let bounds = self.bounds(fast: oneMinute, ceiling: 1800)
+
+        var interval = oneMinute
+        var idle: TimeInterval = 0
+        var sequence: [TimeInterval] = []
+
+        // Simulate 10 consecutive refreshes that observe no activity.
+        for _ in 0..<10 {
+            idle += interval
+            interval = AdaptiveRefreshPlanner.nextInterval(
+                current: interval,
+                timeSinceLastActivity: idle,
+                bounds: bounds
+            )
+            sequence.append(interval)
+        }
+
+        // 60s cadence -> one grace poll at 60s, then doubling to the 1800s ceiling.
+        XCTAssertEqual(sequence, [60, 120, 240, 480, 960, 1800, 1800, 1800, 1800, 1800])
+        XCTAssertLessThanOrEqual(sequence.max() ?? 0, bounds.ceiling)
+    }
+
+    func testCeilingNeverDropsBelowChosenCadence() {
+        // A 15 minute cadence with a 30 minute ceiling still backs off to 30 min.
+        let bounds = AdaptiveRefreshBounds(cadenceInterval: 900)
+        XCTAssertEqual(bounds.ceiling, 1800)
+
+        let backedOff = AdaptiveRefreshPlanner.nextInterval(
+            current: 900,
+            timeSinceLastActivity: 100_000,
+            bounds: bounds
+        )
+        XCTAssertEqual(backedOff, 1800)
+
+        // A cadence longer than the default ceiling is never shortened by adaptive mode.
+        let longBounds = AdaptiveRefreshBounds(cadenceInterval: 3600)
+        XCTAssertEqual(
+            AdaptiveRefreshPlanner.nextInterval(
+                current: 3600,
+                timeSinceLastActivity: 100_000,
+                bounds: longBounds
+            ),
+            3600
+        )
+    }
+
+    func testAdaptiveNeverRefreshesFasterThanChosenCadence() {
+        let bounds = self.bounds(fast: 300)
+
+        for idle in stride(from: 0.0, through: 7200.0, by: 60.0) {
+            let next = AdaptiveRefreshPlanner.nextInterval(
+                current: 300,
+                timeSinceLastActivity: idle,
+                bounds: bounds
+            )
+            XCTAssertGreaterThanOrEqual(next, 300, "idle=\(idle)")
+        }
+    }
+
+    // MARK: - Tracker driven by quota snapshots
+
+    func testTrackerBacksOffWhileUsageIsUnchanged() {
+        let bounds = self.bounds(fast: oneMinute)
+        let start = Date(timeIntervalSince1970: 0)
+        var tracker = AdaptiveRefreshTracker(bounds: bounds, now: start)
+
+        // Seed the baseline.
+        XCTAssertTrue(tracker.observe(quotas: quotas(used: 10), at: start, bounds: bounds))
+        XCTAssertEqual(tracker.interval, oneMinute)
+
+        var now = start
+        var observed: [TimeInterval] = []
+        for _ in 0..<6 {
+            now = now.addingTimeInterval(tracker.interval)
+            XCTAssertFalse(tracker.observe(quotas: quotas(used: 10), at: now, bounds: bounds))
+            observed.append(tracker.interval)
+        }
+
+        XCTAssertEqual(observed, [60, 120, 240, 480, 960, 1800])
+    }
+
+    func testTrackerResetsToFastIntervalWhenUsageMovesAgain() {
+        let bounds = self.bounds(fast: oneMinute)
+        let start = Date(timeIntervalSince1970: 0)
+        var tracker = AdaptiveRefreshTracker(bounds: bounds, now: start)
+
+        tracker.observe(quotas: quotas(used: 10), at: start, bounds: bounds)
+
+        var now = start
+        for _ in 0..<5 {
+            now = now.addingTimeInterval(tracker.interval)
+            tracker.observe(quotas: quotas(used: 10), at: now, bounds: bounds)
+        }
+        XCTAssertGreaterThan(tracker.interval, oneMinute)
+
+        // The user starts coding again: usage moves, cadence snaps back immediately.
+        now = now.addingTimeInterval(tracker.interval)
+        XCTAssertTrue(tracker.observe(quotas: quotas(used: 42), at: now, bounds: bounds))
+        XCTAssertEqual(tracker.interval, oneMinute)
+        XCTAssertEqual(tracker.lastActivityAt, now)
+    }
+
+    func testResetReturnsToFastInterval() {
+        let bounds = self.bounds(fast: oneMinute)
+        let start = Date(timeIntervalSince1970: 0)
+        var tracker = AdaptiveRefreshTracker(bounds: bounds, now: start)
+
+        tracker.observe(quotas: quotas(used: 10), at: start, bounds: bounds)
+        var now = start
+        for _ in 0..<4 {
+            now = now.addingTimeInterval(tracker.interval)
+            tracker.observe(quotas: quotas(used: 10), at: now, bounds: bounds)
+        }
+        XCTAssertGreaterThan(tracker.interval, oneMinute)
+
+        tracker.reset(bounds: bounds, now: now)
+        XCTAssertEqual(tracker.interval, oneMinute)
+    }
+
+    // MARK: - Signature
+
+    func testSignatureIgnoresRefreshTimestamps() {
+        let first = QuotaUsageSignature(quotas: [
+            .claude: ["a@example.com": ProviderQuotaData(
+                models: [ModelQuota(name: "sonnet", percentage: 50, resetTime: "", used: 10)],
+                lastUpdated: Date(timeIntervalSince1970: 0)
+            )]
+        ])
+        let second = QuotaUsageSignature(quotas: [
+            .claude: ["a@example.com": ProviderQuotaData(
+                models: [ModelQuota(name: "sonnet", percentage: 50, resetTime: "", used: 10)],
+                lastUpdated: Date(timeIntervalSince1970: 9999)
+            )]
+        ])
+
+        XCTAssertEqual(first, second)
+    }
+
+    func testSignatureTracksPercentageWhenUsedCountIsUnavailable() {
+        let before = QuotaUsageSignature(quotas: [
+            .codex: ["b@example.com": ProviderQuotaData(
+                models: [ModelQuota(name: "gpt", percentage: 100, resetTime: "")]
+            )]
+        ])
+        let after = QuotaUsageSignature(quotas: [
+            .codex: ["b@example.com": ProviderQuotaData(
+                models: [ModelQuota(name: "gpt", percentage: 0, resetTime: "")]
+            )]
+        ])
+
+        // Remaining 100% -> 0% is the 0 -> 100% usage jump described in issue #172.
+        XCTAssertNotEqual(before, after)
+    }
+
+    func testSignatureDetectsAccountAndModelChanges() {
+        let single = QuotaUsageSignature(quotas: quotas(used: 10))
+        var expanded = quotas(used: 10)
+        expanded[.claude]?["second@example.com"] = ProviderQuotaData(
+            models: [ModelQuota(name: "sonnet", percentage: 90, resetTime: "", used: 5)]
+        )
+
+        XCTAssertNotEqual(single, QuotaUsageSignature(quotas: expanded))
+    }
+
+    // MARK: - Opt-out parity
+
+    @MainActor
+    func testDisabledAdaptiveModeUsesExactlyTheFixedCadence() {
+        // When adaptive refresh is off the view model sleeps on
+        // `RefreshCadence.intervalNanoseconds`; assert those values are the
+        // untouched fixed cadences.
+        XCTAssertNil(RefreshCadence.manual.intervalSeconds)
+        XCTAssertEqual(RefreshCadence.oneMinute.intervalSeconds, 60)
+        XCTAssertEqual(RefreshCadence.twoMinutes.intervalSeconds, 120)
+        XCTAssertEqual(RefreshCadence.fiveMinutes.intervalSeconds, 300)
+        XCTAssertEqual(RefreshCadence.tenMinutes.intervalSeconds, 600)
+        XCTAssertEqual(RefreshCadence.fifteenMinutes.intervalSeconds, 900)
+
+        for cadence in RefreshCadence.allCases {
+            guard let seconds = cadence.intervalSeconds else { continue }
+            XCTAssertEqual(cadence.intervalNanoseconds, UInt64(seconds * 1_000_000_000))
+        }
+    }
+
+    func testAdaptiveBoundsDerivedFromCadence() {
+        let bounds = AdaptiveRefreshBounds(cadenceInterval: 120)
+        XCTAssertEqual(bounds.fastInterval, 120)
+        XCTAssertEqual(bounds.idleGrace, 240)
+        XCTAssertEqual(bounds.multiplier, 2)
+        XCTAssertEqual(bounds.maxInterval, 1800)
+    }
+}


### PR DESCRIPTION
## Motivation

Today the refresh interval is a single fixed value, and that value has to serve two opposite situations. As the reporter puts it in #172:

> 发现目前只能设置固定的时间进行数据更新，但是在使用的时候往往用量数据变化的很快，往往会出现 10 分钟后用量从 0 - 100 的情况；同理若是发现用户当前没有使用，可以退避到固定的时间刷新或者指数退避时间刷新

Translated: while you are actively coding, usage can jump from 0% to 100% inside one 10 minute window, so the default cadence shows stale numbers exactly when they matter. Conversely, when you are not using anything, a short cadence keeps polling provider APIs all night for identical data.

This PR adds an opt-in **Adaptive refresh** mode alongside the existing fixed cadences. It is **off by default**, so nothing changes for existing users unless they enable it.

## Behaviour

- **Fast interval** = the cadence already chosen in Settings. Adaptive mode can only slow refreshes down, never speed them up beyond what the user picked.
- **Active** (usage moved recently): keep refreshing at the fast interval.
- **Idle**: after a grace window of two fast intervals, the interval doubles per poll, capped at a **30 minute ceiling** (never below the chosen cadence, so the 15 min cadence yields 15 → 30 min).
- **Activity resumes**: the interval snaps straight back to the fast cadence on the poll that observes the change.

Backoff schedule with a 1 minute cadence: `60 → 60 → 120 → 240 → 480 → 960 → 1800 → 1800 …` seconds.

## Signal choice

The activity signal is **the quota usage numbers Quotio already fetches**, compared between two consecutive snapshots. Per row the value is the typed `QuotaMetricPresentation` where the provider supplies one (`.progress(used:)`, `.amount(value:)` — the Double-valued dollar/credit metrics used by Amp, OpenRouter, Factory Droid, Devin and GLM), otherwise the legacy `used` counter, otherwise the consumed percentage.

Why this one, rather than proxy request traffic (`RequestTracker`) or a running agent CLI process:

- It works in **Full and Monitor** modes. `RequestTracker` is only fed by `ProxyBridge` while the local proxy is running, so it is blind in Monitor mode, which is exactly where most quota-only users live.
- **Remote proxy mode is explicitly out of scope.** `refreshAllQuotas()` skips the local fetchers there and `refreshData()` does not populate `providerQuotas`, so there is no local activity signal to read. In Remote mode every automatic poll reports `.skipped`, the cadence stays exactly fixed, and the Settings toggle is hidden rather than offered as a setting that would do nothing.
- It requires **no new data source and no process spying** — it is computed from `providerQuotas`, which the refresh loop already produces.
- It measures the thing the issue is actually about: quota consumption moving. Traffic through the local proxy is a proxy for that (pun intended) and misses usage made directly by an agent that is not routed through Quotio.
- Refresh timestamps are deliberately excluded from the comparison, so re-fetching unchanged data never registers as activity.

The trade-off is that activity is detected at poll resolution: after a long idle period the first poll that observes new usage is what resets the cadence. Since the ceiling is 30 minutes and the reset is immediate on that poll, this keeps the worst case well inside what a fixed 10–15 minute cadence already gives, while staying fast for the whole active session.

## Implementation

- `Quotio/Services/AdaptiveRefreshPlanner.swift` (new)
  - `AdaptiveRefreshBounds` — tunables derived from the chosen cadence (fast interval, grace, multiplier, ceiling).
  - `AdaptiveRefreshPlanner.nextInterval(current:timeSinceLastActivity:bounds:)` — **pure, timer-free** cadence decision, the unit under test.
  - `QuotaUsageSignature` — usage snapshot used as the activity signal.
  - `AdaptiveRefreshTracker` — small `Sendable` value type that folds snapshots into the next interval. Still no timers, so it is directly testable.
- `RefreshSettingsManager` gains `adaptiveRefreshEnabled` (persisted, default `false`) and `adaptiveBounds`. Toggling it reuses the existing `onRefreshCadenceChanged` callback so the refresh loop restarts.
- `QuotaRefreshOutcome` (`.sample` / `.skipped` / `.failed`) is returned by `refreshAllQuotas()`, `refreshQuotasUnified()` and `refreshQuotasDirectly()`. Only `.sample` is evidence about the user: `.skipped` (coalesced early return, no local quota source, refresh not due) leaves both the cadence and the comparison baseline untouched, and `.failed` (empty result, or a provider the Monitor coordinator flagged) recovers the cadence to the user's interval so a backed-off delay never survives a failure.
- `QuotaViewModel`: the three auto-refresh loops (`startAutoRefresh`, `startQuotaOnlyAutoRefresh`, `startQuotaAutoRefreshWithoutProxy`) now sleep via `sleepUntilNextRefresh(fixedNanoseconds:)` and feed the **outcome of the refresh they awaited** into the tracker. With the toggle off, that helper sleeps on `RefreshCadence.intervalNanoseconds` exactly as before.
- `refreshData()` keeps a handle to the quota refresh it schedules (it still does not await it, so the management-API results reach the UI immediately). `performAutomaticRefresh()` awaits that handle before recording, so the automatic loop observes the refresh whose result it records instead of the previous poll's snapshot.
- `monitorStatus(for:)` uses the interval actually in effect for its staleness threshold, so a deliberately backed-off account is not mislabelled "outdated".
- **Coalescing and manual refresh untouched**: the adaptive interval is clamped to `>= fastInterval`, so it can never poll harder than fixed mode, and per-provider coalescing in `MonitorRefreshCoordinator` (#439/#440) still de-duplicates in-flight work. `manualRefresh()` is not modified.
- Settings UI: a toggle plus help text in the existing `RefreshCadenceSettingsSection`, hidden when the cadence is `manual` (nothing to adapt). New strings localized in en, fr, vi, zh-Hans.

## Test evidence

`QuotioTests/AdaptiveRefreshPlannerTests.swift` — pure cadence and signature logic:

- activity → fast interval (at zero idle and inside the grace window)
- increasing idle → `[60, 120, 240, 480, 960, 1800, 1800, …]` with the ceiling enforced
- ceiling never below the chosen cadence; a cadence longer than the ceiling is never shortened
- adaptive never returns an interval below the chosen cadence, swept over 0–2 h of idle time
- tracker driven by real `ProviderQuotaData` snapshots: backs off while usage is unchanged, snaps back to the fast interval the moment usage moves, `reset()` returns to fast
- signature ignores `lastUpdated`, tracks percentage when `used` is unavailable, and detects added accounts/models
- **typed metrics**: an Amp-style `.amount` balance (`percentage: -1`, no `used`) moving 20 → 12.5 and an OpenRouter-style `.progress` row moving 4.25 → 4.75 USD at an unchanged integer percentage both register as activity
- **outcome gating**: `.skipped` changes neither interval nor baseline; `.failed` pulls a 30 minute backoff back to the retry cadence and never overwrites the baseline
- fixed `RefreshCadence` interval constants are unchanged

`QuotioTests/AdaptiveRefreshIntegrationTests.swift` — runtime behaviour through `QuotaViewModel`:

- **ordering**: suspends inside the quota refresh and proves nothing is observed while the fetch is in flight, then that the recorded signature is the value the refresh wrote
- a coalesced (`.skipped`) poll does not back off even after the clock passes the idle grace window
- a `.failed` poll recovers a ceiling-level interval to the user's cadence
- **opt-out parity**: with the toggle off no tracker is armed for any cadence and the loop's computed sleep equals `cadence.intervalNanoseconds`, including after ten refreshes that would otherwise have backed off

```
xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build
** BUILD SUCCEEDED **

xcodebuild test -project Quotio.xcodeproj -scheme Quotio -destination 'platform=macOS'
** TEST SUCCEEDED **   (89 tests)
```

## Interaction with other open PRs

Trial-merged in a throwaway worktree (since removed). Pairwise onto this branch, **#480, #486, #472, #474, #485 and #476 all merge clean**. Cumulatively, #480 + #486 + #472 + #474 + #476 on top of this branch merges clean, builds, and the full suite passes.

#485 conflicts with #474 in `Quotio/QuotioApp.swift`, but that conflict reproduces on `master` with only those two applied and involves no file this PR touches, so it is between those two PRs and independent of this one.

Closes #172

