### PR TITLE
fix(menubar): normalize status bar icon and quota spacing to match ma…

### DIFF
--- a/Quotio/Services/StatusBarManager.swift
+++ b/Quotio/Services/StatusBarManager.swift
@@ -68,32 +68,34 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
         button.title = ""
         button.image = nil
         
-        let contentView: AnyView
         if !showQuota || !isRunning || items.isEmpty {
-            contentView = AnyView(
-                StatusBarDefaultView(isRunning: isRunning)
-            )
-        } else {
-            contentView = AnyView(
-                StatusBarQuotaView(items: items, colorMode: colorMode)
-            )
+            let imageName = isRunning ? "gauge.with.dots.needle.67percent" : "gauge.with.dots.needle.0percent"
+            if let image = NSImage(systemSymbolName: imageName, accessibilityDescription: "Quotio") {
+                image.isTemplate = true
+                button.image = image
+                button.imagePosition = .imageOnly
+            }
+            statusItem?.length = NSStatusItem.variableLength
+            return
         }
+        
+        let contentView = AnyView(
+            StatusBarQuotaView(items: items, colorMode: colorMode)
+        )
         
         let hostingView = NSHostingView(rootView: contentView)
         hostingView.setFrameSize(hostingView.intrinsicContentSize)
         
-        // Add horizontal padding to align with native status bar spacing
-        let horizontalPadding: CGFloat = 4
         let contentSize = hostingView.intrinsicContentSize
         let containerSize = NSSize(
-            width: contentSize.width + horizontalPadding * 2,
+            width: contentSize.width,
             height: max(22, contentSize.height)
         )
         
         let containerView = StatusBarContainerView(frame: NSRect(origin: .zero, size: containerSize))
         containerView.addSubview(hostingView)
         hostingView.frame = NSRect(
-            x: horizontalPadding,
+            x: 0,
             y: (containerSize.height - contentSize.height) / 2,
             width: contentSize.width,
             height: contentSize.height
@@ -218,7 +220,6 @@ struct StatusBarQuotaView: View {
                 StatusBarQuotaItemView(item: item, colorMode: colorMode)
             }
         }
-        .padding(.horizontal, 4)
         .frame(height: 22)
         .fixedSize()
     }


### PR DESCRIPTION
### Summary

Fixes the menu bar item having excessive horizontal whitespace on both sides, bringing it to standard macOS menu bar spacing and sizing.

### Cause of the Issue

1. **Default Icon Mode**: When displaying only the status bar icon (no quota shown or proxy stopped), `StatusBarDefaultView` was wrapped in an `NSHostingView` inside a `StatusBarContainerView` with hardcoded `horizontalPadding = 4`, artificially inflating `statusItem.length` and adding unwanted whitespace.
2. **Quota Mode**: `StatusBarQuotaView` had `.padding(.horizontal, 4)` while `StatusBarManager` also added `horizontalPadding: CGFloat = 4` to container width, resulting in cumulative double-padding (16pt total whitespace).

### Changes

- **Default Icon**: Use native `NSStatusBarButton.image` with template rendering and `NSStatusItem.variableLength` for pixel-perfect native macOS status item spacing and click highlight.
- **Quota Display**: Removed redundant `.padding(.horizontal, 4)` in `StatusBarQuotaView` and container horizontal padding in `StatusBarManager.swift` so the status bar item fits its content snugly.

### Verification

- [x] Verified default icon mode uses native macOS system spacing and highlights cleanly.
- [x] Verified quota display mode renders provider icons and percentages without extra blank margins.
- [x] Conforms to project guidelines and invariants in `AGENTS.md`.
