### PR TITLE
feat(release): add optional Developer ID signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,12 +66,143 @@ jobs:
       - name: Install create-dmg
         run: brew install create-dmg
 
+      - name: Configure Developer ID signing and notarization
+        id: signing
+        env:
+          DEVELOPER_ID_CERTIFICATE_BASE64: ${{ secrets.DEVELOPER_ID_CERTIFICATE_BASE64 }}
+          DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+
+          required_secrets=(
+            DEVELOPER_ID_CERTIFICATE_BASE64
+            DEVELOPER_ID_CERTIFICATE_PASSWORD
+            APP_STORE_CONNECT_API_KEY_BASE64
+            APP_STORE_CONNECT_KEY_ID
+            APP_STORE_CONNECT_ISSUER_ID
+          )
+
+          configured_secret_count=0
+          for secret_name in "${required_secrets[@]}"; do
+            if [[ -n "${!secret_name}" ]]; then
+              configured_secret_count=$((configured_secret_count + 1))
+            fi
+          done
+
+          if [[ "${configured_secret_count}" -eq 0 ]]; then
+            echo "enabled=false" >> "${GITHUB_OUTPUT}"
+            echo "Apple signing secrets are not configured; building ad-hoc artifacts."
+            exit 0
+          fi
+
+          if [[ "${configured_secret_count}" -ne "${#required_secrets[@]}" ]]; then
+            echo "Developer ID signing is only enabled when all Apple signing secrets are configured." >&2
+            for secret_name in "${required_secrets[@]}"; do
+              if [[ -z "${!secret_name}" ]]; then
+                echo "Missing GitHub secret: ${secret_name}" >&2
+              fi
+            done
+            exit 1
+          fi
+
+          KEYCHAIN_PATH="${RUNNER_TEMP}/quotio-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
+          CERTIFICATE_PATH="${RUNNER_TEMP}/developer-id-application.p12"
+          API_KEY_PATH="${RUNNER_TEMP}/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8"
+          NOTARY_PROFILE="quotio-notarization-${GITHUB_RUN_ID}"
+          ORIGINAL_KEYCHAINS_PATH="${RUNNER_TEMP}/quotio-original-keychains.txt"
+
+          security list-keychains -d user > "${ORIGINAL_KEYCHAINS_PATH}"
+          {
+            echo "SIGNING_KEYCHAIN_PATH=${KEYCHAIN_PATH}"
+            echo "SIGNING_CERTIFICATE_PATH=${CERTIFICATE_PATH}"
+            echo "NOTARY_API_KEY_PATH=${API_KEY_PATH}"
+            echo "SIGNING_ORIGINAL_KEYCHAINS_PATH=${ORIGINAL_KEYCHAINS_PATH}"
+          } >> "${GITHUB_ENV}"
+
+          printf '%s' "${DEVELOPER_ID_CERTIFICATE_BASE64}" | base64 --decode > "${CERTIFICATE_PATH}"
+          printf '%s' "${APP_STORE_CONNECT_API_KEY_BASE64}" | base64 --decode > "${API_KEY_PATH}"
+
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+          security set-keychain-settings -lut 21600 "${KEYCHAIN_PATH}"
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+
+          existing_keychains=()
+          while IFS= read -r keychain; do
+            existing_keychains+=("${keychain//\"/}")
+          done < <(security list-keychains -d user)
+          security list-keychains -d user -s "${KEYCHAIN_PATH}" "${existing_keychains[@]}"
+
+          security import "${CERTIFICATE_PATH}" \
+            -k "${KEYCHAIN_PATH}" \
+            -P "${DEVELOPER_ID_CERTIFICATE_PASSWORD}" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "${KEYCHAIN_PASSWORD}" \
+            "${KEYCHAIN_PATH}"
+
+          SIGNING_IDENTITY="$(
+            security find-identity -v -p codesigning "${KEYCHAIN_PATH}" \
+              | awk '/Developer ID Application/ && !identity {identity=$2} END {print identity}'
+          )"
+          if [[ -z "${SIGNING_IDENTITY}" ]]; then
+            echo "The imported certificate is not a valid Developer ID Application identity." >&2
+            exit 1
+          fi
+
+          xcrun notarytool store-credentials "${NOTARY_PROFILE}" \
+            --key "${API_KEY_PATH}" \
+            --key-id "${APP_STORE_CONNECT_KEY_ID}" \
+            --issuer "${APP_STORE_CONNECT_ISSUER_ID}" \
+            --keychain "${KEYCHAIN_PATH}"
+
+          {
+            echo "SIGNING_IDENTITY=${SIGNING_IDENTITY}"
+            echo "NOTARYTOOL_KEYCHAIN_PROFILE=${NOTARY_PROFILE}"
+            echo "NOTARYTOOL_KEYCHAIN=${KEYCHAIN_PATH}"
+          } >> "${GITHUB_ENV}"
+          echo "enabled=true" >> "${GITHUB_OUTPUT}"
+
       - name: Build DMG, ZIP, and appcast
         env:
           POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
           POSTHOG_HOST: ${{ vars.POSTHOG_HOST || 'https://us.i.posthog.com' }}
+          SIGNING_ENABLED: ${{ steps.signing.outputs.enabled }}
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-        run: ./scripts/build_dmg.sh --version "${{ steps.version.outputs.VERSION }}" --generate-appcast
+        run: |
+          args=(--version "${{ steps.version.outputs.VERSION }}" --generate-appcast)
+          if [[ "${SIGNING_ENABLED}" == "true" ]]; then
+            args+=(--distribution)
+          fi
+          ./scripts/build_dmg.sh "${args[@]}"
+
+      - name: Remove signing credentials
+        if: always()
+        run: |
+          if [[ -n "${SIGNING_ORIGINAL_KEYCHAINS_PATH:-}" && -f "${SIGNING_ORIGINAL_KEYCHAINS_PATH}" ]]; then
+            original_keychains=()
+            while IFS= read -r keychain; do
+              original_keychains+=("${keychain//\"/}")
+            done < "${SIGNING_ORIGINAL_KEYCHAINS_PATH}"
+            security list-keychains -d user -s "${original_keychains[@]}" || true
+          fi
+          if [[ -n "${SIGNING_KEYCHAIN_PATH:-}" && -f "${SIGNING_KEYCHAIN_PATH}" ]]; then
+            security delete-keychain "${SIGNING_KEYCHAIN_PATH}" || true
+          fi
+          for credential_file in \
+            "${SIGNING_CERTIFICATE_PATH:-}" \
+            "${NOTARY_API_KEY_PATH:-}" \
+            "${SIGNING_ORIGINAL_KEYCHAINS_PATH:-}"; do
+            if [[ -n "${credential_file}" ]]; then
+              rm -f "${credential_file}"
+            fi
+          done
 
       # ===========================================
       # 5. Create tag (for workflow_dispatch)
