### PR TITLE
fix(monitor): read Factory Droid loginkeychain credentials

### DIFF
--- a/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/FactoryDroidQuotaFetcher.swift
@@ -17,35 +17,38 @@ nonisolated enum FactoryDroidCredentialReader {
     static let credentialsDirectory = "~/.factory"
 
     static func load(directory: URL? = nil) -> FactoryDroidCredential? {
+        load(directory: directory, keychainKey: factoryCLIEncryptionKey())
+    }
+
+    static func load(directory: URL?, keychainKey: Data?) -> FactoryDroidCredential? {
         let directory = directory ?? URL(
             fileURLWithPath: MonitorIdentity.expand(credentialsDirectory),
             isDirectory: true
         )
 
-        let keyFileCredentials = directory.appendingPathComponent("auth.v2.file")
-        let keyFileKey = directory.appendingPathComponent("auth.v2.key")
-        if let credential = loadEncrypted(
-            credentialsURL: keyFileCredentials,
-            keyData: try? Data(contentsOf: keyFileKey)
-        ) {
-            return credential
+        let candidates: [(url: URL, keyData: Data?)] = [
+            (directory.appendingPathComponent("auth.v2.loginkeychain"), keychainKey),
+            (directory.appendingPathComponent("auth.v2.file"), try? Data(contentsOf: directory.appendingPathComponent("auth.v2.key"))),
+            (directory.appendingPathComponent("auth.v2.keyring"), keychainKey),
+        ]
+        var newest: (date: Date, credential: FactoryDroidCredential)?
+        for candidate in candidates {
+            guard let date = (try? candidate.url.resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate,
+                let credential = loadEncrypted(credentialsURL: candidate.url, keyData: candidate.keyData)
+            else { continue }
+            if newest == nil || date > newest!.date {
+                newest = (date, credential)
+            }
         }
-
-        let keyringCredentials = directory.appendingPathComponent("auth.v2.keyring")
-        let keyringKey = KeychainHelper.readExternalCredential(
-            service: "Factory CLI",
-            account: "auth-encryption-key"
-        )
-        if let credential = loadEncrypted(credentialsURL: keyringCredentials, keyData: keyringKey) {
-            return credential
-        }
+        if let newest { return newest.credential }
 
         let legacyURL = directory.appendingPathComponent("auth.encrypted")
         guard let legacyData = try? Data(contentsOf: legacyURL) else { return nil }
         if let credential = parseCredential(legacyData, sourcePath: legacyURL.path) {
             return credential
         }
-        guard let key = normalizedKey(keyringKey),
+        guard let key = normalizedKey(keychainKey),
               let encrypted = String(data: legacyData, encoding: .utf8),
               let decrypted = decrypt(encrypted, key: key) else { return nil }
         return parseCredential(decrypted, sourcePath: legacyURL.path)
@@ -78,7 +81,7 @@ nonisolated enum FactoryDroidCredentialReader {
             let keyData: Data? = if credentialsURL.lastPathComponent == "auth.v2.file" {
                 try? Data(contentsOf: credentialsURL.deletingLastPathComponent().appendingPathComponent("auth.v2.key"))
             } else {
-                KeychainHelper.readExternalCredential(service: "Factory CLI", account: "auth-encryption-key")
+                factoryCLIEncryptionKey()
             }
 
             let cleartext: Data
@@ -131,7 +134,7 @@ nonisolated enum FactoryDroidCredentialReader {
         let keyData: Data? = if credentialsURL.lastPathComponent == "auth.v2.file" {
             try? Data(contentsOf: credentialsURL.deletingLastPathComponent().appendingPathComponent("auth.v2.key"))
         } else {
-            KeychainHelper.readExternalCredential(service: "Factory CLI", account: "auth-encryption-key")
+            factoryCLIEncryptionKey()
         }
         guard let encrypted = String(data: storedData, encoding: .utf8),
               let key = normalizedKey(keyData),
@@ -258,6 +261,12 @@ nonisolated enum FactoryDroidCredentialReader {
             }
             return Date().timeIntervalSince(modificationDate) >= 10
         }
+    }
+
+    private static func factoryCLIEncryptionKey() -> Data? {
+        KeychainHelper.readExternalCredential(service: "Factory CLI", account: "auth-encryption-key-security-cli")
+            ?? KeychainHelper.readExternalCredential(service: "Factory CLI")
+            ?? KeychainHelper.readExternalCredential(service: "Factory CLI", account: "auth-encryption-key")
     }
 
     private static func normalizedKey(_ data: Data?) -> Data? {

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -686,6 +686,56 @@ final class MonitorRuntimeTests: XCTestCase {
         )
     }
 
+    func testFactoryDroidLoadsNewestCredentialAcrossFormats() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileKeyData = Data(repeating: 7, count: 32)
+        try Data(fileKeyData.base64EncodedString().utf8).write(to: directory.appendingPathComponent("auth.v2.key"))
+        let staleNonce = try AES.GCM.Nonce(data: Data(repeating: 1, count: 16))
+        let staleSealed = try AES.GCM.seal(
+            Data(#"{"access_token":"stale-token","refresh_token":"stale-refresh","active_organization_id":"org-123"}"#.utf8),
+            using: SymmetricKey(data: fileKeyData),
+            nonce: staleNonce
+        )
+        let fileURL = directory.appendingPathComponent("auth.v2.file")
+        try Data([
+            Data(staleNonce).base64EncodedString(),
+            staleSealed.tag.base64EncodedString(),
+            staleSealed.ciphertext.base64EncodedString(),
+        ].joined(separator: ":").utf8).write(to: fileURL)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 0)],
+            ofItemAtPath: fileURL.path
+        )
+
+        let keychainKeyData = Data(repeating: 9, count: 32)
+        let liveNonce = try AES.GCM.Nonce(data: Data(repeating: 2, count: 16))
+        let liveSealed = try AES.GCM.seal(
+            Data(#"{"access_token":"live-token","refresh_token":"live-refresh","active_organization_id":"org-123"}"#.utf8),
+            using: SymmetricKey(data: keychainKeyData),
+            nonce: liveNonce
+        )
+        try Data([
+            Data(liveNonce).base64EncodedString(),
+            liveSealed.tag.base64EncodedString(),
+            liveSealed.ciphertext.base64EncodedString(),
+        ].joined(separator: ":").utf8).write(to: directory.appendingPathComponent("auth.v2.loginkeychain"))
+
+        let credential = FactoryDroidCredentialReader.load(
+            directory: directory,
+            keychainKey: Data(keychainKeyData.base64EncodedString().utf8)
+        )
+
+        XCTAssertEqual(credential?.accessToken, "live-token")
+        XCTAssertEqual(credential?.refreshToken, "live-refresh")
+        XCTAssertEqual(
+            credential?.sourcePath,
+            directory.appendingPathComponent("auth.v2.loginkeychain").path
+        )
+    }
+
     func testFactoryDroidPersistsRotatedEncryptedCredentialWithoutDroppingFields() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)


### PR DESCRIPTION
Factory CLI migrated its credential store to `~/.factory/auth.v2.loginkeychain` (encryption key in the login Keychain under `auth-encryption-key-security-cli`), but the monitor only read the stale `auth.v2.file`. That file held an access token that expired on Aug 17, so quota fell back to the dead session: the WorkOS refresh flow rejected the already-rotated refresh token (`invalid_grant`, "Session has already ended.") and Factory Droid quota stopped showing.

This restores quota fetching for the live Factory session.

- Read the newest decryptable credential across `auth.v2.loginkeychain`, `auth.v2.file`, and `auth.v2.keyring`, so the app always follows whichever file Factory CLI currently writes
- Resolve the Factory CLI Keychain key under the current account (`auth-encryption-key-security-cli`) with fallbacks, in `load`, `persistRefresh`, and `canPersistRefresh`, so refresh rotation persists to the live file
- Add regression test pinning the newest-credential selection across formats
