### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -222,18 +222,18 @@ Rejoignez notre communauté Discord pour obtenir de l'aide, partager vos comment
   <source
     media="(prefers-color-scheme: dark)"
     srcset="
-      https://api.star-history.com/svg?repos=nguyenphutrong/quotio&type=Date&theme=dark
+      https://star-history.dera.page/svg?repos=nguyenphutrong/quotio&type=Date&theme=dark
     "
   />
   <source
     media="(prefers-color-scheme: light)"
     srcset="
-      https://api.star-history.com/svg?repos=nguyenphutrong/quotio&type=Date
+      https://star-history.dera.page/svg?repos=nguyenphutrong/quotio&type=Date
     "
   />
   <img
     alt="Graphique Historique des Étoiles"
-    src="https://api.star-history.com/svg?repos=nguyenphutrong/quotio&type=Date"
+    src="https://star-history.dera.page/svg?repos=nguyenphutrong/quotio&type=Date"
   />
 </picture>
 

--- a/README.md
+++ b/README.md
@@ -218,18 +218,18 @@ Join our Discord community to get help, share feedback, and connect with other u
   <source
     media="(prefers-color-scheme: dark)"
     srcset="
-      https://api.star-history.com/svg?repos=nguyenphutrong/quotio&type=Date&theme=dark
+      https://star-history.dera.page/svg?repos=nguyenphutrong/quotio&type=Date&theme=dark
     "
   />
   <source
     media="(prefers-color-scheme: light)"
     srcset="
-      https://api.star-history.com/svg?repos=nguyenphutrong/quotio&type=Date
+      https://star-history.dera.page/svg?repos=nguyenphutrong/quotio&type=Date
     "
   />
   <img
     alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=nguyenphutrong/quotio&type=Date"
+    src="https://star-history.dera.page/svg?repos=nguyenphutrong/quotio&type=Date"
   />
 </picture>
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -222,18 +222,18 @@ Tham gia cộng đồng Discord để được hỗ trợ, chia sẻ phản hồ
   <source
     media="(prefers-color-scheme: dark)"
     srcset="
-      https://api.star-history.com/svg?repos=nguyenphutrong/quotio&type=Date&theme=dark
+      https://star-history.dera.page/svg?repos=nguyenphutrong/quotio&type=Date&theme=dark
     "
   />
   <source
     media="(prefers-color-scheme: light)"
     srcset="
-      https://api.star-history.com/svg?repos=nguyenphutrong/quotio&type=Date
+      https://star-history.dera.page/svg?repos=nguyenphutrong/quotio&type=Date
     "
   />
   <img
     alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=nguyenphutrong/quotio&type=Date"
+    src="https://star-history.dera.page/svg?repos=nguyenphutrong/quotio&type=Date"
   />
 </picture>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -222,18 +222,18 @@ brew install --cask quotio
   <source
     media="(prefers-color-scheme: dark)"
     srcset="
-      https://api.star-history.com/svg?repos=nguyenphutrong/quotio&type=Date&theme=dark
+      https://star-history.dera.page/svg?repos=nguyenphutrong/quotio&type=Date&theme=dark
     "
   />
   <source
     media="(prefers-color-scheme: light)"
     srcset="
-      https://api.star-history.com/svg?repos=nguyenphutrong/quotio&type=Date
+      https://star-history.dera.page/svg?repos=nguyenphutrong/quotio&type=Date
     "
   />
   <img
     alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=nguyenphutrong/quotio&type=Date"
+    src="https://star-history.dera.page/svg?repos=nguyenphutrong/quotio&type=Date"
   />
 </picture>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the old provider relies on the GitHub stargazer API, which now restricts the required access. This updates the chart URL in all localized READMEs to point to a working alternative so the chart renders correctly again.