### PR TITLE
feat(menu-bar): stack Claude 5h and weekly quota

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -16828,6 +16828,35 @@
         }
       }
     },
+    "settings.menubar.stackClaudeQuotaWindows" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stack Claude 5h and weekly quota"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empiler les quotas Claude sur 5 h et hebdomadaire"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xếp chồng quota Claude 5 giờ và hàng tuần"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "堆叠显示 Claude 5 小时和每周配额"
+          }
+        }
+      }
+    },
     "settings.networkAccess" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Quotio/Models/MenuBarSettings.swift
+++ b/Quotio/Models/MenuBarSettings.swift
@@ -400,6 +400,24 @@ final class RefreshSettingsManager {
 
 // MARK: - Menu Bar Quota Display Item
 
+/// Claude quota windows rendered together in the compact menu bar layout.
+nonisolated struct MenuBarQuotaWindows: Equatable, Sendable {
+    let fiveHourPercentage: Double
+    let weeklyPercentage: Double
+
+    static func claude(from models: [ModelQuota]) -> MenuBarQuotaWindows? {
+        let fiveHour = models.first { $0.name == "five-hour-session" }?.percentage
+        let weekly = models.first { $0.name == "seven-day-weekly" }?.percentage
+
+        guard fiveHour != nil || weekly != nil else { return nil }
+
+        return MenuBarQuotaWindows(
+            fiveHourPercentage: fiveHour ?? -1,
+            weeklyPercentage: weekly ?? -1
+        )
+    }
+}
+
 /// Data for displaying a single quota item in menu bar
 struct MenuBarQuotaDisplayItem: Identifiable {
     let id: String
@@ -408,8 +426,13 @@ struct MenuBarQuotaDisplayItem: Identifiable {
     let percentage: Double
     let provider: AIProvider
     var isForbidden: Bool = false
+    var quotaWindows: MenuBarQuotaWindows? = nil
     
     var statusColor: Color {
+        statusColor(for: percentage)
+    }
+
+    func statusColor(for percentage: Double) -> Color {
         if isForbidden { return .orange }
         if percentage > 50 { return .green }
         if percentage > 20 { return .orange }
@@ -433,6 +456,7 @@ final class MenuBarSettingsManager {
     private let menuBarMaxItemsKey = "menuBarMaxItems"
     private let quotaDisplayModeKey = "quotaDisplayMode"
     private let quotaDisplayStyleKey = "quotaDisplayStyle"
+    private let stackClaudeQuotaWindowsKey = "menuBarStackClaudeQuotaWindows"
     private let hideSensitiveInfoKey = "hideSensitiveInfo"
     private let totalUsageModeKey = "totalUsageMode"
     private let modelAggregationModeKey = "modelAggregationMode"
@@ -478,6 +502,11 @@ final class MenuBarSettingsManager {
     /// Visual style for quota display
     var quotaDisplayStyle: QuotaDisplayStyle {
         didSet { defaults.set(quotaDisplayStyle.rawValue, forKey: quotaDisplayStyleKey) }
+    }
+
+    /// Whether Claude's 5-hour and weekly windows are stacked in the menu bar.
+    var stackClaudeQuotaWindows: Bool {
+        didSet { defaults.set(stackClaudeQuotaWindows, forKey: stackClaudeQuotaWindowsKey) }
     }
     
     /// Whether to hide sensitive information (emails, account names)
@@ -533,6 +562,10 @@ final class MenuBarSettingsManager {
         self.colorMode = MenuBarColorMode(rawValue: defaults.string(forKey: colorModeKey) ?? "") ?? .colored
         self.quotaDisplayMode = QuotaDisplayMode(rawValue: defaults.string(forKey: quotaDisplayModeKey) ?? "") ?? .used
         self.quotaDisplayStyle = QuotaDisplayStyle(rawValue: defaults.string(forKey: quotaDisplayStyleKey) ?? "") ?? .card
+        if defaults.object(forKey: stackClaudeQuotaWindowsKey) == nil {
+            defaults.set(true, forKey: stackClaudeQuotaWindowsKey)
+        }
+        self.stackClaudeQuotaWindows = defaults.bool(forKey: stackClaudeQuotaWindowsKey)
         self.selectedItems = Self.loadSelectedItems(from: defaults, key: selectedItemsKey)
 
         // Load and clamp menuBarMaxItems, then persist the clamped value

--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -111,6 +111,7 @@ final class AppBootstrap {
 
             var displayPercent: Double = -1
             var isForbidden = false
+            var quotaWindows: MenuBarQuotaWindows?
 
             if let accountQuotas = viewModel.providerQuotas[provider],
                let quotaData = resolveQuotaData(
@@ -122,6 +123,9 @@ final class AppBootstrap {
                 if !quotaData.models.isEmpty {
                     let models = quotaData.models.map { (name: $0.name, percentage: $0.percentage) }
                     displayPercent = menuBarSettings.totalUsagePercent(models: models)
+                    if provider == .claude && menuBarSettings.stackClaudeQuotaWindows {
+                        quotaWindows = MenuBarQuotaWindows.claude(from: quotaData.models)
+                    }
                 }
             }
 
@@ -131,7 +135,8 @@ final class AppBootstrap {
                 accountShort: selectedItem.accountKey,
                 percentage: displayPercent,
                 provider: provider,
-                isForbidden: isForbidden
+                isForbidden: isForbidden,
+                quotaWindows: quotaWindows
             ))
         }
 
@@ -225,6 +230,9 @@ struct QuotioApp: App {
                         bootstrap.updateStatusBar()
                     }
                     .onChange(of: menuBarSettings.colorMode) {
+                        bootstrap.updateStatusBar()
+                    }
+                    .onChange(of: menuBarSettings.stackClaudeQuotaWindows) {
                         bootstrap.updateStatusBar()
                     }
                     .onChange(of: menuBarSettings.totalUsageMode) {

--- a/Quotio/Services/StatusBarManager.swift
+++ b/Quotio/Services/StatusBarManager.swift
@@ -82,8 +82,9 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
         let hostingView = NSHostingView(rootView: contentView)
         hostingView.setFrameSize(hostingView.intrinsicContentSize)
         
-        // Add horizontal padding to align with native status bar spacing
-        let horizontalPadding: CGFloat = 4
+        // Keep the status item close to neighboring macOS menu bar icons.
+        // StatusBarQuotaView already sizes its content, so only a small click-edge inset is needed.
+        let horizontalPadding: CGFloat = 1
         let contentSize = hostingView.intrinsicContentSize
         let containerSize = NSSize(
             width: contentSize.width + horizontalPadding * 2,
@@ -218,7 +219,6 @@ struct StatusBarQuotaView: View {
                 StatusBarQuotaItemView(item: item, colorMode: colorMode)
             }
         }
-        .padding(.horizontal, 4)
         .frame(height: 22)
         .fixedSize()
     }

--- a/Quotio/Services/StatusBarManager.swift
+++ b/Quotio/Services/StatusBarManager.swift
@@ -253,6 +253,14 @@ struct StatusBarQuotaItemView: View {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: 10))
                     .foregroundStyle(.orange)
+            } else if let quotaWindows = item.quotaWindows {
+                VStack(alignment: .trailing, spacing: -1) {
+                    compactQuotaText(quotaWindows.fiveHourPercentage)
+                    compactQuotaText(quotaWindows.weeklyPercentage)
+                }
+                .frame(height: 18)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(quotaWindowsAccessibilityLabel(quotaWindows))
             } else if item.percentage >= 0 {
                 Text(formatPercentage(displayPercent))
                     .font(.system(size: 11, weight: .medium, design: .monospaced))
@@ -268,5 +276,34 @@ struct StatusBarQuotaItemView: View {
         // Defensive clamp to valid 0-100 range
         let clamped = min(100, max(0, value))
         return String(format: "%.0f%%", clamped.rounded())
+    }
+
+    private func compactQuotaText(_ remainingValue: Double) -> some View {
+        let displayedValue = remainingValue < 0
+            ? -1
+            : settings.quotaDisplayMode.displayValue(from: remainingValue)
+        let quotaColor: Color = remainingValue < 0
+            ? .secondary
+            : item.statusColor(for: remainingValue)
+
+        return Text(formatPercentage(displayedValue))
+            .font(.system(size: 8.5, weight: .semibold, design: .monospaced))
+            .foregroundStyle(colorMode == .colored ? quotaColor : .primary)
+            .fixedSize()
+    }
+
+    private func quotaWindowsAccessibilityLabel(_ windows: MenuBarQuotaWindows) -> String {
+        let displayMode = settings.quotaDisplayMode
+        let fiveHour = formatPercentage(
+            windows.fiveHourPercentage < 0
+                ? -1
+                : displayMode.displayValue(from: windows.fiveHourPercentage)
+        )
+        let weekly = formatPercentage(
+            windows.weeklyPercentage < 0
+                ? -1
+                : displayMode.displayValue(from: windows.weeklyPercentage)
+        )
+        return "\("clinepass.quota.fiveHour".localized()): \(fiveHour), \("quota.metric.weekly".localized()): \(weekly)"
     }
 }

--- a/Quotio/Views/Screens/SettingsScreen.swift
+++ b/Quotio/Views/Screens/SettingsScreen.swift
@@ -1723,6 +1723,13 @@ struct MenuBarSettingsSection: View {
             set: { settings.colorMode = $0 }
         )
     }
+
+    private var stackClaudeQuotaWindowsBinding: Binding<Bool> {
+        Binding(
+            get: { settings.stackClaudeQuotaWindows },
+            set: { settings.stackClaudeQuotaWindows = $0 }
+        )
+    }
     
     private var maxItemsBinding: Binding<Int> {
         Binding(
@@ -1752,6 +1759,11 @@ struct MenuBarSettingsSection: View {
                 Toggle("settings.menubar.showQuota".localized(), isOn: showQuotaBinding)
                 
                 if settings.showQuotaInMenuBar {
+                    Toggle(
+                        "settings.menubar.stackClaudeQuotaWindows".localized(),
+                        isOn: stackClaudeQuotaWindowsBinding
+                    )
+
                     HStack {
                         Text("settings.menubar.maxItems".localized())
                         Spacer()

--- a/QuotioTests/MenuBarQuotaWindowsTests.swift
+++ b/QuotioTests/MenuBarQuotaWindowsTests.swift
@@ -1,0 +1,61 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import Quotio
+
+final class MenuBarQuotaWindowsTests: XCTestCase {
+    func testClaudeWindowsUseFiveHourAndWeeklyModels() {
+        let models = [
+            ModelQuota(name: "five-hour-session", percentage: 81, resetTime: ""),
+            ModelQuota(name: "seven-day-weekly", percentage: 63, resetTime: ""),
+            ModelQuota(name: "seven-day-sonnet", percentage: 12, resetTime: ""),
+        ]
+
+        XCTAssertEqual(
+            MenuBarQuotaWindows.claude(from: models),
+            MenuBarQuotaWindows(fiveHourPercentage: 81, weeklyPercentage: 63)
+        )
+    }
+
+    func testClaudeWindowsRepresentAMissingWindowAsUnknown() {
+        let models = [
+            ModelQuota(name: "five-hour-session", percentage: 42, resetTime: ""),
+        ]
+
+        XCTAssertEqual(
+            MenuBarQuotaWindows.claude(from: models),
+            MenuBarQuotaWindows(fiveHourPercentage: 42, weeklyPercentage: -1)
+        )
+    }
+
+    func testClaudeWindowsAreAbsentForUnrelatedModels() {
+        let models = [
+            ModelQuota(name: "seven-day-sonnet", percentage: 70, resetTime: ""),
+        ]
+
+        XCTAssertNil(MenuBarQuotaWindows.claude(from: models))
+    }
+
+    @MainActor
+    func testCompactClaudeQuotaViewFitsMenuBarHeight() {
+        let item = MenuBarQuotaDisplayItem(
+            id: "claude-test",
+            providerSymbol: "C",
+            accountShort: "test",
+            percentage: 63,
+            provider: .claude,
+            quotaWindows: MenuBarQuotaWindows(
+                fiveHourPercentage: 81,
+                weeklyPercentage: 63
+            )
+        )
+        let hostingView = NSHostingView(
+            rootView: StatusBarQuotaItemView(item: item, colorMode: .monochrome)
+        )
+
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertLessThanOrEqual(hostingView.fittingSize.height, 22)
+        XCTAssertLessThan(hostingView.fittingSize.width, 50)
+    }
+}

--- a/QuotioTests/MenuBarQuotaWindowsTests.swift
+++ b/QuotioTests/MenuBarQuotaWindowsTests.swift
@@ -56,6 +56,6 @@ final class MenuBarQuotaWindowsTests: XCTestCase {
         hostingView.layoutSubtreeIfNeeded()
 
         XCTAssertLessThanOrEqual(hostingView.fittingSize.height, 22)
-        XCTAssertLessThan(hostingView.fittingSize.width, 50)
+        XCTAssertLessThan(hostingView.fittingSize.width, 40)
     }
 }


### PR DESCRIPTION
## Summary

- show Claude's 5-hour session quota above its weekly quota in one compact menu bar item
- add a persistent **Stack Claude 5h and weekly quota** toggle under Settings > Menu Bar, enabled by default
- preserve the existing aggregate display when the toggle is off, and leave other providers unchanged
- keep the status item narrow with a 22-point height, localized accessibility labels, and balanced click-edge spacing

## Why

Claude exposes separate 5-hour and 7-day limits, but the current menu bar item reduces them to one aggregate percentage. Seeing both windows at a glance makes the menu bar substantially more useful while avoiding an additional status item.

Top row: 5-hour session. Bottom row: weekly quota.

![Compact Claude 5-hour and weekly quota in the macOS menu bar](https://raw.githubusercontent.com/afu-it/quotio/28a94b9351404d3c843ee974d528ed7146e48a2e/.github/pr-assets/compact-claude-quota-menu-bar.png)

## Testing

- `xcodebuild test -project Quotio.xcodeproj -scheme Quotio -configuration Debug -destination 'platform=macOS'`
- 75 tests passed, including model selection, missing-window fallback, and compact fitting-size coverage
- manually verified the menu bar layout and live toggle on macOS
