### PR TITLE
fix(amp): show subscription reset time

### DIFF
--- a/Quotio/Services/QuotaFetchers/AmpQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/AmpQuotaFetcher.swift
@@ -80,13 +80,14 @@ nonisolated enum AmpQuotaParser {
 
         var plan = identity.flatMap { $0[1].isEmpty ? nil : $0[1] }
         if let subscription = captures(
-            #"(?im)^\s*Subscription\s+([^:\r\n]+):\s*([\d.]+)%\s+(?:other|agent)\s+usage\s+and\s+([\d.]+)%\s+orb\s+usage\s+remaining\b"#,
+            #"(?im)^\s*Subscription\s+([^:\r\n]+):\s*([\d.]+)%\s+(?:other|agent)\s+usage\s+and\s+([\d.]+)%\s+orb\s+usage\s+remaining\b(?:\s*-\s*resets\s+upon\s+renewal\s+in\s+(\d+)\s+(minutes?|hours?|days?|weeks?|months?|years?))?"#,
             in: text
         ), let agent = validPercentage(subscription[1]),
            let orb = validPercentage(subscription[2]) {
             plan = subscription[0]
-            models.append(ModelQuota(name: "amp-agent-usage", percentage: agent, resetTime: ""))
-            models.append(ModelQuota(name: "amp-orb-usage", percentage: orb, resetTime: ""))
+            let resetTime = relativeResetTime(value: subscription[3], unit: subscription[4], after: now)
+            models.append(ModelQuota(name: "amp-agent-usage", percentage: agent, resetTime: resetTime))
+            models.append(ModelQuota(name: "amp-orb-usage", percentage: orb, resetTime: resetTime))
         } else {
             for match in allCaptures(
                 #"(?im)^\s*(agent|other|orb)(?:\s+(?:usage|quota))?\s*:\s*([\d.]+)%"#,
@@ -159,6 +160,25 @@ nonisolated enum AmpQuotaParser {
         let start = calendar.startOfDay(for: date)
         let next = calendar.date(byAdding: .day, value: 1, to: start)!
         return ISO8601DateFormatter().string(from: next)
+    }
+    private static func relativeResetTime(value: String, unit: String, after date: Date) -> String {
+        guard let value = Int(value) else { return "" }
+
+        let component: Calendar.Component
+        switch unit.lowercased() {
+        case "minute", "minutes": component = .minute
+        case "hour", "hours": component = .hour
+        case "day", "days": component = .day
+        case "week", "weeks": component = .weekOfYear
+        case "month", "months": component = .month
+        case "year", "years": component = .year
+        default: return ""
+        }
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        guard let resetDate = calendar.date(byAdding: component, value: value, to: date) else { return "" }
+        return ISO8601DateFormatter().string(from: resetDate)
     }
     private static func stableID(_ value: String) -> String {
         let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()

--- a/QuotioTests/AmpQuotaFetcherTests.swift
+++ b/QuotioTests/AmpQuotaFetcherTests.swift
@@ -75,19 +75,23 @@ final class AmpQuotaFetcherTests: XCTestCase {
     }
 
     func testParserMapsSubscriptionOtherUsageAndRenewalSuffix() throws {
-        let quota = try XCTUnwrap(AmpQuotaParser.parse(displayText:
-            "Subscription Megawatt: 82.5% other usage and 97.25% orb usage remaining - resets upon renewal in 1 month"
+        let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-11T12:00:00Z"))
+        let quota = try XCTUnwrap(AmpQuotaParser.parse(
+            displayText: "Subscription Megawatt: 64% other usage and 98% orb usage remaining - resets upon renewal in 22 days",
+            now: now
         ))
         let agent = try XCTUnwrap(quota.models.first(where: { $0.name == "amp-agent-usage" }))
         let orb = try XCTUnwrap(quota.models.first(where: { $0.name == "amp-orb-usage" }))
 
         XCTAssertEqual(quota.planType, "Megawatt")
-        XCTAssertEqual(agent.percentage, 82.5)
-        XCTAssertEqual(agent.usedPercentage, 17.5)
+        XCTAssertEqual(agent.percentage, 64)
+        XCTAssertEqual(agent.usedPercentage, 36)
         XCTAssertEqual(agent.displayName, "Agent Usage")
-        XCTAssertEqual(orb.percentage, 97.25)
-        XCTAssertEqual(orb.usedPercentage, 2.75)
+        XCTAssertEqual(agent.resetTime, "2026-09-02T12:00:00Z")
+        XCTAssertEqual(orb.percentage, 98)
+        XCTAssertEqual(orb.usedPercentage, 2)
         XCTAssertEqual(orb.displayName, "Orb Usage")
+        XCTAssertEqual(orb.resetTime, "2026-09-02T12:00:00Z")
     }
 
     func testParserUsesIdentityPlanWhenSubscriptionIsMissing() throws {


### PR DESCRIPTION
## Summary
- parse Amp subscription renewal durations from `userDisplayBalanceInfo`
- convert relative renewal durations to ISO-8601 reset timestamps for Agent and Orb usage
- add regression coverage based on the observed Megawatt response format

## Root cause
Amp returns subscription renewal timing as display text such as `resets upon renewal in 22 days`. The quota parser extracted the Agent and Orb percentages but discarded that suffix, leaving both reset times empty.

## Verification
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug test -only-testing:QuotioTests/AmpQuotaFetcherTests`
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build`