### PR TITLE
fix(glm): support CREDIT_LIMIT quota windows

### DIFF
--- a/Quotio/Services/GLMQuotaFetcher.swift
+++ b/Quotio/Services/GLMQuotaFetcher.swift
@@ -173,7 +173,7 @@ actor GLMQuotaFetcher {
             } ?? ""
             let kind = limit.type ?? limit.name
 
-            if kind == "TOKENS_LIMIT",
+            if (kind == "TOKENS_LIMIT" || kind == "CREDIT_LIMIT"),
                let percentage = limit.percentage,
                let unit = limit.unit,
                let number = limit.number,

--- a/QuotioTests/GLMQuotaFetcherTests.swift
+++ b/QuotioTests/GLMQuotaFetcherTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Quotio
+
+final class GLMQuotaFetcherTests: XCTestCase {
+    func testMapQuotaDataAcceptsCreditLimitWindows() {
+        let quota = GLMQuotaFetcher.mapQuotaData(
+            GLMQuotaData(limits: [
+                GLMLimit(
+                    type: "CREDIT_LIMIT",
+                    unit: 3,
+                    number: 5,
+                    percentage: 5,
+                    nextResetTime: 1_786_073_946_574
+                ),
+                GLMLimit(
+                    type: "CREDIT_LIMIT",
+                    unit: 6,
+                    number: 1,
+                    percentage: 10,
+                    nextResetTime: 1_786_660_488_998
+                )
+            ]),
+            planName: "GLM Coding Max"
+        )
+
+        XCTAssertEqual(quota.planType, "GLM Coding Max")
+        XCTAssertEqual(quota.models.map(\.name), ["zai-session", "zai-weekly"])
+        XCTAssertEqual(quota.models.map(\.percentage), [95, 90])
+        XCTAssertTrue(quota.models.allSatisfy { !$0.resetTime.isEmpty })
+    }
+}


### PR DESCRIPTION
## Summary

Z.ai Coding Plan accounts now return `CREDIT_LIMIT` entries for 5-hour and weekly usage-credit windows. Quotio currently accepts only `TOKENS_LIMIT` and `TIME_LIMIT`, so valid responses are rendered as `No quota data yet`.

## Why this was missed

- The original GLM provider implementation in PR #77 (merged January 4, 2026) explicitly modeled only `TOKENS_LIMIT` and `TIME_LIMIT`.
- The July GLM/Monitor refactor in PR #439 broadened field and window handling but retained the `TOKENS_LIMIT` type gate. Its fixtures also covered only token/time rows.
- No `CREDIT_LIMIT` fixture existed before this change.
- Comparable upstream evidence: [CodexBar #2724](https://github.com/steipete/CodexBar/issues/2724) documents the same Z.ai response shape and symptom; [CodexBar #2751](https://github.com/steipete/CodexBar/pull/2751) handles credit limits as token-window equivalents.

## Changes

- Treat `CREDIT_LIMIT` like `TOKENS_LIMIT` in `GLMQuotaFetcher.mapQuotaData`.
- Preserve existing unit/number window mapping and percentage conversion.
- Add regression coverage for 5-hour and weekly `CREDIT_LIMIT` entries.

## Verification

- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug -destination 'platform=macOS' test -only-testing:QuotioTests/GLMQuotaFetcherTests`
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build`

Both passed locally.