@@ -105,10 +236,7 @@ jobs:
 
             Download `Quotio-${{ steps.version.outputs.VERSION }}.dmg` or `Quotio-${{ steps.version.outputs.VERSION }}.zip` below.
 
-            > ⚠️ **Note**: The app is not signed with an Apple Developer certificate. If macOS blocks the app, run:
-            > ```bash
-            > xattr -cr /Applications/Quotio.app
-            > ```
+            ${{ steps.signing.outputs.enabled == 'true' && 'The app is signed with Developer ID and notarized by Apple.' || 'This artifact was built without Developer ID signing because Apple signing secrets were not configured.' }}
           prerelease: ${{ steps.version.outputs.IS_PRERELEASE == 'true' }}
 
       # ===========================================

--- a/Config/Debug.xcconfig
+++ b/Config/Debug.xcconfig
@@ -3,7 +3,7 @@
 // This file is tracked by git
 
 // Default Debug settings (will be overridden by Local.xcconfig if it exists)
-PRODUCT_BUNDLE_IDENTIFIER = dev.quotio.desktop
+PRODUCT_BUNDLE_IDENTIFIER = app.bytrong.quotio
 PRODUCT_NAME = Quotio
 INFOPLIST_KEY_CFBundleDisplayName = Quotio
 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon

--- a/Config/Local.xcconfig.example
+++ b/Config/Local.xcconfig.example
@@ -12,7 +12,7 @@
 // ========================
 
 // Development Bundle Identifier (separate from production)
-PRODUCT_BUNDLE_IDENTIFIER = dev.quotio.desktop.dev
+PRODUCT_BUNDLE_IDENTIFIER = app.bytrong.quotio.dev
 
 // Development App Name (to distinguish in Dock/Finder)
 PRODUCT_NAME = Quotio Dev

--- a/Config/Release.xcconfig
+++ b/Config/Release.xcconfig
@@ -6,7 +6,8 @@
 // to ensure consistent production builds
 
 // Production settings (DO NOT override these locally)
-PRODUCT_BUNDLE_IDENTIFIER = dev.quotio.desktop
+PRODUCT_BUNDLE_IDENTIFIER = app.bytrong.quotio
 PRODUCT_NAME = Quotio
+ENABLE_HARDENED_RUNTIME = YES
 POSTHOG_PROJECT_TOKEN =
 POSTHOG_HOST = https:/$()/us.i.posthog.com

--- a/Quotio.xcodeproj/project.pbxproj
+++ b/Quotio.xcodeproj/project.pbxproj
@@ -241,7 +241,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				PRODUCT_BUNDLE_IDENTIFIER = dev.quotio.desktop.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = app.bytrong.quotio.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -258,7 +258,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				PRODUCT_BUNDLE_IDENTIFIER = dev.quotio.desktop.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = app.bytrong.quotio.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -465,7 +465,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 0.26.0;
-				PRODUCT_BUNDLE_IDENTIFIER = dev.quotio.desktop;
+				PRODUCT_BUNDLE_IDENTIFIER = app.bytrong.quotio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;

--- a/Quotio/Models/AppIdentity.swift
+++ b/Quotio/Models/AppIdentity.swift
@@ -1,0 +1,64 @@
+//
+//  AppIdentity.swift
+//  Quotio
+//
+
+import Foundation
+
+nonisolated enum AppIdentity {
+    static let productionBundleIdentifier = "app.bytrong.quotio"
+    static let legacyBundleIdentifiers = [
+        "dev.quotio.desktop",
+        "proseek.io.vn.Quotio",
+    ]
+
+    private static let userDefaultsMigrationKey = "migratedToByTrongAppIdentity"
+
+    static var bundleIdentifier: String {
+        Bundle.main.bundleIdentifier ?? productionBundleIdentifier
+    }
+
+    static var isProduction: Bool {
+        bundleIdentifier == productionBundleIdentifier
+    }
+
+    static func keychainService(suffix: String) -> String {
+        "\(bundleIdentifier).\(suffix)"
+    }
+
+    static func legacyKeychainServices(suffix: String) -> [String] {
+        legacyBundleIdentifiers.map { "\($0).\(suffix)" } + ["com.quotio.\(suffix)"]
+    }
+
+    @discardableResult
+    static func migrateLegacyUserDefaults(
+        defaults: UserDefaults = .standard,
+        currentBundleIdentifier: String = bundleIdentifier
+    ) -> Bool {
+        guard currentBundleIdentifier == productionBundleIdentifier else { return false }
+
+        var currentDomain = defaults.persistentDomain(forName: currentBundleIdentifier) ?? [:]
+        guard currentDomain[userDefaultsMigrationKey] as? Bool != true else { return false }
+
+        let legacyDomains = legacyBundleIdentifiers.compactMap {
+            defaults.persistentDomain(forName: $0)
+        }
+        currentDomain = mergingUserDefaults(current: currentDomain, legacyDomains: legacyDomains)
+        currentDomain[userDefaultsMigrationKey] = true
+        defaults.setPersistentDomain(currentDomain, forName: currentBundleIdentifier)
+        return true
+    }
+
+    static func mergingUserDefaults(
+        current: [String: Any],
+        legacyDomains: [[String: Any]]
+    ) -> [String: Any] {
+        var merged = current
+        for legacyDomain in legacyDomains {
+            for (key, value) in legacyDomain where merged[key] == nil {
+                merged[key] = value
+            }
+        }
+        return merged
+    }
+}

