### PR TITLE
fix(monitor): refresh Factory Droid credentials

### DIFF
--- a/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
@@ -3,6 +3,7 @@ import Foundation
 
 nonisolated struct FactoryDroidCredential: Sendable, Equatable {
     let accessToken: String
+    let refreshToken: String?
     let activeOrganizationID: String?
     let sourcePath: String
 
@@ -59,6 +60,54 @@ nonisolated enum FactoryDroidCredentialReader {
         return parseCredential(decrypted, sourcePath: sourcePath)
     }
 
+    @discardableResult
+    static func persistRefresh(
+        sourcePath: String,
+        expectedRefreshToken: String,
+        accessToken: String,
+        refreshToken: String?
+    ) throws -> Bool {
+        let credentialsURL = URL(fileURLWithPath: sourcePath)
+        let storedData = try Data(contentsOf: credentialsURL)
+        let keyData: Data? = if credentialsURL.lastPathComponent == "auth.v2.file" {
+            try? Data(contentsOf: credentialsURL.deletingLastPathComponent().appendingPathComponent("auth.v2.key"))
+        } else {
+            KeychainHelper.readExternalCredential(service: "Factory CLI", account: "auth-encryption-key")
+        }
+
+        let cleartext: Data
+        let encryptionKey: Data?
+        let encrypted = String(data: storedData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let json = try? JSONSerialization.jsonObject(with: storedData) as? [String: Any],
+           json["access_token"] != nil {
+            cleartext = storedData
+            encryptionKey = nil
+        } else if let encrypted,
+                  let key = normalizedKey(keyData),
+                  let decrypted = decrypt(encrypted, key: key) {
+            cleartext = decrypted
+            encryptionKey = key
+        } else {
+            throw MonitorRuntimeError.invalidCredential
+        }
+
+        guard var json = try JSONSerialization.jsonObject(with: cleartext) as? [String: Any],
+              trimmed(json["refresh_token"] as? String) == expectedRefreshToken else { return false }
+        json["access_token"] = accessToken
+        json["refresh_token"] = refreshToken ?? expectedRefreshToken
+        let updated = try JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])
+        let output = if let key = encryptionKey {
+            try encrypt(updated, key: key)
+        } else {
+            updated
+        }
+
+        guard (try? Data(contentsOf: credentialsURL)) == storedData else { return false }
+        try SecureAtomicFileWriter.write(output, to: credentialsURL)
+        return true
+    }
+
     private static func loadEncrypted(credentialsURL: URL, keyData: Data?) -> FactoryDroidCredential? {
         guard let encrypted = try? String(contentsOf: credentialsURL, encoding: .utf8),
               let keyData else { return nil }
@@ -92,11 +141,22 @@ nonisolated enum FactoryDroidCredentialReader {
         return try? AES.GCM.open(sealedBox, using: SymmetricKey(data: key))
     }
 
+    private static func encrypt(_ cleartext: Data, key: Data) throws -> Data {
+        let nonce = try AES.GCM.Nonce(data: Data((0..<16).map { _ in UInt8.random(in: .min ... .max) }))
+        let sealed = try AES.GCM.seal(cleartext, using: SymmetricKey(data: key), nonce: nonce)
+        return Data([
+            Data(nonce).base64EncodedString(),
+            sealed.tag.base64EncodedString(),
+            sealed.ciphertext.base64EncodedString(),
+        ].joined(separator: ":").utf8)
+    }
+
     private static func parseCredential(_ data: Data, sourcePath: String) -> FactoryDroidCredential? {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let accessToken = trimmed(json["access_token"] as? String) else { return nil }
         return FactoryDroidCredential(
             accessToken: accessToken,
+            refreshToken: trimmed(json["refresh_token"] as? String),
             activeOrganizationID: trimmed(json["active_organization_id"] as? String),
             sourcePath: sourcePath
         )
@@ -126,6 +186,16 @@ nonisolated struct FactoryDroidAuthMeResponse: Decodable, Sendable {
         guard let email = userProfile?.email?.trimmingCharacters(in: .whitespacesAndNewlines),
               !email.isEmpty else { return nil }
         return email
+    }
+}
+
+nonisolated struct FactoryDroidTokenRefreshResponse: Decodable, Sendable {
+    let accessToken: String
+    let refreshToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
     }
 }
 
