### PR TITLE
fix(amp): show subscription quota and Balance card in menu bar

### DIFF
--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -14,7 +14,7 @@
     "amp.label.placeholder" : { "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Account label" } }, "fr" : { "stringUnit" : { "state" : "translated", "value" : "Libellé du compte" } }, "vi" : { "stringUnit" : { "state" : "translated", "value" : "Nhãn tài khoản" } }, "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "账户标签" } } } },
     "amp.quota.agent" : { "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Agent Usage" } }, "fr" : { "stringUnit" : { "state" : "translated", "value" : "Utilisation Agent" } }, "vi" : { "stringUnit" : { "state" : "translated", "value" : "Mức dùng Agent" } }, "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Agent 用量" } } } },
     "amp.quota.free" : { "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Amp Free" } }, "fr" : { "stringUnit" : { "state" : "translated", "value" : "Amp Gratuit" } }, "vi" : { "stringUnit" : { "state" : "translated", "value" : "Amp Miễn phí" } }, "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Amp 免费额度" } } } },
-    "amp.quota.individualCredits" : { "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Individual Credits" } }, "fr" : { "stringUnit" : { "state" : "translated", "value" : "Crédits individuels" } }, "vi" : { "stringUnit" : { "state" : "translated", "value" : "Số dư cá nhân" } }, "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "个人余额" } } } },
+    "amp.quota.individualCredits" : { "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Balance" } }, "fr" : { "stringUnit" : { "state" : "translated", "value" : "Solde" } }, "vi" : { "stringUnit" : { "state" : "translated", "value" : "Số dư" } }, "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "余额" } } } },
     "amp.quota.orb" : { "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Orb Usage" } }, "fr" : { "stringUnit" : { "state" : "translated", "value" : "Utilisation Orb" } }, "vi" : { "stringUnit" : { "state" : "translated", "value" : "Mức dùng Orb" } }, "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Orb 用量" } } } },
     "amp.quota.workspaceCredits" : { "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Workspace Credits" } }, "fr" : { "stringUnit" : { "state" : "translated", "value" : "Crédits de l’espace de travail" } }, "vi" : { "stringUnit" : { "state" : "translated", "value" : "Số dư không gian làm việc" } }, "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "工作区余额" } } } },
     "-" : {
@@ -24218,10 +24218,10 @@
     },
     "quota.metric.balanceValue" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ left" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "%@ restant" } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Còn %@" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "剩余 %@" } }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "%@" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "%@" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "%@" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "%@" } }
       }
     },
     "quota.metric.credits" : {

--- a/Quotio/Services/QuotaFetchers/AmpQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/AmpQuotaFetcher.swift
@@ -80,7 +80,7 @@ nonisolated enum AmpQuotaParser {
 
         var plan = identity.flatMap { $0[1].isEmpty ? nil : $0[1] }
         if let subscription = captures(
-            #"(?im)^\s*Subscription\s+([^:\r\n]+):\s*([\d.]+)%\s+(?:other|agent)\s+usage\s+and\s+([\d.]+)%\s+orb\s+usage\s+remaining\b(?:\s*-\s*resets\s+upon\s+renewal\s+in\s+(\d+)\s+(minutes?|hours?|days?|weeks?|months?|years?))?"#,
+            #"(?im)^\s*Amp\s+([^:\r\n]+?)\s+Subscription:\s*([\d.]+)%\s+(?:other|agent)\s+usage\s+and\s+([\d.]+)%\s+orb\s+usage\s+remaining\b(?:\s*-\s*resets\s+upon\s+renewal\s+in\s+(\d+)\s+(minutes?|hours?|days?|weeks?|months?|years?))?"#,
             in: text
         ), let agent = validPercentage(subscription[1]),
            let orb = validPercentage(subscription[2]) {

--- a/Quotio/Services/QuotaFetchers/AmpQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/AmpQuotaFetcher.swift
@@ -49,6 +49,7 @@ nonisolated enum AmpQuotaParser {
             in: text
         )
 
+        var freeModel: ModelQuota?
         let freeDollarPattern = #"(?im)^\s*Amp Free:\s*\$?([\d,]+(?:\.\d+)?)\s*/\s*\$?([\d,]+(?:\.\d+)?)\s+remaining(?:\s*\(replenishes\s*\+\$?([\d,]+(?:\.\d+)?)\s*/\s*hour\))?"#
         if let match = captures(freeDollarPattern, in: text),
            let remaining = dollars(match[0]),
@@ -61,21 +62,21 @@ nonisolated enum AmpQuotaParser {
             let reset = hourly > 0
                 ? ISO8601DateFormatter().string(from: now.addingTimeInterval(used / hourly * 3600))
                 : ""
-            models.append(ModelQuota(
+            freeModel = ModelQuota(
                 name: "amp-free",
                 percentage: remaining / limit * 100,
                 resetTime: reset,
                 presentation: .progress(used: used, limit: limit, unit: .usd)
-            ))
+            )
         } else if let match = captures(
             #"(?im)^\s*Amp Free:\s*([\d.]+)%\s+remaining(?:\s+today)?(?:\s*\(resets\s+daily\))?"#,
             in: text
         ), let remaining = validPercentage(match[0]) {
-            models.append(ModelQuota(
+            freeModel = ModelQuota(
                 name: "amp-free",
                 percentage: remaining,
                 resetTime: nextMidnightUTC(after: now)
-            ))
+            )
         }
 
         var plan = identity.flatMap { $0[1].isEmpty ? nil : $0[1] }
@@ -100,6 +101,8 @@ nonisolated enum AmpQuotaParser {
                 }
             }
         }
+
+        if let freeModel { models.append(freeModel) }
 
         if let match = captures(
             #"(?im)^\s*Individual credits:\s*\$?([\d,]+(?:\.\d+)?)\s+remaining"#,

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -1075,16 +1075,22 @@ private struct MenuAccountCardView: View {
     // MARK: - Quota Content
     
     private var quotaContentSection: some View {
+        let isCardStyle = displayStyle == .card
         let models: [ModelBadgeData] = {
             if isAntigravity {
                 return antigravityGroups.map { ModelBadgeData(name: $0.name, percentage: $0.percentage, resetTime: $0.resetTime) }
             } else {
-                return data.models.filter { !$0.isStandaloneMetric }.map {
+                let meterModels = data.models.filter { !$0.isStandaloneMetric }.map {
                     ModelBadgeData(name: $0.displayName, percentage: $0.percentage, resetTime: $0.resetTime)
                 }
+                guard isCardStyle else { return meterModels }
+                let standaloneModels = data.models.filter(\.isStandaloneMetric).map {
+                    ModelBadgeData(name: $0.displayName, percentage: $0.percentage, resetTime: $0.resetTime, usage: $0.formattedUsage)
+                }
+                return meterModels + standaloneModels
             }
         }()
-        let standaloneModels = isAntigravity ? [] : data.models.filter(\.isStandaloneMetric)
+        let standaloneModels = isAntigravity || isCardStyle ? [] : data.models.filter(\.isStandaloneMetric)
         let factorySections = provider == .factoryDroid
             ? FactoryDroidQuotaSection.sections(from: data.models.filter { !$0.isStandaloneMetric })
             : []
@@ -2118,6 +2124,14 @@ private struct ModelBadgeData: Identifiable {
     let name: String
     let percentage: Double
     let resetTime: String?
+    let usage: String?
+
+    init(name: String, percentage: Double, resetTime: String?, usage: String? = nil) {
+        self.name = name
+        self.percentage = percentage
+        self.resetTime = resetTime
+        self.usage = usage
+    }
 
     var id: String { name }
 
@@ -2345,12 +2359,20 @@ private struct CardGridLayout: View {
                                 .font(.system(size: 9, design: .rounded))
                                 .foregroundStyle(.tertiary)
                         }
-                        Text(menuPercentText(remainingPercent: model.percentage, displayMode: displayMode))
-                            .font(.system(size: 10, weight: .bold, design: .monospaced))
-                            .foregroundStyle(menuStatusColor(remainingPercent: model.percentage, displayMode: displayMode))
+                        if let usage = model.usage {
+                            Text(usage)
+                                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                                .foregroundStyle(.primary)
+                        } else {
+                            Text(menuPercentText(remainingPercent: model.percentage, displayMode: displayMode))
+                                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                                .foregroundStyle(menuStatusColor(remainingPercent: model.percentage, displayMode: displayMode))
+                        }
                     }
 
-                    ModernProgressBar(percentage: model.percentage, height: 4)
+                    if model.usage == nil {
+                        ModernProgressBar(percentage: model.percentage, height: 4)
+                    }
                 }
                 .padding(8)
                 .background(Color.secondary.opacity(0.05))

--- a/Quotio/Views/Screens/QuotaScreen.swift
+++ b/Quotio/Views/Screens/QuotaScreen.swift
@@ -913,6 +913,7 @@ private struct AccountQuotaCardV2: View {
     
     @ViewBuilder
     private func standardContentByStyle(data: ProviderQuotaData) -> some View {
+        let isCard = displayStyle == .card
         let meterModels = data.models.filter { !$0.isStandaloneMetric }
         let standaloneModels = data.models.filter(\.isStandaloneMetric)
         let factorySections = provider == .factoryDroid
@@ -931,8 +932,12 @@ private struct AccountQuotaCardV2: View {
                 meterContentByStyle(models: meterModels)
             }
 
-            ForEach(standaloneModels) { model in
-                StandaloneMetricRow(model: model)
+            if isCard {
+                meterContentByStyle(models: standaloneModels)
+            } else {
+                ForEach(standaloneModels) { model in
+                    StandaloneMetricRow(model: model)
+                }
             }
         }
     }

--- a/QuotioTests/AmpQuotaFetcherTests.swift
+++ b/QuotioTests/AmpQuotaFetcherTests.swift
@@ -105,6 +105,7 @@ final class AmpQuotaFetcherTests: XCTestCase {
         """
         let quota = try XCTUnwrap(AmpQuotaParser.parse(displayText: text))
         XCTAssertEqual(quota.planType, "Megawatt")
+        XCTAssertEqual(quota.models.map(\.name), ["amp-agent-usage", "amp-orb-usage", "amp-free", "amp-individual-credits"])
         XCTAssertEqual(quota.models.first(where: { $0.name == "amp-free" })?.percentage, 0)
         XCTAssertEqual(quota.models.first(where: { $0.name == "amp-agent-usage" })?.percentage, 100)
         XCTAssertEqual(quota.models.first(where: { $0.name == "amp-orb-usage" })?.percentage, 100)

--- a/QuotioTests/AmpQuotaFetcherTests.swift
+++ b/QuotioTests/AmpQuotaFetcherTests.swift
@@ -58,7 +58,7 @@ final class AmpQuotaFetcherTests: XCTestCase {
         let text = """
         Signed in as person@example.com (Pro)
         Amp Free: 75% remaining today (resets daily)
-        Subscription Megawatt: 40% agent usage and 60% orb usage remaining
+        Amp Megawatt Subscription: 40% agent usage and 60% orb usage remaining
         Individual credits: $12.50 remaining
         Workspace Acme: $8.25 remaining
         """
@@ -77,7 +77,7 @@ final class AmpQuotaFetcherTests: XCTestCase {
     func testParserMapsSubscriptionOtherUsageAndRenewalSuffix() throws {
         let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-11T12:00:00Z"))
         let quota = try XCTUnwrap(AmpQuotaParser.parse(
-            displayText: "Subscription Megawatt: 64% other usage and 98% orb usage remaining - resets upon renewal in 22 days",
+            displayText: "Amp Megawatt Subscription: 64% other usage and 98% orb usage remaining - resets upon renewal in 22 days",
             now: now
         ))
         let agent = try XCTUnwrap(quota.models.first(where: { $0.name == "amp-agent-usage" }))
@@ -92,6 +92,23 @@ final class AmpQuotaFetcherTests: XCTestCase {
         XCTAssertEqual(orb.usedPercentage, 2)
         XCTAssertEqual(orb.displayName, "Orb Usage")
         XCTAssertEqual(orb.resetTime, "2026-09-02T12:00:00Z")
+    }
+
+    func testParserMapsRealBalanceOutputWithFreeAndSubscription() throws {
+        let text = """
+        Signed in as nguyenphutrong.dev@gmail.com (trng)
+        Amp Free: 0% remaining today (resets daily) - https://ampcode.com/settings#amp-free
+        Amp Megawatt Subscription: 100% other usage and 100% orb usage remaining - resets upon renewal in 1 month
+        Individual credits: $21.57 remaining (set up auto-reload to avoid running out) - https://ampcode.com/settings
+
+        Run amp usage --details for more detailed information.
+        """
+        let quota = try XCTUnwrap(AmpQuotaParser.parse(displayText: text))
+        XCTAssertEqual(quota.planType, "Megawatt")
+        XCTAssertEqual(quota.models.first(where: { $0.name == "amp-free" })?.percentage, 0)
+        XCTAssertEqual(quota.models.first(where: { $0.name == "amp-agent-usage" })?.percentage, 100)
+        XCTAssertEqual(quota.models.first(where: { $0.name == "amp-orb-usage" })?.percentage, 100)
+        XCTAssertEqual(quota.models.first(where: { $0.name == "amp-individual-credits" })?.presentation, .amount(value: 21.57, unit: .usd, semantics: .balance))
     }
 
     func testParserUsesIdentityPlanWhenSubscriptionIsMissing() throws {


### PR DESCRIPTION
Fixes Amp quota display for users who have both a subscription and free quota: the subscription line was never parsed because the real Amp output is `Amp <Plan> Subscription:` while the parser expected `Subscription <Plan>:`. The menu bar pair could not resolve, so it fell back to showing only the free quota. Also renders the Individual Credits (now "Balance") amount as a card alongside the other quota items and orders the cards Agent Usage, Orb Usage, Amp Free, Balance.

- fix(amp): parse subscription line from real Amp balance output
- fix(amp): rename individual credits label and drop balance suffix
- fix(amp): order subscription quota before free in model list
- feat(quota): render standalone metrics as cards
