### PR TITLE
fix(menubar): render native template image to eliminate glow and unfocused blur

### DIFF
--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -95,6 +95,7 @@ final class AppBootstrap {
         statusBarManager.updateStatusBar(
             items: quotaItems,
             colorMode: menuBarSettings.colorMode,
+            quotaDisplayMode: menuBarSettings.quotaDisplayMode,
             isRunning: hasQuotaData,
             showMenuBarIcon: menuBarSettings.showMenuBarIcon,
             showQuota: menuBarSettings.showQuotaInMenuBar
@@ -237,6 +238,10 @@ struct QuotioApp: App {
                     }
                     .onChange(of: menuBarSettings.colorMode) {
                         bootstrap.updateStatusBar()
+                    }
+                    .onChange(of: menuBarSettings.quotaDisplayMode) {
+                        bootstrap.updateStatusBar()
+                        statusBarManager.rebuildMenuInPlace()
                     }
                     .onChange(of: menuBarSettings.stackPairedQuotaMetrics) {
                         bootstrap.updateStatusBar()

--- a/Quotio/Services/StatusBarManager.swift
+++ b/Quotio/Services/StatusBarManager.swift
@@ -42,6 +42,7 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
     func updateStatusBar(
         items: [MenuBarQuotaDisplayItem],
         colorMode: MenuBarColorMode,
+        quotaDisplayMode: QuotaDisplayMode,
         isRunning: Bool,
         showMenuBarIcon: Bool,
         showQuota: Bool
@@ -80,11 +81,20 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
                 button.image = image
                 button.imagePosition = .imageOnly
             }
+            button.setAccessibilityLabel("Quotio")
             statusItem?.length = NSStatusItem.variableLength
             return
         }
         
-        let quotaView = StatusBarQuotaView(items: items, colorMode: colorMode)
+        let colorScheme: ColorScheme = button.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? .dark : .light
+        
+        let quotaView = StatusBarQuotaView(
+            items: items,
+            colorMode: colorMode,
+            quotaDisplayMode: quotaDisplayMode
+        )
+        .environment(\.colorScheme, colorScheme)
+        
         let renderer = ImageRenderer(content: quotaView)
         let scale = targetBackingScaleFactor
         renderer.scale = scale
@@ -98,10 +108,37 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
             if colorMode == .monochrome {
                 image.isTemplate = true
             }
+            
+            let description = accessibilityDescription(for: items, displayMode: quotaDisplayMode)
+            image.accessibilityDescription = description
+            button.setAccessibilityLabel(description)
+            
             button.image = image
             button.imagePosition = .imageOnly
             statusItem?.length = width
         }
+    }
+    
+    private func accessibilityDescription(for items: [MenuBarQuotaDisplayItem], displayMode: QuotaDisplayMode) -> String {
+        let itemDescriptions = items.map { item -> String in
+            let providerName = item.provider.displayName
+            if item.isForbidden {
+                return "\(providerName): \("status.error".localized())"
+            }
+            if let pair = item.quotaPair {
+                let topDesc = "\(pair.top.labelKey.localized()): \(StatusBarQuotaItemView.accessibilityValue(for: pair.top, displayMode: displayMode))"
+                let bottomDesc = "\(pair.bottom.labelKey.localized()): \(StatusBarQuotaItemView.accessibilityValue(for: pair.bottom, displayMode: displayMode))"
+                return "\(providerName): \(topDesc), \(bottomDesc)"
+            }
+            if item.percentage >= 0 {
+                let displayedValue = displayMode.displayValue(from: item.percentage)
+                let clamped = min(100, max(0, displayedValue))
+                let percentString = String(format: "%lld percent".localized(), Int64(clamped.rounded()))
+                return "\(providerName): \(percentString)"
+            }
+            return "\(providerName): \("quota.noDataYet".localized())"
+        }
+        return "Quotio, " + itemDescriptions.joined(separator: ", ")
     }
     
     // MARK: - NSMenuDelegate
@@ -198,13 +235,19 @@ struct StatusBarDefaultView: View {
 struct StatusBarQuotaView: View {
     let items: [MenuBarQuotaDisplayItem]
     let colorMode: MenuBarColorMode
+    let quotaDisplayMode: QuotaDisplayMode
     
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: 8) {
             ForEach(items) { item in
-                StatusBarQuotaItemView(item: item, colorMode: colorMode)
+                StatusBarQuotaItemView(
+                    item: item,
+                    colorMode: colorMode,
+                    quotaDisplayMode: quotaDisplayMode
+                )
             }
         }
+        .padding(.horizontal, 4)
         .frame(height: 22)
         .fixedSize()
     }
