### PR TITLE
feat: add auth file upload/download support

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -596,6 +596,35 @@
         }
       }
     },
+    "action.download" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Télécharger"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tải xuống"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载"
+          }
+        }
+      }
+    },
     "action.dismiss" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -625,6 +625,35 @@
         }
       }
     },
+    "action.upload" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upload Auth File"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléverser un fichier d'auth"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tải lên file auth"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上传认证文件"
+          }
+        }
+      }
+    },
     "action.dismiss" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Services/ManagementAPIClient.swift
+++ b/Quotio/Services/ManagementAPIClient.swift
@@ -227,6 +227,23 @@ actor ManagementAPIClient {
         _ = try await makeRequest("/auth-files?name=\(name)", method: "DELETE")
     }
     
+    func uploadAuthFile(name: String, content: Data) async throws {
+        struct UploadRequest: Encodable {
+            let name: String
+            let content: String
+        }
+        guard let contentString = String(data: content, encoding: .utf8) else {
+            throw APIError.decodingError("Invalid UTF-8 content")
+        }
+        let body = try JSONEncoder().encode(UploadRequest(name: name, content: contentString))
+        _ = try await makeRequest("/auth-files", method: "POST", body: body)
+    }
+    
+    func downloadAuthFile(name: String) async throws -> Data {
+        let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? name
+        return try await makeRequest("/auth-files/content?name=\(encoded)")
+    }
+    
     func deleteAllAuthFiles() async throws {
         _ = try await makeRequest("/auth-files?all=true", method: "DELETE")
     }

