### PR TITLE
fix(yubikey): avoid key export prompts

### DIFF
--- a/Quotio/Services/YubiKeySecretVault.swift
+++ b/Quotio/Services/YubiKeySecretVault.swift
@@ -297,12 +297,12 @@ nonisolated enum YubiKeySecretVault {
             guard let privateKey = privateKey(for: identity),
                   let attributes = SecKeyCopyAttributes(privateKey) as? [String: Any],
                   isPIVToken(attributes[kSecAttrTokenID as String] as? String),
-                  let publicKey = SecKeyCopyPublicKey(privateKey),
+                  let certificate = certificate(for: identity),
+                  // Export the certificate's public key, not one derived from the
+                  // token's private key, which makes macOS request authorization.
+                  let publicKey = SecCertificateCopyKey(certificate),
                   SecKeyIsAlgorithmSupported(publicKey, .encrypt, .rsaEncryptionOAEPSHA256),
                   let external = SecKeyCopyExternalRepresentation(publicKey, nil) as Data? else { return nil }
-            var certificate: SecCertificate?
-            guard SecIdentityCopyCertificate(identity, &certificate) == errSecSuccess,
-                  let certificate else { return nil }
             let summary = SecCertificateCopySubjectSummary(certificate) as String? ?? "PIV key"
             let fingerprint = SHA256.hash(data: external).map { String(format: "%02x", $0) }.joined()
             return YubiKeyPIVIdentity(id: fingerprint, name: summary, fingerprint: fingerprint, identity: identity)
@@ -375,9 +375,13 @@ nonisolated enum YubiKeySecretVault {
     }
 
     private static func publicKey(for identity: SecIdentity) -> SecKey? {
-        var key: SecKey?
-        guard SecIdentityCopyPrivateKey(identity, &key) == errSecSuccess, let key else { return nil }
-        return SecKeyCopyPublicKey(key)
+        guard let certificate = certificate(for: identity) else { return nil }
+        return SecCertificateCopyKey(certificate)
+    }
+
+    private static func certificate(for identity: SecIdentity) -> SecCertificate? {
+        var certificate: SecCertificate?
+        return SecIdentityCopyCertificate(identity, &certificate) == errSecSuccess ? certificate : nil
     }
 
     private static func privateKey(for identity: SecIdentity) -> SecKey? {


### PR DESCRIPTION
This follow-up to #490 prevents macOS from asking users to authorize exporting a YubiKey-backed key when Quotio launches. The vault now reads the RSA public key from the identity certificate instead of deriving it from the token private key, while preserving the existing public-key representation and stored fingerprint.

- Avoid exporting a public key derived from the YubiKey private key during identity discovery.
- Use the certificate public key for vault encryption so public operations remain off-token.
- Preserve compatibility with fingerprints and encrypted vault data created by #490.

Validation:
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build`
- Targeted PIV identity tests in `MonitorRuntimeTests`
- Confirmed certificate-derived and private-key-derived RSA public representations are byte-identical.

Refs #490