--- a/Quotio/Models/ProxyVersionModels.swift
+++ b/Quotio/Models/ProxyVersionModels.swift
@@ -17,8 +17,23 @@ nonisolated enum ProxyBinarySource: String, Codable, CaseIterable, Identifiable,
     static let explicitSelectionDefaultsKey = "hasExplicitProxyBinarySourceSelection"
     static let plusLocalVersion = "6.9.28-0"
     static let plusLocalSHA256 = "a722885ab3c0cea5535ee69a86220d35c4f95ee7656e009d872d24de2910acf0"
+    static let plusLocalSHA256InfoKey = "QuotioBundledProxySHA256"
     static let plusLocalBinaryName = "cli-proxy-api-plus"
     static let plusLocalResourceSubdirectory = "Proxy"
+
+    static var bundledPlusLocalSHA256: String {
+        resolvedPlusLocalSHA256(
+            bundleValue: Bundle.main.object(forInfoDictionaryKey: plusLocalSHA256InfoKey) as? String
+        )
+    }
+
+    static func resolvedPlusLocalSHA256(bundleValue: String?) -> String {
+        guard let value = bundleValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              value.range(of: "^[0-9a-fA-F]{64}$", options: .regularExpression) != nil else {
+            return plusLocalSHA256
+        }
+        return value.lowercased()
+    }
 
     var id: String { rawValue }
 