@@ -215,25 +258,10 @@ struct StatusBarQuotaView: View {
 struct StatusBarQuotaItemView: View {
     let item: MenuBarQuotaDisplayItem
     let colorMode: MenuBarColorMode
-    
-    @State private var settings = MenuBarSettingsManager.shared
-    
-    private var defaultTextColor: Color {
-        .primary
-    }
-    
-    private var symbolColor: Color {
-        colorMode == .colored ? item.provider.color : defaultTextColor
-    }
-    
-    private func textColor(for remainingPercentage: Double) -> Color {
-        guard colorMode == .colored else { return defaultTextColor }
-        return remainingPercentage < 0 ? Color(nsColor: .secondaryLabelColor) : item.statusColor(for: remainingPercentage)
-    }
+    var quotaDisplayMode: QuotaDisplayMode = .used
     
     var body: some View {
-        let displayMode = settings.quotaDisplayMode
-        let displayPercent = displayMode.displayValue(from: item.percentage)
+        let displayPercent = quotaDisplayMode.displayValue(from: item.percentage)
         
         HStack(spacing: 2) {
             if let assetName = item.provider.menuBarIconAsset {
@@ -244,7 +272,7 @@ struct StatusBarQuotaItemView: View {
             } else {
                 Text(item.provider.menuBarSymbol)
                     .font(.system(size: 11, weight: .semibold, design: .rounded))
-                    .foregroundStyle(symbolColor)
+                    .foregroundStyle(colorMode == .colored ? item.provider.color : .primary)
                     .fixedSize()
             }
             
@@ -258,12 +286,10 @@ struct StatusBarQuotaItemView: View {
                     compactQuotaText(quotaPair.bottom.remainingPercentage)
                 }
                 .frame(height: 18)
-                .accessibilityElement(children: .ignore)
-                .accessibilityLabel(quotaPairAccessibilityLabel(quotaPair))
             } else if item.percentage >= 0 {
                 Text(formatPercentage(displayPercent))
                     .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundStyle(textColor(for: item.percentage))
+                    .foregroundStyle(colorMode == .colored ? item.statusColor : .primary)
                     .fixedSize()
             }
         }
@@ -280,17 +306,15 @@ struct StatusBarQuotaItemView: View {
     private func compactQuotaText(_ remainingValue: Double) -> some View {
         let displayedValue = remainingValue < 0
             ? -1
-            : settings.quotaDisplayMode.displayValue(from: remainingValue)
+            : quotaDisplayMode.displayValue(from: remainingValue)
+        let quotaColor: Color = remainingValue < 0
+            ? .secondary
+            : item.statusColor(for: remainingValue)
 
         return Text(formatPercentage(displayedValue))
             .font(.system(size: 8.5, weight: .semibold, design: .monospaced))
-            .foregroundStyle(textColor(for: remainingValue))
+            .foregroundStyle(colorMode == .colored ? quotaColor : .primary)
             .fixedSize()
-    }
-
-    private func quotaPairAccessibilityLabel(_ pair: MenuBarQuotaPair) -> String {
-        "\(pair.top.labelKey.localized()): \(Self.accessibilityValue(for: pair.top, displayMode: settings.quotaDisplayMode)), "
-            + "\(pair.bottom.labelKey.localized()): \(Self.accessibilityValue(for: pair.bottom, displayMode: settings.quotaDisplayMode))"
     }
 
     static func accessibilityValue(for metric: MenuBarQuotaMetric, displayMode: QuotaDisplayMode) -> String {

--- a/Quotio/Services/StatusBarManager.swift
+++ b/Quotio/Services/StatusBarManager.swift
@@ -34,6 +34,11 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
         MenuActionHandler.shared.viewModel = viewModel
     }
     
+    /// Highest backing scale factor across all active screens to ensure sharp rendering in multi-monitor setups
+    private var targetBackingScaleFactor: CGFloat {
+        NSScreen.screens.map(\.backingScaleFactor).max() ?? 2.0
+    }
+    
     func updateStatusBar(
         items: [MenuBarQuotaDisplayItem],
         colorMode: MenuBarColorMode,
@@ -68,39 +73,35 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
         button.title = ""
         button.image = nil
         
-        let contentView: AnyView
         if !showQuota || !isRunning || items.isEmpty {
-            contentView = AnyView(
-                StatusBarDefaultView(isRunning: isRunning)
-            )
-        } else {
-            contentView = AnyView(
-                StatusBarQuotaView(items: items, colorMode: colorMode)
-            )
+            let imageName = isRunning ? "gauge.with.dots.needle.67percent" : "gauge.with.dots.needle.0percent"
+            if let image = NSImage(systemSymbolName: imageName, accessibilityDescription: "Quotio") {
+                image.isTemplate = true
+                button.image = image
+                button.imagePosition = .imageOnly
+            }
+            statusItem?.length = NSStatusItem.variableLength
+            return
         }
         
-        let hostingView = NSHostingView(rootView: contentView)
-        hostingView.setFrameSize(hostingView.intrinsicContentSize)
+        let quotaView = StatusBarQuotaView(items: items, colorMode: colorMode)
+        let renderer = ImageRenderer(content: quotaView)
+        let scale = targetBackingScaleFactor
+        renderer.scale = scale
+        renderer.isOpaque = false
         
-        // Add horizontal padding to align with native status bar spacing
-        let horizontalPadding: CGFloat = 4
-        let contentSize = hostingView.intrinsicContentSize
-        let containerSize = NSSize(
-            width: contentSize.width + horizontalPadding * 2,
-            height: max(22, contentSize.height)
-        )
-        
-        let containerView = StatusBarContainerView(frame: NSRect(origin: .zero, size: containerSize))
-        containerView.addSubview(hostingView)
-        hostingView.frame = NSRect(
-            x: horizontalPadding,
-            y: (containerSize.height - contentSize.height) / 2,
-            width: contentSize.width,
-            height: contentSize.height
-        )
-        
-        button.addSubview(containerView)
-        statusItem?.length = containerSize.width
+        if let cgImage = renderer.cgImage {
+            let width = CGFloat(cgImage.width) / scale
+            let height = CGFloat(cgImage.height) / scale
+            let size = NSSize(width: width, height: height)
+            let image = NSImage(cgImage: cgImage, size: size)
+            if colorMode == .monochrome {
+                image.isTemplate = true
+            }
+            button.image = image
+            button.imagePosition = .imageOnly
+            statusItem?.length = width
+        }
     }
     
     // MARK: - NSMenuDelegate
@@ -180,20 +181,6 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
     }
 }
 
-// MARK: - Status Bar Container View
-
-final class StatusBarContainerView: NSView {
-    override var allowsVibrancy: Bool { true }
-    
-    override func mouseDown(with event: NSEvent) {
-        superview?.mouseDown(with: event)
-    }
-    
-    override func mouseUp(with event: NSEvent) {
-        superview?.mouseUp(with: event)
-    }
-}
-
 // MARK: - Status Bar Default View
 
 struct StatusBarDefaultView: View {
@@ -218,7 +205,6 @@ struct StatusBarQuotaView: View {
                 StatusBarQuotaItemView(item: item, colorMode: colorMode)
             }
         }
-        .padding(.horizontal, 4)
         .frame(height: 22)
         .fixedSize()
     }
@@ -231,6 +217,19 @@ struct StatusBarQuotaItemView: View {
     let colorMode: MenuBarColorMode
     
     @State private var settings = MenuBarSettingsManager.shared
+    
+    private var defaultTextColor: Color {
+        .primary
+    }
+    
+    private var symbolColor: Color {
+        colorMode == .colored ? item.provider.color : defaultTextColor
+    }
+    
+    private func textColor(for remainingPercentage: Double) -> Color {
+        guard colorMode == .colored else { return defaultTextColor }
+        return remainingPercentage < 0 ? Color(nsColor: .secondaryLabelColor) : item.statusColor(for: remainingPercentage)
+    }
     
     var body: some View {
         let displayMode = settings.quotaDisplayMode
@@ -245,7 +244,7 @@ struct StatusBarQuotaItemView: View {
             } else {
                 Text(item.provider.menuBarSymbol)
                     .font(.system(size: 11, weight: .semibold, design: .rounded))
-                    .foregroundStyle(colorMode == .colored ? item.provider.color : .primary)
+                    .foregroundStyle(symbolColor)
                     .fixedSize()
             }
             
@@ -254,7 +253,7 @@ struct StatusBarQuotaItemView: View {
                     .font(.system(size: 10))
                     .foregroundStyle(.orange)
             } else if let quotaPair = item.quotaPair {
-                VStack(alignment: .trailing, spacing: -1) {
+                VStack(alignment: .trailing, spacing: 0) {
                     compactQuotaText(quotaPair.top.remainingPercentage)
                     compactQuotaText(quotaPair.bottom.remainingPercentage)
                 }
@@ -264,7 +263,7 @@ struct StatusBarQuotaItemView: View {
             } else if item.percentage >= 0 {
                 Text(formatPercentage(displayPercent))
                     .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundStyle(colorMode == .colored ? item.statusColor : .primary)
+                    .foregroundStyle(textColor(for: item.percentage))
                     .fixedSize()
             }
         }
@@ -282,13 +281,10 @@ struct StatusBarQuotaItemView: View {
         let displayedValue = remainingValue < 0
             ? -1
             : settings.quotaDisplayMode.displayValue(from: remainingValue)
-        let quotaColor: Color = remainingValue < 0
-            ? .secondary
-            : item.statusColor(for: remainingValue)
 
         return Text(formatPercentage(displayedValue))
             .font(.system(size: 8.5, weight: .semibold, design: .monospaced))
-            .foregroundStyle(colorMode == .colored ? quotaColor : .primary)
+            .foregroundStyle(textColor(for: remainingValue))
             .fixedSize()
     }
 


### PR DESCRIPTION
### Summary

- Fixes the menu bar unfocused blur, washed-out text, and vibrancy glow when the menu bar window is inactive on secondary/inactive displays.
- Renders the status bar quota content directly into a native template `NSImage` via `ImageRenderer` on `NSStatusBarButton.image`, eliminating the need for `NSHostingView` subview layers.
- Uses `targetBackingScaleFactor` derived from `NSScreen.screens` to dynamically preserve maximum resolution across multi-monitor setups without scale drops when switching focus.
- Removes intermediate `StatusBarContainerView` class and restores canonical AppKit event handling.
- Keeps typography font sizes, weights, and provider icon assets completely unchanged from master for minimal diff.