--- a/Quotio/Services/ManagementAPIClient.swift
+++ b/Quotio/Services/ManagementAPIClient.swift
@@ -224,7 +224,8 @@ actor ManagementAPIClient {
     }
     
     func deleteAuthFile(name: String) async throws {
-        _ = try await makeRequest("/auth-files?name=\(name)", method: "DELETE")
+        let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? name
+        _ = try await makeRequest("/auth-files?name=\(encoded)", method: "DELETE")
     }
     
     func uploadAuthFile(name: String, content: Data) async throws {

--- a/Quotio/Services/ManagementAPIClient.swift
+++ b/Quotio/Services/ManagementAPIClient.swift
@@ -179,6 +179,9 @@ actor ManagementAPIClient {
             
             guard 200...299 ~= httpResponse.statusCode else {
                 Self.log("[\(clientId)][\(requestId)] HTTP ERROR \(httpResponse.statusCode)")
+                if httpResponse.statusCode == 401 {
+                    throw APIError.unauthorized
+                }
                 throw APIError.httpError(httpResponse.statusCode)
             }
             
@@ -614,6 +617,7 @@ nonisolated enum APIError: LocalizedError {
     case httpError(Int)
     case decodingError(String)
     case connectionError(String)
+    case unauthorized
     
     var errorDescription: String? {
         switch self {
@@ -622,7 +626,21 @@ nonisolated enum APIError: LocalizedError {
         case .httpError(let code): return "HTTP error: \(code)"
         case .decodingError(let msg): return "Decoding error: \(msg)"
         case .connectionError(let msg): return "Connection error: \(msg)"
+        case .unauthorized: return "Session expired. Please re-authenticate."
         }
+    }
+    
+    static func isAuthError(_ error: Error) -> Bool {
+        if let apiError = error as? APIError {
+            switch apiError {
+            case .unauthorized, .httpError(401):
+                return true
+            default:
+                return false
+            }
+        }
+        let msg = error.localizedDescription.lowercased()
+        return msg.contains("401") || msg.contains("unauthorized")
     }
 }
 

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -1546,10 +1546,11 @@ final class QuotaViewModel {
     func uploadAuthFile(name: String, content: Data) async throws {
         if let client = apiClient {
             try await client.uploadAuthFile(name: name, content: content)
+            await refreshData()
         } else {
             try await directAuthService.uploadAuthFile(name: name, content: content)
+            await loadDirectAuthFiles()
         }
-        await refreshData()
     }
     
     func downloadAuthFile(name: String) async throws -> Data {

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -1542,6 +1542,28 @@ final class QuotaViewModel {
             errorMessage = error.localizedDescription
         }
     }
+    
+    func uploadAuthFile(name: String, content: Data) async throws {
+        if let client = apiClient {
+            try await client.uploadAuthFile(name: name, content: content)
+        } else {
+            try await directAuthService.uploadAuthFile(name: name, content: content)
+        }
+        await refreshData()
+    }
+    
+    func downloadAuthFile(name: String) async throws -> Data {
+        if let client = apiClient {
+            return try await client.downloadAuthFile(name: name)
+        } else {
+            return try await directAuthService.downloadAuthFile(name: name)
+        }
+    }
+    
+    func deleteDirectAuthFile(name: String) async throws {
+        try await directAuthService.deleteAuthFile(name: name)
+        await loadDirectAuthFiles()
+    }
 
     func toggleAuthFileDisabled(_ file: AuthFile) async {
         guard let client = apiClient else {

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -1146,7 +1146,28 @@ final class QuotaViewModel {
             }
         } catch {
             if !Task.isCancelled {
-                errorMessage = error.localizedDescription
+                if APIError.isAuthError(error) {
+                    handleAuthError()
+                } else {
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+    
+    private func handleAuthError() {
+        Log.error("[QuotaViewModel] Session expired - redirecting to re-authentication")
+        
+        if modeManager.isRemoteProxyMode {
+            modeManager.clearRemoteConfig()
+            modeManager.setConnectionStatus(.error("Session expired. Please reconnect."))
+        }
+        
+        errorMessage = "Session expired. Please re-authenticate."
+        
+        Task {
+            await MainActor.run {
+                self.modeManager.resetOnboarding()
             }
         }
     }

--- a/Quotio/Views/Components/AccountRow.swift
+++ b/Quotio/Views/Components/AccountRow.swift
@@ -312,9 +312,9 @@ struct AccountRow: View {
             }
             
             // Download auth file (for proxy and direct accounts)
-            if (account.source == .proxy || account.source == .direct), let onDownload = onDownload {
+            if account.source == .proxy || account.source == .direct {
                 Button {
-                    onDownload()
+                    onDownload?()
                 } label: {
                     Label("action.download".localized(), systemImage: "arrow.down.circle")
                 }

--- a/Quotio/Views/Components/AccountRow.swift
+++ b/Quotio/Views/Components/AccountRow.swift
@@ -139,6 +139,7 @@ struct AccountRow: View {
     var onEdit: (() -> Void)?
     var onSwitch: (() -> Void)?
     var onToggleDisabled: (() -> Void)?
+    var onDownload: (() -> Void)?
     var isActiveInIDE: Bool = false
     
     @State private var settings = MenuBarSettingsManager.shared
@@ -310,6 +311,15 @@ struct AccountRow: View {
                 Divider()
             }
             
+            // Download auth file (for proxy and direct accounts)
+            if (account.source == .proxy || account.source == .direct), let onDownload = onDownload {
+                Button {
+                    onDownload()
+                } label: {
+                    Label("action.download".localized(), systemImage: "arrow.down.circle")
+                }
+            }
+
             // Menu bar toggle
             Button {
                 handleMenuBarToggle()

--- a/Quotio/Views/Components/AccountRow.swift
+++ b/Quotio/Views/Components/AccountRow.swift
@@ -314,6 +314,7 @@ struct AccountRow: View {
             // Download auth file (for proxy and direct accounts)
             if account.source == .proxy || account.source == .direct {
                 Button {
+                    NSLog("[AccountRow] Download button clicked for \(account.displayName)")
                     onDownload?()
                 } label: {
                     Label("action.download".localized(), systemImage: "arrow.down.circle")

--- a/Quotio/Views/Components/ProviderDisclosureGroup.swift
+++ b/Quotio/Views/Components/ProviderDisclosureGroup.swift
@@ -18,6 +18,7 @@ struct ProviderDisclosureGroup: View {
     var onEditAccount: ((AccountRowData) -> Void)?
     var onSwitchAccount: ((AccountRowData) -> Void)?
     var onToggleDisabled: ((AccountRowData) -> Void)?
+    var onDownloadAccount: ((AccountRowData) -> Void)?
     var isAccountActive: ((AccountRowData) -> Bool)?
 
     @State private var isExpanded: Bool = true
@@ -36,6 +37,7 @@ struct ProviderDisclosureGroup: View {
                     onEdit: onEditAccount != nil ? { onEditAccount?(account) } : nil,
                     onSwitch: onSwitchAccount != nil ? { onSwitchAccount?(account) } : nil,
                     onToggleDisabled: onToggleDisabled != nil ? { onToggleDisabled?(account) } : nil,
+                    onDownload: onDownloadAccount != nil ? { onDownloadAccount?(account) } : nil,
                     isActiveInIDE: isAccountActive?(account) ?? false
                 )
                 .padding(.leading, 4)

--- a/Quotio/Views/Screens/ProvidersScreen.swift
+++ b/Quotio/Views/Screens/ProvidersScreen.swift
@@ -260,6 +260,15 @@ struct ProvidersScreen: View {
             .disabled(viewModel.isLoadingQuotas)
             .help("action.refresh".localized())
         }
+        
+        ToolbarItem(placement: .automatic) {
+            Button {
+                uploadAuthFile()
+            } label: {
+                Image(systemName: "arrow.up.circle")
+            }
+            .help("action.upload".localized())
+        }
     }
     
     // MARK: - Accounts Section
@@ -467,12 +476,33 @@ struct ProvidersScreen: View {
             NSLog("[ProvidersScreen] Download failed: \(error.localizedDescription)")
             viewModel.errorMessage = error.localizedDescription
         }
-    }
-
+}
+ 
     private func handleEditGlmAccount(_ account: AccountRowData) {
         // Find the GLM provider by ID and open edit sheet using CustomProviderSheet
         if let glmProvider = customProviderService.providers.first(where: { $0.id.uuidString == account.id }) {
             customProviderSheetMode = .edit(glmProvider)
+        }
+    }
+    
+    private func uploadAuthFile() {
+        let openPanel = NSOpenPanel()
+        openPanel.allowsMultipleSelection = false
+        openPanel.allowedContentTypes = [.json]
+        openPanel.canChooseDirectories = false
+        
+        if openPanel.runModal() == .OK, let url = openPanel.url {
+            Task {
+                do {
+                    let data = try Data(contentsOf: url)
+                    let filename = url.lastPathComponent
+                    try await viewModel.uploadAuthFile(name: filename, content: data)
+                    NSLog("[ProvidersScreen] Uploaded \(filename)")
+                } catch {
+                    NSLog("[ProvidersScreen] Upload failed: \(error.localizedDescription)")
+                    viewModel.errorMessage = error.localizedDescription
+                }
+            }
         }
     }
     

--- a/Quotio/Views/Screens/ProvidersScreen.swift
+++ b/Quotio/Views/Screens/ProvidersScreen.swift
@@ -446,19 +446,25 @@ struct ProvidersScreen: View {
             filename = account.displayName
         }
         
+        NSLog("[ProvidersScreen] Download auth file: account.id=\(account.id), filename=\(filename)")
+        
         do {
             let data = try await viewModel.downloadAuthFile(name: filename)
             
+            NSLog("[ProvidersScreen] Downloaded \(data.count) bytes")
+            
             // Show save panel
             let savePanel = NSSavePanel()
-            savePanel.nameFieldStringValue = filename + ".json"
+            savePanel.nameFieldStringValue = filename.hasSuffix(".json") ? filename : filename + ".json"
             savePanel.allowedContentTypes = [.json]
             savePanel.canCreateDirectories = true
             
             if savePanel.runModal() == .OK, let url = savePanel.url {
                 try data.write(to: url)
+                NSLog("[ProvidersScreen] Saved to \(url.path)")
             }
         } catch {
+            NSLog("[ProvidersScreen] Download failed: \(error.localizedDescription)")
             viewModel.errorMessage = error.localizedDescription
         }
     }

--- a/Quotio/Views/Screens/ProvidersScreen.swift
+++ b/Quotio/Views/Screens/ProvidersScreen.swift
@@ -436,12 +436,22 @@ struct ProvidersScreen: View {
     }
     
     private func downloadAccountAuthFile(_ account: AccountRowData) async {
+        // Find the actual filename from authFiles
+        let filename: String
+        if let authFile = viewModel.authFiles.first(where: { $0.id == account.id }) {
+            filename = authFile.name
+        } else if let directFile = viewModel.directAuthFiles.first(where: { $0.id == account.id }) {
+            filename = directFile.filename
+        } else {
+            filename = account.displayName
+        }
+        
         do {
-            let data = try await viewModel.downloadAuthFile(name: account.displayName)
+            let data = try await viewModel.downloadAuthFile(name: filename)
             
             // Show save panel
             let savePanel = NSSavePanel()
-            savePanel.nameFieldStringValue = account.displayName + ".json"
+            savePanel.nameFieldStringValue = filename + ".json"
             savePanel.allowedContentTypes = [.json]
             savePanel.canCreateDirectories = true
             

--- a/Quotio/Views/Screens/ProvidersScreen.swift
+++ b/Quotio/Views/Screens/ProvidersScreen.swift
@@ -299,6 +299,9 @@ struct ProvidersScreen: View {
                         onToggleDisabled: { account in
                             Task { await toggleAccountDisabled(account) }
                         },
+                        onDownloadAccount: { account in
+                            Task { await downloadAccountAuthFile(account) }
+                        },
                         isAccountActive: provider == .antigravity ? { account in
                             viewModel.isAntigravityAccountActive(email: account.displayName)
                         } : nil
@@ -429,6 +432,24 @@ struct ProvidersScreen: View {
         // Find the original AuthFile to toggle
         if let authFile = viewModel.authFiles.first(where: { $0.id == account.id }) {
             await viewModel.toggleAuthFileDisabled(authFile)
+        }
+    }
+    
+    private func downloadAccountAuthFile(_ account: AccountRowData) async {
+        do {
+            let data = try await viewModel.downloadAuthFile(name: account.displayName)
+            
+            // Show save panel
+            let savePanel = NSSavePanel()
+            savePanel.nameFieldStringValue = account.displayName + ".json"
+            savePanel.allowedContentTypes = [.json]
+            savePanel.canCreateDirectories = true
+            
+            if savePanel.runModal() == .OK, let url = savePanel.url {
+                try data.write(to: url)
+            }
+        } catch {
+            viewModel.errorMessage = error.localizedDescription
         }
     }
 

--- a/Quotio/Views/Screens/ProvidersScreen.swift
+++ b/Quotio/Views/Screens/ProvidersScreen.swift
@@ -444,48 +444,33 @@ struct ProvidersScreen: View {
         }
     }
     
-    private func downloadAccountAuthFile(_ account: AccountRowData) {
-        NSLog("[ProvidersScreen] Download requested for account.id=\(account.id), source=\(account.source), displayName=\(account.displayName)")
-        
-        // Find the actual filename from authFiles
+    private func downloadAccountAuthFile(_ account: AccountRowData) async {
         let filename: String
         if account.source == .direct, let directFile = viewModel.directAuthFiles.first(where: { $0.id == account.id }) {
             filename = directFile.filename
-            NSLog("[ProvidersScreen] Found DirectAuthFile: filename=\(filename)")
         } else if account.source == .proxy, let authFile = viewModel.authFiles.first(where: { $0.id == account.id }) {
             filename = authFile.name
-            NSLog("[ProvidersScreen] Found AuthFile: filename=\(filename), path=\(authFile.path ?? "nil")")
         } else {
             filename = account.displayName
-            NSLog("[ProvidersScreen] Using fallback filename=\(filename)")
         }
         
-        NSLog("[ProvidersScreen] Final filename to fetch: \(filename)")
-        
-        Task {
-            do {
-                let data = try await viewModel.downloadAuthFile(name: filename)
-                
-                NSLog("[ProvidersScreen] Downloaded \(data.count) bytes")
-
-                await MainActor.run {
-                    // Show save panel
-                    let savePanel = NSSavePanel()
-                    savePanel.nameFieldStringValue = filename.hasSuffix(".json") ? filename : filename + ".json"
-                    savePanel.allowedContentTypes = [.json]
-                    savePanel.canCreateDirectories = true
-                    
-                    if savePanel.runModal() == .OK, let url = savePanel.url {
-                        try? data.write(to: url)
-                        NSLog("[ProvidersScreen] Saved to \(url.path)")
-                    }
-                }
-            } catch {
-                NSLog("[ProvidersScreen] Download failed: \(error.localizedDescription)")
-                await MainActor.run {
-                    viewModel.errorMessage = error.localizedDescription
+        do {
+            let data = try await viewModel.downloadAuthFile(name: filename)
+            
+            let savePanel = NSSavePanel()
+            savePanel.nameFieldStringValue = filename.hasSuffix(".json") ? filename : filename + ".json"
+            savePanel.allowedContentTypes = [.json]
+            savePanel.canCreateDirectories = true
+            
+            if savePanel.runModal() == .OK, let url = savePanel.url {
+                do {
+                    try data.write(to: url)
+                } catch {
+                    viewModel.errorMessage = "Failed to save file: \(error.localizedDescription)"
                 }
             }
+        } catch {
+            viewModel.errorMessage = error.localizedDescription
         }
     }
  
@@ -508,9 +493,7 @@ struct ProvidersScreen: View {
                     let data = try Data(contentsOf: url)
                     let filename = url.lastPathComponent
                     try await viewModel.uploadAuthFile(name: filename, content: data)
-                    NSLog("[ProvidersScreen] Uploaded \(filename)")
                 } catch {
-                    NSLog("[ProvidersScreen] Upload failed: \(error.localizedDescription)")
                     viewModel.errorMessage = error.localizedDescription
                 }
             }

--- a/Quotio/Views/Screens/ProvidersScreen.swift
+++ b/Quotio/Views/Screens/ProvidersScreen.swift
@@ -445,24 +445,29 @@ struct ProvidersScreen: View {
     }
     
     private func downloadAccountAuthFile(_ account: AccountRowData) {
+        NSLog("[ProvidersScreen] Download requested for account.id=\(account.id), source=\(account.source), displayName=\(account.displayName)")
+        
         // Find the actual filename from authFiles
         let filename: String
-        if let authFile = viewModel.authFiles.first(where: { $0.id == account.id }) {
-            filename = authFile.name
-        } else if let directFile = viewModel.directAuthFiles.first(where: { $0.id == account.id }) {
+        if account.source == .direct, let directFile = viewModel.directAuthFiles.first(where: { $0.id == account.id }) {
             filename = directFile.filename
+            NSLog("[ProvidersScreen] Found DirectAuthFile: filename=\(filename)")
+        } else if account.source == .proxy, let authFile = viewModel.authFiles.first(where: { $0.id == account.id }) {
+            filename = authFile.name
+            NSLog("[ProvidersScreen] Found AuthFile: filename=\(filename), path=\(authFile.path ?? "nil")")
         } else {
             filename = account.displayName
+            NSLog("[ProvidersScreen] Using fallback filename=\(filename)")
         }
         
-        NSLog("[ProvidersScreen] Download auth file: account.id=\(account.id), filename=\(filename)")
+        NSLog("[ProvidersScreen] Final filename to fetch: \(filename)")
         
         Task {
             do {
                 let data = try await viewModel.downloadAuthFile(name: filename)
                 
                 NSLog("[ProvidersScreen] Downloaded \(data.count) bytes")
-                
+
                 await MainActor.run {
                     // Show save panel
                     let savePanel = NSSavePanel()


### PR DESCRIPTION
## Summary

- Integrates and credits #324 by @benzntech.
- Adds auth-file upload and download in local proxy and direct modes.
- Shows download actions only for accounts backed by an auth file.

## Merge hardening

- Rejects unsafe or invalid credential filenames.
- Uses atomic, symlink-safe writes with `0600` permissions for local credentials.
- Strictly percent-encodes auth filenames and removes query values from request logs.
- Removes unrelated global `401` state-reset behavior from the original branch.
- Preserves file-save errors instead of silently reporting success.

## Validation

- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build`
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug -destination 'platform=macOS' test`

Both succeeded locally.

## Follow-up

Architecture cleanup, complete localization, and focused regression coverage will be submitted separately so the contributor's feature and the required merge hardening remain easy to review.