@@ -245,11 +315,14 @@ nonisolated enum FactoryDroidQuotaMapper {
 }
 
 actor FactoryDroidQuotaFetcher {
+    private static let workOSClientID = "client_01HNM792M5G5G1A2THWPXKFMXB"
+
     private let vault: MonitorCredentialStore
     private let metadata: MonitorMetadataStore
     private var session: URLSession
     private let limitsURL = URL(string: "https://api.factory.ai/api/billing/limits")!
     private let profileURL = URL(string: "https://api.factory.ai/api/app/auth/me")!
+    private let refreshURL = URL(string: "https://api.workos.com/user_management/authenticate")!
 
     init(
         vault: MonitorCredentialStore = MonitorCredentialVault.shared,
@@ -271,7 +344,7 @@ actor FactoryDroidQuotaFetcher {
         if let localCredential = FactoryDroidCredentialReader.load() {
             let account = Self.localAccount(for: localCredential)
             if !disabledAccountIDs.contains(account.id),
-               let quota = await fetch(accessToken: localCredential.accessToken) {
+               let quota = await fetch(localCredential: localCredential) {
                 results[account.accountKey] = quota
             }
         }
@@ -291,7 +364,7 @@ actor FactoryDroidQuotaFetcher {
         if let localCredential = FactoryDroidCredentialReader.load() {
             let account = Self.localAccount(for: localCredential)
             if account.accountKey == accountKey && !disabledAccountIDs.contains(account.id) {
-                return await fetch(accessToken: localCredential.accessToken)
+                return await fetch(localCredential: localCredential)
             }
         }
 
@@ -311,6 +384,90 @@ actor FactoryDroidQuotaFetcher {
             source: .nativeCredential,
             credentialReference: credential.sourcePath
         )
+    }
+
+    nonisolated static func makeRefreshRequest(
+        refreshToken: String,
+        organizationID: String?,
+        url: URL = URL(string: "https://api.workos.com/user_management/authenticate")!
+    ) -> URLRequest {
+        var items = [
+            URLQueryItem(name: "grant_type", value: "refresh_token"),
+            URLQueryItem(name: "refresh_token", value: refreshToken),
+            URLQueryItem(name: "client_id", value: workOSClientID),
+        ]
+        if let organizationID { items.append(URLQueryItem(name: "organization_id", value: organizationID)) }
+        var components = URLComponents()
+        components.queryItems = items
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = Data((components.percentEncodedQuery ?? "").utf8)
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        return request
+    }
+
+    private func fetch(localCredential: FactoryDroidCredential) async -> ProviderQuotaData? {
+        var credential = localCredential
+        var didRefresh = false
+        if Self.isExpiring(accessToken: credential.accessToken),
+           let refreshed = await refresh(credential) {
+            credential = refreshed
+            didRefresh = true
+        }
+
+        var quota = await fetch(accessToken: credential.accessToken)
+        if quota?.isForbidden == true, !didRefresh,
+           let refreshed = await refresh(credential) {
+            quota = await fetch(accessToken: refreshed.accessToken)
+        }
+        return quota
+    }
+
+    private func refresh(_ credential: FactoryDroidCredential) async -> FactoryDroidCredential? {
+        guard let refreshToken = credential.refreshToken else { return nil }
+        let request = Self.makeRefreshRequest(
+            refreshToken: refreshToken,
+            organizationID: credential.activeOrganizationID,
+            url: refreshURL
+        )
+        guard let (data, response) = try? await session.data(for: request),
+              let http = response as? HTTPURLResponse,
+              200...299 ~= http.statusCode,
+              let refreshed = try? JSONDecoder().decode(FactoryDroidTokenRefreshResponse.self, from: data) else {
+            return nil
+        }
+
+        do {
+            try FactoryDroidCredentialReader.persistRefresh(
+                sourcePath: credential.sourcePath,
+                expectedRefreshToken: refreshToken,
+                accessToken: refreshed.accessToken,
+                refreshToken: refreshed.refreshToken
+            )
+        } catch {
+            Log.quota("Failed to persist refreshed Factory Droid credential")
+        }
+        return FactoryDroidCredential(
+            accessToken: refreshed.accessToken,
+            refreshToken: refreshed.refreshToken ?? refreshToken,
+            activeOrganizationID: credential.activeOrganizationID,
+            sourcePath: credential.sourcePath
+        )
+    }
+
+    private nonisolated static func isExpiring(accessToken: String, leeway: TimeInterval = 60) -> Bool {
+        let pieces = accessToken.split(separator: ".", omittingEmptySubsequences: false)
+        guard pieces.count == 3 else { return true }
+        var payload = String(pieces[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        payload += String(repeating: "=", count: (4 - payload.count % 4) % 4)
+        guard let data = Data(base64Encoded: payload),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let expiry = json["exp"] as? NSNumber else { return true }
+        return Date().addingTimeInterval(leeway).timeIntervalSince1970 >= expiry.doubleValue
     }
 
     private func fetch(accessToken: String) async -> ProviderQuotaData? {

--- a/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
@@ -1,4 +1,5 @@
 import CryptoKit
+import Darwin
 import Foundation
 
 nonisolated struct FactoryDroidCredential: Sendable, Equatable {
@@ -72,44 +73,45 @@ nonisolated enum FactoryDroidCredentialReader {
            values.isSymbolicLink == true {
             throw MonitorRuntimeError.symbolicLinkRefused
         }
-        let storedData = try Data(contentsOf: credentialsURL)
-        let keyData: Data? = if credentialsURL.lastPathComponent == "auth.v2.file" {
-            try? Data(contentsOf: credentialsURL.deletingLastPathComponent().appendingPathComponent("auth.v2.key"))
-        } else {
-            KeychainHelper.readExternalCredential(service: "Factory CLI", account: "auth-encryption-key")
-        }
+        return try withDroidCredentialWriteLock(directory: credentialsURL.deletingLastPathComponent()) {
+            let storedData = try Data(contentsOf: credentialsURL)
+            let keyData: Data? = if credentialsURL.lastPathComponent == "auth.v2.file" {
+                try? Data(contentsOf: credentialsURL.deletingLastPathComponent().appendingPathComponent("auth.v2.key"))
+            } else {
+                KeychainHelper.readExternalCredential(service: "Factory CLI", account: "auth-encryption-key")
+            }
 
-        let cleartext: Data
-        let encryptionKey: Data?
-        let encrypted = String(data: storedData, encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        if let json = try? JSONSerialization.jsonObject(with: storedData) as? [String: Any],
-           json["access_token"] != nil {
-            cleartext = storedData
-            encryptionKey = nil
-        } else if let encrypted,
-                  let key = normalizedKey(keyData),
-                  let decrypted = decrypt(encrypted, key: key) {
-            cleartext = decrypted
-            encryptionKey = key
-        } else {
-            throw MonitorRuntimeError.invalidCredential
-        }
+            let cleartext: Data
+            let encryptionKey: Data?
+            let encrypted = String(data: storedData, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if let json = try? JSONSerialization.jsonObject(with: storedData) as? [String: Any],
+               json["access_token"] != nil {
+                cleartext = storedData
+                encryptionKey = nil
+            } else if let encrypted,
+                      let key = normalizedKey(keyData),
+                      let decrypted = decrypt(encrypted, key: key) {
+                cleartext = decrypted
+                encryptionKey = key
+            } else {
+                throw MonitorRuntimeError.invalidCredential
+            }
 
-        guard var json = try JSONSerialization.jsonObject(with: cleartext) as? [String: Any],
-              trimmed(json["refresh_token"] as? String) == expectedRefreshToken else { return false }
-        json["access_token"] = accessToken
-        json["refresh_token"] = refreshToken ?? expectedRefreshToken
-        let updated = try JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])
-        let output = if let key = encryptionKey {
-            try encrypt(updated, key: key)
-        } else {
-            updated
-        }
+            guard var json = try JSONSerialization.jsonObject(with: cleartext) as? [String: Any],
+                  trimmed(json["refresh_token"] as? String) == expectedRefreshToken else { return false }
+            json["access_token"] = accessToken
+            json["refresh_token"] = refreshToken ?? expectedRefreshToken
+            let updated = try JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])
+            let output = if let key = encryptionKey {
+                try encrypt(updated, key: key)
+            } else {
+                updated
+            }
 
-        guard (try? Data(contentsOf: credentialsURL)) == storedData else { return false }
-        try SecureAtomicFileWriter.write(output, to: credentialsURL)
-        return true
+            try SecureAtomicFileWriter.write(output, to: credentialsURL)
+            return true
+        }
     }
 
     static func canPersistRefresh(sourcePath: String, expectedRefreshToken: String) -> Bool {
@@ -144,6 +146,43 @@ nonisolated enum FactoryDroidCredentialReader {
             keyData: keyData,
             sourcePath: credentialsURL.path
         )
+    }
+
+    private static func withDroidCredentialWriteLock<T>(directory: URL, operation: () throws -> T) throws -> T {
+        let manager = FileManager.default
+        let lockURL = directory.appendingPathComponent("auth.v2.write.lock", isDirectory: true)
+        let token = UUID().uuidString
+        let pendingURL = directory.appendingPathComponent("auth.v2.write.lock.\(token).pending", isDirectory: true)
+        try manager.createDirectory(
+            at: pendingURL,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
+        defer { try? manager.removeItem(at: pendingURL) }
+        let ownerData = try JSONSerialization.data(withJSONObject: [
+            "token": token,
+            "pid": ProcessInfo.processInfo.processIdentifier,
+        ])
+        let ownerURL = pendingURL.appendingPathComponent("owner.json")
+        try ownerData.write(to: ownerURL, options: .withoutOverwriting)
+        try manager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: ownerURL.path)
+
+        let deadline = Date().addingTimeInterval(2)
+        while rename(pendingURL.path, lockURL.path) != 0 {
+            guard [EEXIST, ENOTEMPTY, ENOTDIR, EISDIR].contains(errno), Date() < deadline else {
+                throw MonitorRuntimeError.credentialWriteFailed
+            }
+            Thread.sleep(forTimeInterval: 0.015)
+        }
+
+        defer {
+            if let data = try? Data(contentsOf: lockURL.appendingPathComponent("owner.json")),
+               let owner = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               owner["token"] as? String == token {
+                try? manager.removeItem(at: lockURL)
+            }
+        }
+        return try operation()
     }
 
     private static func normalizedKey(_ data: Data?) -> Data? {

--- a/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
@@ -116,11 +116,13 @@ nonisolated enum FactoryDroidCredentialReader {
 
     static func canPersistRefresh(sourcePath: String, expectedRefreshToken: String) -> Bool {
         let credentialsURL = URL(fileURLWithPath: sourcePath)
+        let credentialsDirectory = credentialsURL.deletingLastPathComponent()
         if let values = try? credentialsURL.resourceValues(forKeys: [.isSymbolicLinkKey]),
            values.isSymbolicLink == true {
             return false
         }
-        guard FileManager.default.isWritableFile(atPath: credentialsURL.path),
+        guard FileManager.default.isWritableFile(atPath: credentialsDirectory.path),
+              FileManager.default.isWritableFile(atPath: credentialsURL.path),
               let storedData = try? Data(contentsOf: credentialsURL) else { return false }
         if let json = try? JSONSerialization.jsonObject(with: storedData) as? [String: Any] {
             return trimmed(json["refresh_token"] as? String) == expectedRefreshToken
@@ -172,6 +174,9 @@ nonisolated enum FactoryDroidCredentialReader {
             guard [EEXIST, ENOTEMPTY, ENOTDIR, EISDIR].contains(errno), Date() < deadline else {
                 throw MonitorRuntimeError.credentialWriteFailed
             }
+            if try reclaimAbandonedDroidCredentialWriteLock(at: lockURL, manager: manager) {
+                continue
+            }
             Thread.sleep(forTimeInterval: 0.015)
         }
 
@@ -183,6 +188,76 @@ nonisolated enum FactoryDroidCredentialReader {
             }
         }
         return try operation()
+    }
+
+    private static func reclaimAbandonedDroidCredentialWriteLock(
+        at lockURL: URL,
+        manager: FileManager
+    ) throws -> Bool {
+        guard let initial = droidCredentialWriteLockSnapshot(at: lockURL, manager: manager),
+              initial.isAbandoned else { return false }
+
+        let reclaimURL = URL(fileURLWithPath: lockURL.path + ".reclaim", isDirectory: true)
+        let token = UUID().uuidString
+        let pendingURL = URL(fileURLWithPath: reclaimURL.path + ".\(token).pending", isDirectory: true)
+        try manager.createDirectory(
+            at: pendingURL,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
+        defer { try? manager.removeItem(at: pendingURL) }
+        let ownerData = try JSONSerialization.data(withJSONObject: [
+            "token": token,
+            "pid": ProcessInfo.processInfo.processIdentifier,
+        ])
+        let ownerURL = pendingURL.appendingPathComponent("owner.json")
+        try ownerData.write(to: ownerURL, options: .withoutOverwriting)
+        try manager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: ownerURL.path)
+
+        guard rename(pendingURL.path, reclaimURL.path) == 0 else {
+            if let abandonedReclaim = droidCredentialWriteLockSnapshot(at: reclaimURL, manager: manager),
+               abandonedReclaim.isAbandoned,
+               droidCredentialWriteLockSnapshot(at: reclaimURL, manager: manager) == abandonedReclaim {
+                try? manager.removeItem(at: reclaimURL)
+            }
+            return false
+        }
+        defer {
+            if droidCredentialWriteLockSnapshot(at: reclaimURL, manager: manager)?.token == token {
+                try? manager.removeItem(at: reclaimURL)
+            }
+        }
+        guard droidCredentialWriteLockSnapshot(at: lockURL, manager: manager) == initial else { return false }
+        try manager.removeItem(at: lockURL)
+        return true
+    }
+
+    private static func droidCredentialWriteLockSnapshot(
+        at lockURL: URL,
+        manager: FileManager
+    ) -> DroidCredentialWriteLockSnapshot? {
+        guard let attributes = try? manager.attributesOfItem(atPath: lockURL.path),
+              let modificationDate = attributes[.modificationDate] as? Date else { return nil }
+        let ownerData = try? Data(contentsOf: lockURL.appendingPathComponent("owner.json"))
+        let owner = ownerData.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }
+        return DroidCredentialWriteLockSnapshot(
+            token: owner?["token"] as? String,
+            pid: (owner?["pid"] as? NSNumber)?.int32Value,
+            modificationDate: modificationDate
+        )
+    }
+
+    private struct DroidCredentialWriteLockSnapshot: Equatable {
+        let token: String?
+        let pid: Int32?
+        let modificationDate: Date
+
+        var isAbandoned: Bool {
+            if let pid {
+                return kill(pid, 0) != 0 && errno == ESRCH
+            }
+            return Date().timeIntervalSince(modificationDate) >= 10
+        }
     }
 
     private static func normalizedKey(_ data: Data?) -> Data? {

--- a/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
@@ -68,6 +68,10 @@ nonisolated enum FactoryDroidCredentialReader {
         refreshToken: String?
     ) throws -> Bool {
         let credentialsURL = URL(fileURLWithPath: sourcePath)
+        if let values = try? credentialsURL.resourceValues(forKeys: [.isSymbolicLinkKey]),
+           values.isSymbolicLink == true {
+            throw MonitorRuntimeError.symbolicLinkRefused
+        }
         let storedData = try Data(contentsOf: credentialsURL)
         let keyData: Data? = if credentialsURL.lastPathComponent == "auth.v2.file" {
             try? Data(contentsOf: credentialsURL.deletingLastPathComponent().appendingPathComponent("auth.v2.key"))
@@ -106,6 +110,30 @@ nonisolated enum FactoryDroidCredentialReader {
         guard (try? Data(contentsOf: credentialsURL)) == storedData else { return false }
         try SecureAtomicFileWriter.write(output, to: credentialsURL)
         return true
+    }
+
+    static func canPersistRefresh(sourcePath: String, expectedRefreshToken: String) -> Bool {
+        let credentialsURL = URL(fileURLWithPath: sourcePath)
+        if let values = try? credentialsURL.resourceValues(forKeys: [.isSymbolicLinkKey]),
+           values.isSymbolicLink == true {
+            return false
+        }
+        guard FileManager.default.isWritableFile(atPath: credentialsURL.path),
+              let storedData = try? Data(contentsOf: credentialsURL) else { return false }
+        if let json = try? JSONSerialization.jsonObject(with: storedData) as? [String: Any] {
+            return trimmed(json["refresh_token"] as? String) == expectedRefreshToken
+        }
+
+        let keyData: Data? = if credentialsURL.lastPathComponent == "auth.v2.file" {
+            try? Data(contentsOf: credentialsURL.deletingLastPathComponent().appendingPathComponent("auth.v2.key"))
+        } else {
+            KeychainHelper.readExternalCredential(service: "Factory CLI", account: "auth-encryption-key")
+        }
+        guard let encrypted = String(data: storedData, encoding: .utf8),
+              let key = normalizedKey(keyData),
+              let cleartext = decrypt(encrypted.trimmingCharacters(in: .whitespacesAndNewlines), key: key),
+              let json = try? JSONSerialization.jsonObject(with: cleartext) as? [String: Any] else { return false }
+        return trimmed(json["refresh_token"] as? String) == expectedRefreshToken
     }
 
     private static func loadEncrypted(credentialsURL: URL, keyData: Data?) -> FactoryDroidCredential? {
@@ -320,6 +348,7 @@ actor FactoryDroidQuotaFetcher {
     private let vault: MonitorCredentialStore
     private let metadata: MonitorMetadataStore
     private var session: URLSession
+    private var pendingLocalCredentials: [String: (credential: FactoryDroidCredential, replacedRefreshToken: String)] = [:]
     private let limitsURL = URL(string: "https://api.factory.ai/api/billing/limits")!
     private let profileURL = URL(string: "https://api.factory.ai/api/app/auth/me")!
     private let refreshURL = URL(string: "https://api.workos.com/user_management/authenticate")!
@@ -352,7 +381,7 @@ actor FactoryDroidQuotaFetcher {
         for account in await vault.accounts()
         where account.provider == .factoryDroid && !disabledAccountIDs.contains(account.id) {
             guard let credential = await vault.credential(for: account.id),
-                  let quota = await fetch(accessToken: credential.accessToken) else { continue }
+                  let quota = await fetch(accessToken: credential.accessToken).quota else { continue }
             results[account.accountKey] = quota
         }
         return results
@@ -373,7 +402,7 @@ actor FactoryDroidQuotaFetcher {
                 && $0.accountKey == accountKey
                 && !disabledAccountIDs.contains($0.id)
         }), let credential = await vault.credential(for: account.id) else { return nil }
-        return await fetch(accessToken: credential.accessToken)
+        return await fetch(accessToken: credential.accessToken).quota
     }
 
     nonisolated static func localAccount(for credential: FactoryDroidCredential) -> MonitorAccount {
@@ -397,19 +426,39 @@ actor FactoryDroidQuotaFetcher {
             URLQueryItem(name: "client_id", value: workOSClientID),
         ]
         if let organizationID { items.append(URLQueryItem(name: "organization_id", value: organizationID)) }
-        var components = URLComponents()
-        components.queryItems = items
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.httpBody = Data((components.percentEncodedQuery ?? "").utf8)
+        request.httpBody = Data(items.map {
+            formEncoded($0.name) + "=" + formEncoded($0.value ?? "")
+        }.joined(separator: "&").utf8)
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         return request
     }
 
+    private nonisolated static func formEncoded(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~"))
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? ""
+    }
+
     private func fetch(localCredential: FactoryDroidCredential) async -> ProviderQuotaData? {
         var credential = localCredential
+        if let pending = pendingLocalCredentials[credential.sourcePath] {
+            if credential.refreshToken == pending.replacedRefreshToken {
+                credential = pending.credential
+                if (try? FactoryDroidCredentialReader.persistRefresh(
+                    sourcePath: credential.sourcePath,
+                    expectedRefreshToken: pending.replacedRefreshToken,
+                    accessToken: credential.accessToken,
+                    refreshToken: credential.refreshToken
+                )) == true {
+                    pendingLocalCredentials.removeValue(forKey: credential.sourcePath)
+                }
+            } else {
+                pendingLocalCredentials.removeValue(forKey: credential.sourcePath)
+            }
+        }
         var didRefresh = false
         if Self.isExpiring(accessToken: credential.accessToken),
            let refreshed = await refresh(credential) {
@@ -417,16 +466,24 @@ actor FactoryDroidQuotaFetcher {
             didRefresh = true
         }
 
-        var quota = await fetch(accessToken: credential.accessToken)
-        if quota?.isForbidden == true, !didRefresh,
+        var response = await fetch(accessToken: credential.accessToken)
+        if Self.shouldRefresh(statusCode: response.statusCode, didRefresh: didRefresh),
            let refreshed = await refresh(credential) {
-            quota = await fetch(accessToken: refreshed.accessToken)
+            response = await fetch(accessToken: refreshed.accessToken)
         }
-        return quota
+        return response.quota
+    }
+
+    nonisolated static func shouldRefresh(statusCode: Int?, didRefresh: Bool) -> Bool {
+        statusCode == 401 && !didRefresh
     }
 
     private func refresh(_ credential: FactoryDroidCredential) async -> FactoryDroidCredential? {
-        guard let refreshToken = credential.refreshToken else { return nil }
+        guard let refreshToken = credential.refreshToken,
+              FactoryDroidCredentialReader.canPersistRefresh(
+                sourcePath: credential.sourcePath,
+                expectedRefreshToken: refreshToken
+              ) else { return nil }
         let request = Self.makeRefreshRequest(
             refreshToken: refreshToken,
             organizationID: credential.activeOrganizationID,
@@ -439,22 +496,27 @@ actor FactoryDroidQuotaFetcher {
             return nil
         }
 
-        do {
-            try FactoryDroidCredentialReader.persistRefresh(
-                sourcePath: credential.sourcePath,
-                expectedRefreshToken: refreshToken,
-                accessToken: refreshed.accessToken,
-                refreshToken: refreshed.refreshToken
-            )
-        } catch {
-            Log.quota("Failed to persist refreshed Factory Droid credential")
-        }
-        return FactoryDroidCredential(
+        let updatedCredential = FactoryDroidCredential(
             accessToken: refreshed.accessToken,
             refreshToken: refreshed.refreshToken ?? refreshToken,
             activeOrganizationID: credential.activeOrganizationID,
             sourcePath: credential.sourcePath
         )
+        do {
+            let persisted = try FactoryDroidCredentialReader.persistRefresh(
+                sourcePath: credential.sourcePath,
+                expectedRefreshToken: refreshToken,
+                accessToken: refreshed.accessToken,
+                refreshToken: refreshed.refreshToken
+            )
+            if !persisted {
+                pendingLocalCredentials[credential.sourcePath] = (updatedCredential, refreshToken)
+            }
+        } catch {
+            Log.quota("Failed to persist refreshed Factory Droid credential")
+            pendingLocalCredentials[credential.sourcePath] = (updatedCredential, refreshToken)
+        }
+        return updatedCredential
     }
 
     private nonisolated static func isExpiring(accessToken: String, leeway: TimeInterval = 60) -> Bool {
@@ -470,24 +532,24 @@ actor FactoryDroidQuotaFetcher {
         return Date().addingTimeInterval(leeway).timeIntervalSince1970 >= expiry.doubleValue
     }
 
-    private func fetch(accessToken: String) async -> ProviderQuotaData? {
+    private func fetch(accessToken: String) async -> (quota: ProviderQuotaData?, statusCode: Int?) {
         async let profile = fetchProfile(accessToken: accessToken)
 
         var request = URLRequest(url: limitsURL)
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         guard let (data, response) = try? await session.data(for: request),
-              let http = response as? HTTPURLResponse else { return nil }
+              let http = response as? HTTPURLResponse else { return (nil, nil) }
         if http.statusCode == 401 || http.statusCode == 403 {
-            return ProviderQuotaData(isForbidden: true)
+            return (ProviderQuotaData(isForbidden: true), http.statusCode)
         }
         guard 200...299 ~= http.statusCode,
               let decoded = try? JSONDecoder().decode(FactoryDroidQuotaResponse.self, from: data) else {
-            return nil
+            return (nil, http.statusCode)
         }
         var quota = FactoryDroidQuotaMapper.map(decoded)
         quota.accountDisplayName = await profile?.email
-        return quota
+        return (quota, http.statusCode)
     }
 
     private func fetchProfile(accessToken: String) async -> FactoryDroidAuthMeResponse? {

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -703,6 +703,10 @@ final class MonitorRuntimeTests: XCTestCase {
         try Data(encrypted.utf8).write(to: credentialsURL)
         try Data(keyData.base64EncodedString().utf8).write(to: directory.appendingPathComponent("auth.v2.key"))
 
+        XCTAssertTrue(FactoryDroidCredentialReader.canPersistRefresh(
+            sourcePath: credentialsURL.path,
+            expectedRefreshToken: "old-refresh"
+        ))
         XCTAssertTrue(try FactoryDroidCredentialReader.persistRefresh(
             sourcePath: credentialsURL.path,
             expectedRefreshToken: "old-refresh",
@@ -738,6 +742,21 @@ final class MonitorRuntimeTests: XCTestCase {
         ))
     }
 
+    func testFactoryDroidRefusesRefreshWhenCredentialDestinationIsSymbolicLink() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let target = directory.appendingPathComponent("target.json")
+        let link = directory.appendingPathComponent("auth.encrypted")
+        try Data(#"{"access_token":"old-token","refresh_token":"old-refresh"}"#.utf8).write(to: target)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        XCTAssertFalse(FactoryDroidCredentialReader.canPersistRefresh(
+            sourcePath: link.path,
+            expectedRefreshToken: "old-refresh"
+        ))
+    }
+
     func testFactoryDroidBuildsDroidCompatibleRefreshRequest() throws {
         let request = FactoryDroidQuotaFetcher.makeRefreshRequest(
             refreshToken: "refresh + token",
@@ -750,10 +769,17 @@ final class MonitorRuntimeTests: XCTestCase {
 
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded")
+        XCTAssertTrue(String(decoding: body, as: UTF8.self).contains("refresh_token=refresh%20%2B%20token"))
         XCTAssertEqual(values["grant_type"], "refresh_token")
         XCTAssertEqual(values["refresh_token"], "refresh + token")
         XCTAssertEqual(values["client_id"], "client_01HNM792M5G5G1A2THWPXKFMXB")
         XCTAssertEqual(values["organization_id"], "org-123")
+    }
+
+    func testFactoryDroidOnlyRetriesUnauthorizedResponses() {
+        XCTAssertTrue(FactoryDroidQuotaFetcher.shouldRefresh(statusCode: 401, didRefresh: false))
+        XCTAssertFalse(FactoryDroidQuotaFetcher.shouldRefresh(statusCode: 403, didRefresh: false))
+        XCTAssertFalse(FactoryDroidQuotaFetcher.shouldRefresh(statusCode: 401, didRefresh: true))
     }
 
     func testFactoryDroidMapsStandardCoreAndExtraUsage() throws {

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -734,12 +734,49 @@ final class MonitorRuntimeTests: XCTestCase {
         let updatedCleartext = try AES.GCM.open(updatedBox, using: SymmetricKey(data: keyData))
         let updatedJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: updatedCleartext) as? [String: String])
         XCTAssertEqual(updatedJSON["unknown"], "keep")
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent("auth.v2.write.lock").path
+        ))
         XCTAssertFalse(try FactoryDroidCredentialReader.persistRefresh(
             sourcePath: credentialsURL.path,
             expectedRefreshToken: "old-refresh",
             accessToken: "stale-token",
             refreshToken: nil
         ))
+    }
+
+    func testFactoryDroidCoordinatesCredentialReplacementWithDroidWriteLock() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let credentialsURL = directory.appendingPathComponent("auth.encrypted")
+        let lockURL = directory.appendingPathComponent("auth.v2.write.lock")
+        try Data(#"{"access_token":"old-token","refresh_token":"old-refresh"}"#.utf8).write(to: credentialsURL)
+        try FileManager.default.createDirectory(at: lockURL, withIntermediateDirectories: false)
+        let owner = try JSONSerialization.data(withJSONObject: [
+            "token": "droid-writer",
+            "pid": ProcessInfo.processInfo.processIdentifier,
+        ])
+        try owner.write(to: lockURL.appendingPathComponent("owner.json"))
+
+        let writerFinished = expectation(description: "Droid writer finished")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+            try? Data(#"{"access_token":"droid-token","refresh_token":"droid-refresh"}"#.utf8)
+                .write(to: credentialsURL)
+            try? FileManager.default.removeItem(at: lockURL)
+            writerFinished.fulfill()
+        }
+
+        XCTAssertFalse(try FactoryDroidCredentialReader.persistRefresh(
+            sourcePath: credentialsURL.path,
+            expectedRefreshToken: "old-refresh",
+            accessToken: "quotio-token",
+            refreshToken: "quotio-refresh"
+        ))
+        wait(for: [writerFinished], timeout: 1)
+        let stored = try JSONSerialization.jsonObject(with: Data(contentsOf: credentialsURL)) as? [String: String]
+        XCTAssertEqual(stored?["access_token"], "droid-token")
+        XCTAssertEqual(stored?["refresh_token"], "droid-refresh")
     }
 
     func testFactoryDroidRefusesRefreshWhenCredentialDestinationIsSymbolicLink() throws {

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -779,6 +779,49 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertEqual(stored?["refresh_token"], "droid-refresh")
     }
 
+    func testFactoryDroidPreflightRequiresWritableCredentialDirectory() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let credentialsURL = directory.appendingPathComponent("auth.encrypted")
+        try Data(#"{"access_token":"old-token","refresh_token":"old-refresh"}"#.utf8).write(to: credentialsURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: directory.path)
+
+        XCTAssertFalse(FactoryDroidCredentialReader.canPersistRefresh(
+            sourcePath: credentialsURL.path,
+            expectedRefreshToken: "old-refresh"
+        ))
+    }
+
+    func testFactoryDroidReclaimsWriteLockFromTerminatedOwner() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let credentialsURL = directory.appendingPathComponent("auth.encrypted")
+        let lockURL = directory.appendingPathComponent("auth.v2.write.lock")
+        try Data(#"{"access_token":"old-token","refresh_token":"old-refresh"}"#.utf8).write(to: credentialsURL)
+        try FileManager.default.createDirectory(at: lockURL, withIntermediateDirectories: false)
+        let owner = try JSONSerialization.data(withJSONObject: [
+            "token": "abandoned-writer",
+            "pid": Int32.max,
+        ])
+        try owner.write(to: lockURL.appendingPathComponent("owner.json"))
+
+        XCTAssertTrue(try FactoryDroidCredentialReader.persistRefresh(
+            sourcePath: credentialsURL.path,
+            expectedRefreshToken: "old-refresh",
+            accessToken: "new-token",
+            refreshToken: "new-refresh"
+        ))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: lockURL.path))
+        let stored = try JSONSerialization.jsonObject(with: Data(contentsOf: credentialsURL)) as? [String: String]
+        XCTAssertEqual(stored?["access_token"], "new-token")
+        XCTAssertEqual(stored?["refresh_token"], "new-refresh")
+    }
+
     func testFactoryDroidRefusesRefreshWhenCredentialDestinationIsSymbolicLink() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -653,6 +653,7 @@ final class MonitorRuntimeTests: XCTestCase {
 
         XCTAssertEqual(credential, FactoryDroidCredential(
             accessToken: "local-token",
+            refreshToken: "refresh",
             activeOrganizationID: "org-123",
             sourcePath: "/tmp/auth.v2.file"
         ))
@@ -677,11 +678,82 @@ final class MonitorRuntimeTests: XCTestCase {
         let credential = FactoryDroidCredentialReader.load(directory: directory)
 
         XCTAssertEqual(credential?.accessToken, "directory-token")
+        XCTAssertNil(credential?.refreshToken)
         XCTAssertEqual(credential?.accountKey, "org-directory")
         XCTAssertEqual(
             FactoryDroidQuotaFetcher.localAccount(for: try XCTUnwrap(credential)).provider,
             .factoryDroid
         )
+    }
+
+    func testFactoryDroidPersistsRotatedEncryptedCredentialWithoutDroppingFields() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let keyData = Data(repeating: 9, count: 32)
+        let nonce = try AES.GCM.Nonce(data: Data(repeating: 10, count: 16))
+        let cleartext = Data(#"{"access_token":"old-token","refresh_token":"old-refresh","active_organization_id":"org-123","unknown":"keep"}"#.utf8)
+        let sealed = try AES.GCM.seal(cleartext, using: SymmetricKey(data: keyData), nonce: nonce)
+        let encrypted = [
+            Data(nonce).base64EncodedString(),
+            sealed.tag.base64EncodedString(),
+            sealed.ciphertext.base64EncodedString(),
+        ].joined(separator: ":")
+        let credentialsURL = directory.appendingPathComponent("auth.v2.file")
+        try Data(encrypted.utf8).write(to: credentialsURL)
+        try Data(keyData.base64EncodedString().utf8).write(to: directory.appendingPathComponent("auth.v2.key"))
+
+        XCTAssertTrue(try FactoryDroidCredentialReader.persistRefresh(
+            sourcePath: credentialsURL.path,
+            expectedRefreshToken: "old-refresh",
+            accessToken: "new-token",
+            refreshToken: "new-refresh"
+        ))
+
+        let updated = try String(contentsOf: credentialsURL, encoding: .utf8)
+        let decrypted = try XCTUnwrap(FactoryDroidCredentialReader.decryptCredential(
+            encrypted: updated,
+            keyData: keyData,
+            sourcePath: credentialsURL.path
+        ))
+        XCTAssertEqual(decrypted.accessToken, "new-token")
+        XCTAssertEqual(decrypted.refreshToken, "new-refresh")
+        let pieces = updated.split(separator: ":")
+        let updatedNonce = try AES.GCM.Nonce(data: XCTUnwrap(Data(base64Encoded: String(pieces[0]))))
+        let updatedTag = try XCTUnwrap(Data(base64Encoded: String(pieces[1])))
+        let updatedCiphertext = try XCTUnwrap(Data(base64Encoded: String(pieces[2])))
+        let updatedBox = try AES.GCM.SealedBox(
+            nonce: updatedNonce,
+            ciphertext: updatedCiphertext,
+            tag: updatedTag
+        )
+        let updatedCleartext = try AES.GCM.open(updatedBox, using: SymmetricKey(data: keyData))
+        let updatedJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: updatedCleartext) as? [String: String])
+        XCTAssertEqual(updatedJSON["unknown"], "keep")
+        XCTAssertFalse(try FactoryDroidCredentialReader.persistRefresh(
+            sourcePath: credentialsURL.path,
+            expectedRefreshToken: "old-refresh",
+            accessToken: "stale-token",
+            refreshToken: nil
+        ))
+    }
+
+    func testFactoryDroidBuildsDroidCompatibleRefreshRequest() throws {
+        let request = FactoryDroidQuotaFetcher.makeRefreshRequest(
+            refreshToken: "refresh + token",
+            organizationID: "org-123"
+        )
+        let body = try XCTUnwrap(request.httpBody)
+        var components = URLComponents()
+        components.percentEncodedQuery = String(decoding: body, as: UTF8.self)
+        let values = Dictionary(uniqueKeysWithValues: try XCTUnwrap(components.queryItems).map { ($0.name, $0.value) })
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded")
+        XCTAssertEqual(values["grant_type"], "refresh_token")
+        XCTAssertEqual(values["refresh_token"], "refresh + token")
+        XCTAssertEqual(values["client_id"], "client_01HNM792M5G5G1A2THWPXKFMXB")
+        XCTAssertEqual(values["organization_id"], "org-123")
     }
 
     func testFactoryDroidMapsStandardCoreAndExtraUsage() throws {


### PR DESCRIPTION
Factory Droid's local credential contains a rotating WorkOS refresh token, but the quota monitor discarded it and continued using the original access token indefinitely. This refreshes expiring credentials using Droid's own WorkOS request format, retries authorization failures once, and safely persists rotated tokens back to the encrypted credential file.

- Parse the local Factory Droid refresh token and active organization
- Refresh access tokens before JWT expiry or after a 401/403 response
- Preserve unknown credential fields and avoid overwriting concurrent Droid updates
- Cover the WorkOS request format, encrypted token rotation, credential parsing, and stale-write protection

## Verification
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build`
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug -destination 'platform=macOS' -only-testing:QuotioTests/MonitorRuntimeTests test`