--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -171,6 +171,10 @@ final class AppBootstrap {
 
 @main
 struct QuotioApp: App {
+    private let userDefaultsMigration: Void = {
+        guard !isRunningUnitTests else { return }
+        AppIdentity.migrateLegacyUserDefaults()
+    }()
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     // Use shared bootstrap instance for viewModel
     private var bootstrap: AppBootstrap { AppBootstrap.shared }

--- a/Quotio/Services/ImageCacheService.swift
+++ b/Quotio/Services/ImageCacheService.swift
@@ -14,7 +14,7 @@ final class ImageCacheService: @unchecked Sendable {
     static let shared = ImageCacheService()
 
     private let cache = NSCache<NSString, NSImage>()
-    private let queue = DispatchQueue(label: "dev.quotio.desktop.imagecache", attributes: .concurrent)
+    private let queue = DispatchQueue(label: "\(AppIdentity.bundleIdentifier).imagecache", attributes: .concurrent)
 
     /// Retained memory pressure source to prevent deallocation
     private var memoryPressureSource: DispatchSourceMemoryPressure?

--- a/Quotio/Services/KeychainHelper.swift
+++ b/Quotio/Services/KeychainHelper.swift
@@ -18,28 +18,36 @@ enum KeychainHelper {
     }
 
     nonisolated private static let securityLock = NSRecursiveLock()
-    private static let remoteService = "dev.quotio.desktop.remote-management"
-    private static let localService = "dev.quotio.desktop.local-management"
-    private static let warpService = "dev.quotio.desktop.warp"
+    nonisolated private static var remoteService: String {
+        AppIdentity.keychainService(suffix: "remote-management")
+    }
+    nonisolated private static var localService: String {
+        AppIdentity.keychainService(suffix: "local-management")
+    }
+    nonisolated private static var warpService: String {
+        AppIdentity.keychainService(suffix: "warp")
+    }
     private static let localManagementAccount = "local-management-key"
     private static let warpTokensAccount = "warp-tokens"
     private static let localManagementDefaultsKey = "managementKey"
     private static let warpTokensDefaultsKey = "warpTokens"
-    nonisolated private static let monitorAuthService = "dev.quotio.desktop.monitor-auth"
+    nonisolated private static var monitorAuthService: String {
+        AppIdentity.keychainService(suffix: "monitor-auth")
+    }
 
     // Legacy service names for keychain migration (newest first)
-    private static let legacyRemoteServices = [
-        "proseek.io.vn.Quotio.remote-management",
-        "com.quotio.remote-management",
-    ]
-    private static let legacyLocalServices = [
-        "proseek.io.vn.Quotio.local-management",
-        "com.quotio.local-management",
-    ]
-    private static let legacyWarpServices = [
-        "proseek.io.vn.Quotio.warp",
-        "com.quotio.warp",
-    ]
+    nonisolated private static var legacyRemoteServices: [String] {
+        AppIdentity.legacyKeychainServices(suffix: "remote-management")
+    }
+    nonisolated private static var legacyLocalServices: [String] {
+        AppIdentity.legacyKeychainServices(suffix: "local-management")
+    }
+    nonisolated private static var legacyWarpServices: [String] {
+        AppIdentity.legacyKeychainServices(suffix: "warp")
+    }
+    nonisolated private static var legacyMonitorAuthServices: [String] {
+        AppIdentity.legacyKeychainServices(suffix: "monitor-auth")
+    }
 
     static func saveManagementKey(_ key: String, for configId: String) {
         let account = "management-key-\(configId)"
@@ -54,14 +62,17 @@ enum KeychainHelper {
         if let key = readString(service: remoteService, account: account) {
             return key
         }
+        guard AppIdentity.isProduction else { return nil }
         return migrateString(from: legacyRemoteServices, to: remoteService, account: account)
     }
 
     static func deleteManagementKey(for configId: String) {
         let account = "management-key-\(configId)"
         deleteData(service: remoteService, account: account)
-        for legacy in legacyRemoteServices {
-            deleteData(service: legacy, account: account)
+        if AppIdentity.isProduction {
+            for legacy in legacyRemoteServices {
+                deleteData(service: legacy, account: account)
+            }
         }
     }
 
@@ -84,7 +95,8 @@ enum KeychainHelper {
         }
 
         // Migrate from legacy keychain service name
-        if let legacyKey = migrateString(from: legacyLocalServices, to: localService, account: localManagementAccount) {
+        if AppIdentity.isProduction,
+           let legacyKey = migrateString(from: legacyLocalServices, to: localService, account: localManagementAccount) {
             return legacyKey
         }
 
@@ -102,8 +114,10 @@ enum KeychainHelper {
 
     static func deleteLocalManagementKey() {
         deleteData(service: localService, account: localManagementAccount)
-        for legacy in legacyLocalServices {
-            deleteData(service: legacy, account: localManagementAccount)
+        if AppIdentity.isProduction {
+            for legacy in legacyLocalServices {
+                deleteData(service: legacy, account: localManagementAccount)
+            }
         }
         UserDefaults.standard.removeObject(forKey: localManagementDefaultsKey)
     }
@@ -121,7 +135,8 @@ enum KeychainHelper {
             return data
         }
 
-        if let legacyData = migrateData(from: legacyWarpServices, to: warpService, account: warpTokensAccount) {
+        if AppIdentity.isProduction,
+           let legacyData = migrateData(from: legacyWarpServices, to: warpService, account: warpTokensAccount) {
             return legacyData
         }
 
@@ -138,8 +153,10 @@ enum KeychainHelper {
 
     static func deleteWarpTokens() {
         deleteData(service: warpService, account: warpTokensAccount)
-        for legacy in legacyWarpServices {
-            deleteData(service: legacy, account: warpTokensAccount)
+        if AppIdentity.isProduction {
+            for legacy in legacyWarpServices {
+                deleteData(service: legacy, account: warpTokensAccount)
+            }
         }
         UserDefaults.standard.removeObject(forKey: warpTokensDefaultsKey)
     }
@@ -151,11 +168,20 @@ enum KeychainHelper {
     }
 
     nonisolated static func getMonitorCredential(account: String) -> Data? {
-        readData(service: monitorAuthService, account: account)
+        if let data = readData(service: monitorAuthService, account: account) {
+            return data
+        }
+        guard AppIdentity.isProduction else { return nil }
+        return migrateData(from: legacyMonitorAuthServices, to: monitorAuthService, account: account)
     }
 
     nonisolated static func deleteMonitorCredential(account: String) {
         deleteData(service: monitorAuthService, account: account)
+        if AppIdentity.isProduction {
+            for legacy in legacyMonitorAuthServices {
+                deleteData(service: legacy, account: account)
+            }
+        }
     }
 
     nonisolated static func compareAndSwapMonitorCredential(
@@ -266,7 +292,7 @@ enum KeychainHelper {
         ]
     }
 
-    private static func migrateData(from oldServices: [String], to newService: String, account: String) -> Data? {
+    nonisolated private static func migrateData(from oldServices: [String], to newService: String, account: String) -> Data? {
         for oldService in oldServices {
             guard let data = readData(service: oldService, account: account) else { continue }
             if saveData(data, service: newService, account: account) {
@@ -277,7 +303,7 @@ enum KeychainHelper {
         return nil
     }
 
-    private static func migrateString(from oldServices: [String], to newService: String, account: String) -> String? {
+    nonisolated private static func migrateString(from oldServices: [String], to newService: String, account: String) -> String? {
         // Non-destructive read: validate UTF-8 before committing the destructive migration
         for oldService in oldServices {
             guard let data = readData(service: oldService, account: account) else { continue }

--- a/Quotio/Services/Logger.swift
+++ b/Quotio/Services/Logger.swift
@@ -13,7 +13,7 @@ import os.log
 /// All logging is disabled in Release builds to prevent sensitive data leakage.
 /// Marked nonisolated to be callable from any actor context.
 nonisolated enum Log {
-    private static let subsystem = Bundle.main.bundleIdentifier ?? "dev.quotio.desktop"
+    private static let subsystem = AppIdentity.bundleIdentifier
 
     // MARK: - Log Categories
     // os.Logger is thread-safe and can be called from any context

--- a/Quotio/Services/Monitor/MonitorOAuthCallbackServer.swift
+++ b/Quotio/Services/Monitor/MonitorOAuthCallbackServer.swift
@@ -38,7 +38,7 @@ nonisolated final class MonitorOAuthCallbackServer: @unchecked Sendable {
                     break
                 }
             }
-            listener.start(queue: DispatchQueue(label: "dev.quotio.monitor-oauth"))
+            listener.start(queue: DispatchQueue(label: "\(AppIdentity.bundleIdentifier).monitor-oauth"))
         }
     }
 
@@ -100,7 +100,7 @@ nonisolated final class MonitorOAuthCallbackServer: @unchecked Sendable {
     }
 
     private func handle(_ connection: NWConnection) {
-        connection.start(queue: DispatchQueue(label: "dev.quotio.monitor-oauth.connection"))
+        connection.start(queue: DispatchQueue(label: "\(AppIdentity.bundleIdentifier).monitor-oauth.connection"))
         connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { [weak self] data, _, _, _ in
             guard let self,
                   let data,

--- a/Quotio/Services/Proxy/CLIProxyManager.swift
+++ b/Quotio/Services/Proxy/CLIProxyManager.swift
@@ -2197,7 +2197,7 @@ extension CLIProxyManager {
         return ProxyVersionInfo(
             source: .plusLocal,
             version: ProxyBinarySource.plusLocalVersion,
-            sha256: ProxyBinarySource.plusLocalSHA256,
+            sha256: ProxyBinarySource.bundledPlusLocalSHA256,
             localFilePath: bundledBinaryPath,
             releaseNotes: "Fixed local CLIProxyAPIPlus binary for legacy compatibility."
         )

--- a/Quotio/Services/Proxy/ProxyBridge.swift
+++ b/Quotio/Services/Proxy/ProxyBridge.swift
@@ -100,7 +100,7 @@ final class ProxyBridge {
     // MARK: - Properties
     
     private var listener: NWListener?
-    private let stateQueue = DispatchQueue(label: "dev.quotio.desktop.proxy-bridge-state")
+    private let stateQueue = DispatchQueue(label: "\(AppIdentity.bundleIdentifier).proxy-bridge-state")
     
     /// The port this proxy listens on (user-facing port)
     private(set) var listenPort: UInt16 = 8080

--- a/Quotio/Services/RequestTracker.swift
+++ b/Quotio/Services/RequestTracker.swift
@@ -38,7 +38,7 @@ final class RequestTracker {
     private var store: RequestHistoryStore = .empty
     
     /// Queue for file operations
-    private let fileQueue = DispatchQueue(label: "dev.quotio.desktop.request-tracker-file")
+    private let fileQueue = DispatchQueue(label: "\(AppIdentity.bundleIdentifier).request-tracker-file")
     
     /// Storage file URL
     private var storageURL: URL {

--- a/QuotioTests/AppIdentityTests.swift
+++ b/QuotioTests/AppIdentityTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import Quotio
+
+final class AppIdentityTests: XCTestCase {
+    func testProductionIdentityUsesByTrongDomain() {
+        XCTAssertEqual(AppIdentity.productionBundleIdentifier, "app.bytrong.quotio")
+        XCTAssertEqual(
+            AppIdentity.keychainService(suffix: "remote-management"),
+            "app.bytrong.quotio.remote-management"
+        )
+        XCTAssertEqual(
+            AppIdentity.legacyKeychainServices(suffix: "remote-management").first,
+            "dev.quotio.desktop.remote-management"
+        )
+    }
+
+    func testLegacyDefaultsMergePreservesCurrentValuesAndNewestLegacyDomain() {
+        let merged = AppIdentity.mergingUserDefaults(
+            current: ["existing": "current"],
+            legacyDomains: [
+                ["existing": "legacy", "legacyOnly": "newest"],
+                ["legacyOnly": "oldest", "oldestOnly": true],
+            ]
+        )
+
+        XCTAssertEqual(merged["existing"] as? String, "current")
+        XCTAssertEqual(merged["legacyOnly"] as? String, "newest")
+        XCTAssertEqual(merged["oldestOnly"] as? Bool, true)
+    }
+}

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -180,7 +180,7 @@ final class MonitorRuntimeTests: XCTestCase {
         // A per-run account, so the real credentials of whoever runs the suite
         // are never the thing being overwritten.
         let configId = UUID().uuidString
-        let service = "dev.quotio.desktop.remote-management"
+        let service = AppIdentity.keychainService(suffix: "remote-management")
         let account = "management-key-\(configId)"
         let digest = SHA256.hash(data: Data("\(service)\u{0}\(account)".utf8))
             .map { String(format: "%02x", $0) }

--- a/QuotioTests/ProxyVersionModelsTests.swift
+++ b/QuotioTests/ProxyVersionModelsTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import Quotio
+
+final class ProxyVersionModelsTests: XCTestCase {
+    func testBundledProxyChecksumAcceptsSignedArtifactValue() {
+        let signedChecksum = String(repeating: "A", count: 64)
+
+        XCTAssertEqual(
+            ProxyBinarySource.resolvedPlusLocalSHA256(bundleValue: signedChecksum),
+            signedChecksum.lowercased()
+        )
+    }
+
+    func testBundledProxyChecksumFallsBackForInvalidBundleValue() {
+        XCTAssertEqual(
+            ProxyBinarySource.resolvedPlusLocalSHA256(bundleValue: "not-a-checksum"),
+            ProxyBinarySource.plusLocalSHA256
+        )
+    }
+}

--- a/README.fr.md
+++ b/README.fr.md
@@ -91,10 +91,7 @@ brew install --cask quotio
 ### Téléchargement
 Téléchargez le dernier `.dmg` depuis la page [Releases](https://github.com/nguyenphutrong/quotio/releases).
 
-> ⚠️ **Note** : L'application n'est pas encore signée avec un certificat Apple Developer. Si macOS bloque l'application, exécutez :
-> ```bash
-> xattr -cr /Applications/Quotio.app
-> ```
+Les versions officielles sont signées avec Developer ID et notariées par Apple ; aucun contournement de Gatekeeper n'est nécessaire.
 
 ### Compilation depuis les Sources
 

--- a/README.md
+++ b/README.md
@@ -89,10 +89,7 @@ brew install --cask quotio
 ### Download
 Download the latest `.dmg` from the [Releases](https://github.com/nguyenphutrong/quotio/releases) page.
 
-> ⚠️ **Note**: The app is not signed with an Apple Developer certificate yet. If macOS blocks the app, run:
-> ```bash
-> xattr -cr /Applications/Quotio.app
-> ```
+Official release artifacts are signed with Developer ID and notarized by Apple, so no Gatekeeper bypass is required.
 
 ### Building from Source
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -91,10 +91,7 @@ brew install --cask quotio
 ### Tải xuống
 Tải file `.dmg` mới nhất từ trang [Releases](https://github.com/nguyenphutrong/quotio/releases).
 
-> ⚠️ **Lưu ý**: Ứng dụng chưa được ký bằng chứng chỉ Apple Developer. Nếu macOS chặn ứng dụng, chạy lệnh sau:
-> ```bash
-> xattr -cr /Applications/Quotio.app
-> ```
+Các bản phát hành chính thức được ký bằng Developer ID và được Apple công chứng, vì vậy không cần bỏ qua Gatekeeper.
 
 ### Build từ source
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -91,10 +91,7 @@ brew install --cask quotio
 ### 下载
 从 [Releases](https://github.com/nguyenphutrong/quotio/releases) 页面下载最新的 `.dmg`。
 
-> ⚠️ **注意**：应用尚未使用 Apple Developer 证书签名。如果 macOS 阻止运行，请执行：
-> ```bash
-> xattr -cr /Applications/Quotio.app
-> ```
+官方发布包使用 Developer ID 签名并经过 Apple 公证，无需绕过 Gatekeeper。
 
 ### 从源码构建
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,19 +7,41 @@ Use the GitHub **Release** workflow. It can be triggered from the Actions page w
 The workflow:
 
 1. Updates `CHANGELOG.md` and the Xcode version.
-2. Calls `scripts/build_dmg.sh` to archive the app and create DMG and ZIP artifacts.
-3. Signs the ZIP and creates the Sparkle appcast.
-4. Creates the tag and GitHub Release.
-5. Commits the version and changelog changes back to the source branch.
-6. Updates the Homebrew tap for stable releases.
+2. When Apple credentials are configured, imports the Developer ID Application certificate into a temporary keychain.
+3. When signing is enabled, signs nested code and the app with Hardened Runtime, notarizes the app, and staples the ticket.
+4. Creates the ZIP and DMG; signed builds also sign, notarize, and staple the DMG.
+5. Signs the final ZIP with Sparkle and creates the appcast.
+6. Creates the tag and GitHub Release.
+7. Commits the version and changelog changes back to the source branch.
+8. Updates the Homebrew tap for stable releases.
 
-The repository must have these GitHub Actions secrets:
+GitHub Actions reads release credentials only from repository secrets:
 
 | Name | Purpose |
 |------|---------|
+| `DEVELOPER_ID_CERTIFICATE_BASE64` | Base64-encoded Developer ID Application certificate and private key (`.p12`) |
+| `DEVELOPER_ID_CERTIFICATE_PASSWORD` | Password used when exporting the `.p12` |
+| `APP_STORE_CONNECT_API_KEY_BASE64` | Base64-encoded App Store Connect API private key (`.p8`) |
+| `APP_STORE_CONNECT_KEY_ID` | App Store Connect API key ID |
+| `APP_STORE_CONNECT_ISSUER_ID` | App Store Connect API issuer ID |
 | `SPARKLE_PRIVATE_KEY` | Sparkle EdDSA signing key |
 | `POSTHOG_PROJECT_TOKEN` | Optional PostHog project token embedded at build time |
 | `TAP_TOKEN` | Dispatch the stable release to the Homebrew tap |
+
+The five Apple signing secrets are an optional all-or-none group. When all five are absent, the workflow still builds the existing ad-hoc artifacts, which keeps forks usable without access to the upstream credentials. When any Apple signing secret is set, all five must be set so a partially configured release cannot silently fall back to ad-hoc signing.
+
+Create a **Developer ID Application** certificate from the Apple Developer portal or Xcode, install it together with its private key, and export both from Keychain Access as a password-protected `.p12`. Create a team App Store Connect API key under **Users and Access > Integrations** and download its `.p8` file. The private key can only be downloaded once.
+
+Encode the two files before adding them as GitHub Actions secrets:
+
+```bash
+base64 -i DeveloperIDApplication.p12 | pbcopy
+base64 -i AuthKey_KEY_ID.p8 | pbcopy
+```
+
+Do not commit either file. The workflow validates all credentials before building and deletes its temporary keychain and key files after the build.
+
+The production bundle identifier is `app.bytrong.quotio`. The first signed release using this identifier migrates preferences and Quotio-owned Keychain items from `dev.quotio.desktop`. Because both the bundle identifier and signing requirement change, existing ad-hoc installations may need to install that release manually once; later Sparkle updates retain the stable Developer ID identity. Users may also need to re-enable Launch at Login after this one-time transition.
 
 ## Local Artifacts
 
@@ -40,16 +62,26 @@ Install `create-dmg` for the custom DMG layout; otherwise the script falls back 
 brew install create-dmg
 ```
 
-## Local Release Preparation
+## Local Signed Release
 
-The same CI path can be exercised locally when a Sparkle private key is available:
+Install the Developer ID Application certificate and private key in Keychain, then store the notarization API credentials once:
 
 ```bash
-SPARKLE_PRIVATE_KEY=... \
-  ./scripts/build_dmg.sh --version 1.2.3 --generate-appcast
+xcrun notarytool store-credentials quotio-notarization \
+  --key /path/to/AuthKey_KEY_ID.p8 \
+  --key-id KEY_ID \
+  --issuer ISSUER_ID
 ```
 
-`--version` modifies `CHANGELOG.md` and `Quotio.xcodeproj/project.pbxproj`. `--generate-appcast` creates `build/release/appcast.xml`; it does not create a tag, push, or publish a GitHub Release.
+Run the same signed and notarized packaging path as CI:
+
+```bash
+NOTARYTOOL_KEYCHAIN_PROFILE=quotio-notarization \
+SPARKLE_PRIVATE_KEY=... \
+  ./scripts/build_dmg.sh --version 1.2.3 --distribution --generate-appcast
+```
+
+`SIGNING_IDENTITY` defaults to `Developer ID Application`; set it to the identity's SHA-1 hash if multiple Developer ID certificates are installed. `--version` modifies `CHANGELOG.md` and `Quotio.xcodeproj/project.pbxproj`. `--generate-appcast` creates `build/release/appcast.xml`; the script does not create a tag, push, or publish a GitHub Release.
 
 Pre-release versions containing `alpha`, `beta`, or `rc` are added to the Sparkle beta channel.
 
@@ -57,6 +89,8 @@ Pre-release versions containing `alpha`, `beta`, or `rc` are added to the Sparkl
 
 After a release:
 
-- Download and open the DMG.
+- Download and open the DMG on a Mac that has not built Quotio locally.
+- Confirm Gatekeeper opens Quotio without an `xattr` command or unsigned-app warning.
+- Confirm `spctl --assess --type execute --verbose=2 /Applications/Quotio.app` reports `accepted` and `source=Notarized Developer ID`.
 - Confirm the ZIP and `appcast.xml` are attached to the GitHub Release.
 - Check stable and beta update channels as applicable.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,7 +3,9 @@
 Quotio has two self-contained script entrypoints:
 
 - `build_and_run.sh`: build Debug, stop any running Quotio process, and launch the fresh app. Optional flags: `--debug`, `--logs`, `--telemetry`, `--verify`.
-- `build_dmg.sh`: build a Release archive, verify the bundled proxy, and create ZIP and DMG artifacts.
+- `build_dmg.sh`: build a Release archive, verify the bundled proxy, and create ZIP and DMG artifacts. Pass `--distribution` to require Developer ID signing, notarization, stapling, and Gatekeeper validation.
+
+`build_and_run.sh` respects the Xcode signing configuration. To sign local Debug builds with an Apple Development certificate, copy `Config/Local.xcconfig.example` to `Config/Local.xcconfig` and set `DEVELOPMENT_TEAM` to your Apple team ID.
 
 For a local release build:
 
@@ -11,8 +13,14 @@ For a local release build:
 ./scripts/build_dmg.sh
 ```
 
-The release workflow also uses this entrypoint to prepare the requested version and generate the signed Sparkle appcast:
+When the complete Apple credential set is present, the release workflow enables distribution mode to notarize the artifacts. Without those secrets it builds ad-hoc artifacts, so forks do not need the upstream signing credentials. A partially configured credential set fails instead of silently publishing unsigned artifacts.
+
+Run the distribution path locally with:
 
 ```bash
-SPARKLE_PRIVATE_KEY=... ./scripts/build_dmg.sh --version 1.2.3 --generate-appcast
+NOTARYTOOL_KEYCHAIN_PROFILE=quotio-notarization \
+SPARKLE_PRIVATE_KEY=... \
+  ./scripts/build_dmg.sh --version 1.2.3 --distribution --generate-appcast
 ```
+
+`SIGNING_IDENTITY` defaults to `Developer ID Application`. Set it to the certificate's SHA-1 hash when more than one matching identity is installed. See `RELEASE.md` for credential setup.

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -8,7 +8,7 @@ BUILD_DIR="${PROJECT_DIR}/build"
 DERIVED_DATA="${BUILD_DIR}/DebugDerivedData"
 APP_PATH="${DERIVED_DATA}/Build/Products/Debug/${PROJECT_NAME}.app"
 APP_BINARY="${APP_PATH}/Contents/MacOS/${PROJECT_NAME}"
-BUNDLE_ID="dev.quotio.desktop"
+BUNDLE_ID="app.bytrong.quotio"
 MODE="run"
 
 usage() {
@@ -47,9 +47,6 @@ xcodebuild \
     -destination "platform=macOS" \
     -derivedDataPath "${DERIVED_DATA}" \
     build \
-    CODE_SIGN_IDENTITY="-" \
-    CODE_SIGNING_REQUIRED=NO \
-    CODE_SIGNING_ALLOWED=NO \
     2>&1 | tee "${BUILD_DIR}/debug-build.log"
 
 if [ ! -d "${APP_PATH}" ]; then

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -14,14 +14,20 @@ RELEASE_DIR="${BUILD_DIR}/release"
 APPCAST_PATH="${RELEASE_DIR}/appcast.xml"
 RELEASE_VERSION=""
 GENERATE_APPCAST=false
+DISTRIBUTION=false
 SIGN_UPDATE=""
 TEMP_ROOT=""
+SIGNING_IDENTITY="${SIGNING_IDENTITY:-Developer ID Application}"
+NOTARYTOOL_KEYCHAIN_PROFILE="${NOTARYTOOL_KEYCHAIN_PROFILE:-}"
+NOTARYTOOL_KEYCHAIN="${NOTARYTOOL_KEYCHAIN:-}"
+NOTARYTOOL_AUTH_ARGS=()
 
 usage() {
-    echo "Usage: $0 [--version VERSION] [--generate-appcast]"
+    echo "Usage: $0 [--version VERSION] [--distribution] [--generate-appcast]"
     echo ""
     echo "Build the Release app and create DMG and ZIP artifacts."
     echo "  --version VERSION      update the Xcode version and CHANGELOG before building"
+    echo "  --distribution         require Developer ID signing and Apple notarization"
     echo "  --generate-appcast     sign the ZIP and create appcast.xml using SPARKLE_PRIVATE_KEY"
 }
 
@@ -103,6 +109,137 @@ verify_bundled_proxy() {
     [ "${actual_sha256}" = "${expected_sha256}" ] \
         || fail "bundled proxy checksum mismatch"
     log "Verified bundled proxy checksum"
+}
+
+configure_distribution() {
+    [ -n "${NOTARYTOOL_KEYCHAIN_PROFILE}" ] \
+        || fail "NOTARYTOOL_KEYCHAIN_PROFILE is required for --distribution"
+
+    NOTARYTOOL_AUTH_ARGS=(--keychain-profile "${NOTARYTOOL_KEYCHAIN_PROFILE}")
+    if [ -n "${NOTARYTOOL_KEYCHAIN}" ]; then
+        NOTARYTOOL_AUTH_ARGS+=(--keychain "${NOTARYTOOL_KEYCHAIN}")
+    fi
+
+    security find-identity -v -p codesigning | grep -F "${SIGNING_IDENTITY}" >/dev/null \
+        || fail "code-signing identity not found: ${SIGNING_IDENTITY}"
+}
+
+sign_macho_files() {
+    local binary_path
+
+    while IFS= read -r binary_path; do
+        if file "${binary_path}" | grep -q "Mach-O"; then
+            codesign \
+                --force \
+                --sign "${SIGNING_IDENTITY}" \
+                --options runtime \
+                --timestamp \
+                --preserve-metadata=identifier,entitlements \
+                "${binary_path}"
+        fi
+    done < <(find "${APP_PATH}/Contents" -type f)
+}
+
+sign_nested_code_bundles() {
+    local code_path
+
+    while IFS= read -r code_path; do
+        codesign \
+            --force \
+            --sign "${SIGNING_IDENTITY}" \
+            --options runtime \
+            --timestamp \
+            --preserve-metadata=identifier,entitlements \
+            "${code_path}"
+    done < <(
+        find "${APP_PATH}/Contents" -type d \( \
+            -name "*.framework" -o \
+            -name "*.xpc" -o \
+            -name "*.appex" -o \
+            -name "*.app" \
+        \) \
+            | awk '{ print gsub("/", "/"), $0 }' \
+            | sort -rn \
+            | cut -d' ' -f2-
+    )
+}
+
+record_signed_proxy_checksum() {
+    local resources_dir="${APP_PATH}/Contents/Resources"
+    local binary_path=""
+    local signed_sha256
+    local info_plist="${APP_PATH}/Contents/Info.plist"
+
+    if [ -f "${resources_dir}/Proxy/cli-proxy-api-plus" ]; then
+        binary_path="${resources_dir}/Proxy/cli-proxy-api-plus"
+    elif [ -f "${resources_dir}/cli-proxy-api-plus" ]; then
+        binary_path="${resources_dir}/cli-proxy-api-plus"
+    else
+        fail "cli-proxy-api-plus is missing from the app bundle"
+    fi
+
+    signed_sha256="$(shasum -a 256 "${binary_path}" | awk '{print $1}')"
+    /usr/libexec/PlistBuddy \
+        -c "Delete :QuotioBundledProxySHA256" \
+        "${info_plist}" >/dev/null 2>&1 || true
+    /usr/libexec/PlistBuddy \
+        -c "Add :QuotioBundledProxySHA256 string ${signed_sha256}" \
+        "${info_plist}"
+}
+
+sign_app_for_distribution() {
+    local team_identifier
+
+    log "Signing nested code with Developer ID"
+    sign_macho_files
+    record_signed_proxy_checksum
+    sign_nested_code_bundles
+
+    codesign \
+        --force \
+        --sign "${SIGNING_IDENTITY}" \
+        --options runtime \
+        --timestamp \
+        --entitlements "${PROJECT_DIR}/Quotio/Quotio.entitlements" \
+        "${APP_PATH}"
+    codesign --verify --deep --strict --verbose=2 "${APP_PATH}"
+
+    team_identifier="$(
+        codesign -dv --verbose=4 "${APP_PATH}" 2>&1 \
+            | sed -n 's/^TeamIdentifier=//p' \
+            | head -n 1
+    )"
+    [ -n "${team_identifier}" ] && [ "${team_identifier}" != "not set" ] \
+        || fail "Developer ID signature has no TeamIdentifier"
+    log "Signed app with TeamIdentifier ${team_identifier}"
+}
+
+notarize_app() {
+    local submission_zip="${TEMP_ROOT}/${PROJECT_NAME}-notarization.zip"
+
+    log "Submitting app for notarization"
+    ditto -c -k --sequesterRsrc --keepParent "${APP_PATH}" "${submission_zip}"
+    xcrun notarytool submit "${submission_zip}" "${NOTARYTOOL_AUTH_ARGS[@]}" --wait
+    xcrun stapler staple "${APP_PATH}"
+    xcrun stapler validate "${APP_PATH}"
+    spctl --assess --type execute --verbose=2 "${APP_PATH}"
+}
+
+notarize_dmg() {
+    local dmg_file="$1"
+
+    log "Signing and notarizing ${dmg_file}"
+    codesign --force --sign "${SIGNING_IDENTITY}" --timestamp "${dmg_file}"
+    codesign --verify --strict --verbose=2 "${dmg_file}"
+    xcrun notarytool submit "${dmg_file}" "${NOTARYTOOL_AUTH_ARGS[@]}" --wait
+    xcrun stapler staple "${dmg_file}"
+    xcrun stapler validate "${dmg_file}"
+    spctl \
+        --assess \
+        --type open \
+        --context context:primary-signature \
+        --verbose=2 \
+        "${dmg_file}"
 }
 
 install_sparkle_tools() {
@@ -216,6 +353,10 @@ while [ "$#" -gt 0 ]; do
             GENERATE_APPCAST=true
             shift
             ;;
+        --distribution)
+            DISTRIBUTION=true
+            shift
+            ;;
         -h|--help)
             usage
             exit 0
@@ -232,6 +373,14 @@ require_command ditto
 require_command codesign
 require_command shasum
 require_command hdiutil
+
+if [ "${DISTRIBUTION}" = true ]; then
+    require_command security
+    require_command file
+    require_command xcrun
+    require_command spctl
+    configure_distribution
+fi
 
 if [ -n "${RELEASE_VERSION}" ]; then
     prepare_release_version "${RELEASE_VERSION}"
@@ -278,12 +427,17 @@ ARCHIVED_APP="${ARCHIVE_PATH}/Products/Applications/${PROJECT_NAME}.app"
 [ -d "${ARCHIVED_APP}" ] || fail "archive did not contain ${PROJECT_NAME}.app"
 cp -R "${ARCHIVED_APP}" "${APP_PATH}"
 verify_bundled_proxy
-codesign --force --deep --sign - "${APP_PATH}"
+if [ "${DISTRIBUTION}" = true ]; then
+    sign_app_for_distribution
+    notarize_app
+else
+    codesign --force --deep --sign - "${APP_PATH}"
+fi
 
 ZIP_FILE="${RELEASE_DIR}/${PROJECT_NAME}-${VERSION}.zip"
 DMG_FILE="${RELEASE_DIR}/${PROJECT_NAME}-${VERSION}.dmg"
 log "Creating ${ZIP_FILE}"
-ditto -c -k --keepParent "${APP_PATH}" "${ZIP_FILE}"
+ditto -c -k --sequesterRsrc --keepParent "${APP_PATH}" "${ZIP_FILE}"
 
 mkdir -p "${DMG_STAGING}"
 cp -R "${APP_PATH}" "${DMG_STAGING}/"
@@ -314,6 +468,10 @@ fi
 
 [ -f "${ZIP_FILE}" ] || fail "ZIP artifact was not created"
 [ -f "${DMG_FILE}" ] || fail "DMG artifact was not created"
+
+if [ "${DISTRIBUTION}" = true ]; then
+    notarize_dmg "${DMG_FILE}"
+fi
 
 if [ "${GENERATE_APPCAST}" = true ]; then
     generate_appcast "${VERSION}" "${BUILD_NUMBER}" "${ZIP_FILE}"


### PR DESCRIPTION
Adds an optional Developer ID distribution path so official Quotio releases can use a stable Apple signing identity, pass Gatekeeper without a bypass, and preserve Keychain authorization across updates. The Apple credential set remains optional for the public repository: forks without it continue to build ad-hoc artifacts, while partial credential configuration fails explicitly.

- Standardize production identity on `app.bytrong.quotio` and migrate Quotio-owned preferences and Keychain services from legacy identifiers.
- Sign nested code and the app with Hardened Runtime, notarize and staple the app and DMG, and verify the packaged artifacts.
- Preserve the signed bundled-proxy checksum in the app metadata so signing does not break runtime verification.
- Configure signing exclusively through GitHub Secrets without hard-coded certificates, Team IDs, passwords, or API credentials.
- Keep `build_and_run.sh` focused on local debugging and make `build_dmg.sh --distribution` the explicit fail-closed release path.
- Document the signing setup, first signed-release migration, and Gatekeeper verification procedure.

## Verification

- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build`
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build-for-testing`
- Mock distribution packaging with nested signing, two notarization submissions, stapling validation, and signed-proxy checksum assertions
- Shell syntax, workflow YAML, and `git diff --check`

Refs #447
