### PR TITLE
fix(keychain): prevent background authorization prompts

### DIFF
--- a/Quotio/Services/Monitor/MonitorRuntime.swift
+++ b/Quotio/Services/Monitor/MonitorRuntime.swift
@@ -583,9 +583,6 @@ actor MonitorAccountDiscovery {
            (oauth["accessToken"] as? String)?.isEmpty == false {
             accounts.append(.make(provider: .claude, accountKey: (oauth["email"] as? String) ?? "Claude Code", source: .nativeCredential, credentialReference: "keychain:Claude Code-credentials"))
         }
-        if KeychainHelper.readExternalCredential(service: "gh:github.com") != nil {
-            accounts.append(.make(provider: .copilot, accountKey: "GitHub Copilot", source: .nativeCredential, credentialReference: "keychain:gh:github.com"))
-        }
         return accounts
     }
 }

--- a/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CopilotQuotaFetcher.swift
@@ -366,12 +366,6 @@ actor CopilotQuotaFetcher {
                 if !token.isEmpty { tokens.append(token) }
             }
         }
-
-        if let data = KeychainHelper.readExternalCredential(service: "gh:github.com"),
-           let token = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !token.isEmpty {
-            tokens.append(token)
-        }
         return Array(Set(tokens))
     }
 

--- a/Quotio/Services/YubiKeySecretVault.swift
+++ b/Quotio/Services/YubiKeySecretVault.swift
@@ -283,26 +283,32 @@ nonisolated enum YubiKeySecretVault {
         return driver == "com.apple.pivtoken" || driver == "com.apple.CryptoTokenKit.pivtoken"
     }
 
-    static func availableIdentities() -> [YubiKeyPIVIdentity] {
+    static func availableIdentityQuery() -> [String: Any] {
         let context = LAContext()
         context.interactionNotAllowed = true
-        let query: [String: Any] = [
+        return [
             kSecClass as String: kSecClassIdentity,
+            kSecAttrAccessGroup as String: kSecAttrAccessGroupToken,
+            kSecReturnAttributes as String: true,
             kSecReturnRef as String: true,
             kSecMatchLimit as String: kSecMatchLimitAll,
             kSecUseAuthenticationContext as String: context,
         ]
+    }
+
+    static func availableIdentities() -> [YubiKeyPIVIdentity] {
+        let query = availableIdentityQuery()
         var result: CFTypeRef?
         guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-              let identities = result as? [SecIdentity] else { return [] }
+              let items = result as? [[String: Any]] else { return [] }
 
-        return identities.compactMap { identity in
-            guard let privateKey = privateKey(for: identity),
-                  let attributes = SecKeyCopyAttributes(privateKey) as? [String: Any],
-                  isPIVToken(attributes[kSecAttrTokenID as String] as? String),
-                  let certificate = certificate(for: identity),
-                  // Export the certificate's public key, not one derived from the
-                  // token's private key, which makes macOS request authorization.
+        return items.compactMap { item in
+            guard isPIVToken(item[kSecAttrTokenID as String] as? String),
+                  let reference = item[kSecValueRef as String] else { return nil }
+            let cfReference = reference as CFTypeRef
+            guard CFGetTypeID(cfReference) == SecIdentityGetTypeID() else { return nil }
+            let identity = reference as! SecIdentity
+            guard let certificate = certificate(for: identity),
                   let publicKey = SecCertificateCopyKey(certificate),
                   SecKeyIsAlgorithmSupported(publicKey, .encrypt, .rsaEncryptionOAEPSHA256),
                   let external = SecKeyCopyExternalRepresentation(publicKey, nil) as Data? else { return nil }

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -200,16 +200,16 @@ final class MonitorRuntimeTests: XCTestCase {
     }
 
     func testExternalCredentialOperationsDoNotAllowAuthenticationUI() {
-        let readQuery = KeychainHelper.externalCredentialQuery(service: "gh:github.com", account: "github.com")
-        let updateQuery = KeychainHelper.externalCredentialUpdateQuery(service: "gh:github.com", account: "github.com")
+        let readQuery = KeychainHelper.externalCredentialQuery(service: "fixture.external", account: "fixture-account")
+        let updateQuery = KeychainHelper.externalCredentialUpdateQuery(service: "fixture.external", account: "fixture-account")
 
-        XCTAssertEqual(readQuery[kSecAttrService as String] as? String, "gh:github.com")
-        XCTAssertEqual(readQuery[kSecAttrAccount as String] as? String, "github.com")
+        XCTAssertEqual(readQuery[kSecAttrService as String] as? String, "fixture.external")
+        XCTAssertEqual(readQuery[kSecAttrAccount as String] as? String, "fixture-account")
         XCTAssertTrue(
             (readQuery[kSecUseAuthenticationContext as String] as? LAContext)?.interactionNotAllowed == true
         )
-        XCTAssertEqual(updateQuery[kSecAttrService as String] as? String, "gh:github.com")
-        XCTAssertEqual(updateQuery[kSecAttrAccount as String] as? String, "github.com")
+        XCTAssertEqual(updateQuery[kSecAttrService as String] as? String, "fixture.external")
+        XCTAssertEqual(updateQuery[kSecAttrAccount as String] as? String, "fixture-account")
         XCTAssertTrue(
             (updateQuery[kSecUseAuthenticationContext as String] as? LAContext)?.interactionNotAllowed == true
         )

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -147,6 +147,19 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertFalse(YubiKeySecretVault.isPIVToken("com.apple.pivtokenizer:1234"))
     }
 
+    func testPIVIdentityQueryOnlyReturnsExternalTokenMetadataAndReferences() {
+        let query = YubiKeySecretVault.availableIdentityQuery()
+
+        XCTAssertEqual(query[kSecClass as String] as? String, kSecClassIdentity as String)
+        XCTAssertEqual(query[kSecAttrAccessGroup as String] as? String, kSecAttrAccessGroupToken as String)
+        XCTAssertEqual(query[kSecReturnAttributes as String] as? Bool, true)
+        XCTAssertEqual(query[kSecReturnRef as String] as? Bool, true)
+        XCTAssertNil(query[kSecReturnData as String])
+        XCTAssertTrue(
+            (query[kSecUseAuthenticationContext as String] as? LAContext)?.interactionNotAllowed == true
+        )
+    }
+
     /// The rollback this prevents: with the vault enabled and the key absent or
     /// the PIN prompt dismissed, `CLIProxyManager.init` reads nil, mints a fresh
     /// UUID and saves it — destroying the envelope holding the real management


### PR DESCRIPTION
Background Copilot discovery still read GitHub CLI's legacy `gh:github.com` item, while PIV identity discovery requested full private-key attributes that legacy Keychain can satisfy through an export operation. This removes both background prompt paths while preserving file-based, CLIProxyAPI, Quotio-owned, and certificate-based credential flows.

- Stop automatic Copilot discovery and quota fetches from the GitHub CLI Keychain item.
- Restrict YubiKey identity enumeration to external-token metadata and references, without requesting software private-key attributes or key data.
- Add regression coverage for noninteractive external credential queries and PIV query scope.
- Users whose Copilot token exists only in GitHub CLI's Keychain will need another supported credential source; no foreground import flow is added here.

## Validation
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug -destination 'platform=macOS' -only-testing:QuotioTests/MonitorRuntimeTests -only-testing:QuotioTests/CopilotQuotaFetcherTests test` — 99 passed
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug -destination 'platform=macOS' -only-testing:QuotioTests/MonitorRuntimeTests test` — 87 passed
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build` — succeeded
- `git diff --check` — passed

Fixes #447
Refs #490
