### PR TITLE
fix(dock): restore system-managed stable icon

### DIFF
--- a/Quotio/Services/UpdaterService.swift
+++ b/Quotio/Services/UpdaterService.swift
@@ -129,6 +129,7 @@ final class UpdaterService: NSObject {
         guard let iconImage = NSImage(named: iconName) else {
             NSApplication.shared.applicationIconImage = nil
             currentAppIcon = NSApplication.shared.applicationIconImage
+                ?? NSWorkspace.shared.icon(forFile: Bundle.main.bundlePath)
             return
         }
         

--- a/Quotio/Services/UpdaterService.swift
+++ b/Quotio/Services/UpdaterService.swift
@@ -123,9 +123,14 @@ final class UpdaterService: NSObject {
     // MARK: - Icon Management
     
     func updateAppIcon() {
-        let iconName = updateChannel == .beta ? "AppIconBetaImage" : "AppIconImage"
+        let channel = updateChannel
+        let iconName = channel == .beta ? "AppIconBetaImage" : "AppIconImage"
         
-        guard let iconImage = NSImage(named: iconName) else { return }
+        guard let iconImage = NSImage(named: iconName) else {
+            NSApplication.shared.applicationIconImage = nil
+            currentAppIcon = NSApplication.shared.applicationIconImage
+            return
+        }
         
         let displaySize = NSSize(width: 256, height: 256)
         let roundedIcon = NSImage(size: displaySize, flipped: false) { rect in
@@ -136,7 +141,13 @@ final class UpdaterService: NSObject {
         }
         
         self.currentAppIcon = roundedIcon
-        NSApplication.shared.applicationIconImage = roundedIcon
+
+        if channel == .beta {
+            NSApplication.shared.applicationIconImage = roundedIcon
+        } else {
+            // Restore the bundle icon so macOS can apply the system icon appearance.
+            NSApplication.shared.applicationIconImage = nil
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Let macOS manage the Stable channel app icon so system icon appearances work.
- Keep the custom runtime icon for the Beta channel.
- Fall back to the bundle icon if a runtime icon asset cannot be loaded.

## Problem

`UpdaterService` assigns a rendered `NSImage` to
`NSApplication.shared.applicationIconImage` for both Stable and Beta channels.

On macOS 26, this runtime override prevents the Stable icon from participating
in the system-managed Default, Dark, Clear, and Tinted appearance pipeline.

## Changes

- Cache the current update channel while updating the icon.
- Preserve the rounded image in `currentAppIcon` for in-app presentation.
- Assign the rounded runtime icon only for the Beta channel.
- Clear `applicationIconImage` for Stable so AppKit falls back to the bundle icon.
- Clear the override safely when an icon asset is unavailable.

## Appearance verification

Captured from the final v0.29.1 build on macOS 26.5.

| Default | Dark | Clear | Tinted |
|---|---|---|---|
| ![Default](https://raw.githubusercontent.com/shockbladenull/quotio/fec48843da377c9dc3979b5e31e0f079e595303a/docs/pr-assets/system-managed-stable-icon/default.png) | ![Dark](https://raw.githubusercontent.com/shockbladenull/quotio/fec48843da377c9dc3979b5e31e0f079e595303a/docs/pr-assets/system-managed-stable-icon/dark.png) | ![Clear](https://raw.githubusercontent.com/shockbladenull/quotio/fec48843da377c9dc3979b5e31e0f079e595303a/docs/pr-assets/system-managed-stable-icon/clear.png) | ![Tinted](https://raw.githubusercontent.com/shockbladenull/quotio/fec48843da377c9dc3979b5e31e0f079e595303a/docs/pr-assets/system-managed-stable-icon/tinted.png) |

All four system appearances produced distinct rendered output.

## Verification

Tested from upstream `master` at `5a9c369` (version 0.29.1) using Xcode 26.6
on macOS 26.5.

- Debug build completed successfully.
- Verified Stable under all four top-level system icon styles:
  - Default
  - Dark
  - Clear
  - Tinted
- Each style produced a distinct system-rendered icon.
- Verified Beta still installs its custom 256×256 runtime icon.
- Verified switching back to Stable restores the bundle/system-managed icon.
- Restored the original update-channel and system-appearance preferences after testing.

## Scope

This change does not add dedicated Dark or monochrome artwork and does not
convert the existing icon assets to Icon Composer. macOS continues to derive
those appearances from the existing bundle icon.

The Beta icon intentionally remains a fixed runtime icon so it stays visually
distinct from Stable.
