### PR TITLE
fix(menubar): follow explicit app appearance

### DIFF
--- a/Quotio/Models/MenuBarSettings.swift
+++ b/Quotio/Models/MenuBarSettings.swift
@@ -89,6 +89,22 @@ enum AppearanceMode: String, CaseIterable, Identifiable {
         case .dark: return "moon.fill"
         }
     }
+
+    var appKitAppearance: NSAppearance? {
+        switch self {
+        case .system: nil
+        case .light: NSAppearance(named: .aqua)
+        case .dark: NSAppearance(named: .darkAqua)
+        }
+    }
+
+    var preferredColorScheme: ColorScheme? {
+        switch self {
+        case .system: nil
+        case .light: .light
+        case .dark: .dark
+        }
+    }
 }
 
 // MARK: - Appearance Settings Manager
@@ -117,14 +133,7 @@ final class AppearanceManager {
     
     /// Apply the current appearance mode to the app
     func applyAppearance() {
-        switch appearanceMode {
-        case .system:
-            NSApp.appearance = nil
-        case .light:
-            NSApp.appearance = NSAppearance(named: .aqua)
-        case .dark:
-            NSApp.appearance = NSAppearance(named: .darkAqua)
-        }
+        NSApp.appearance = appearanceMode.appKitAppearance
     }
 }
 

--- a/Quotio/Models/MenuBarSettings.swift
+++ b/Quotio/Models/MenuBarSettings.swift
@@ -97,14 +97,6 @@ enum AppearanceMode: String, CaseIterable, Identifiable {
         case .dark: NSAppearance(named: .darkAqua)
         }
     }
-
-    var preferredColorScheme: ColorScheme? {
-        switch self {
-        case .system: nil
-        case .light: .light
-        case .dark: .dark
-        }
-    }
 }
 
 // MARK: - Appearance Settings Manager

--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -228,6 +228,9 @@ struct QuotioApp: App {
                         bootstrap.updateStatusBar()
                         statusBarManager.rebuildMenuInPlace()
                     }
+                    .onChange(of: appearanceManager.appearanceMode) {
+                        statusBarManager.refreshMenuAppearance()
+                    }
                     .onChange(of: menuBarSettings.showQuotaInMenuBar) {
                         bootstrap.updateStatusBar()
                     }

--- a/Quotio/QuotioApp.swift
+++ b/Quotio/QuotioApp.swift
@@ -229,7 +229,7 @@ struct QuotioApp: App {
                         statusBarManager.rebuildMenuInPlace()
                     }
                     .onChange(of: appearanceManager.appearanceMode) {
-                        statusBarManager.refreshMenuAppearance()
+                        statusBarManager.rebuildMenuInPlace()
                     }
                     .onChange(of: menuBarSettings.showQuotaInMenuBar) {
                         bootstrap.updateStatusBar()

--- a/Quotio/Services/StatusBarManager.swift
+++ b/Quotio/Services/StatusBarManager.swift
@@ -230,11 +230,6 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
         performMenuRebuild(using: menu)
     }
 
-    func refreshMenuAppearance() {
-        menu?.appearance = AppearanceManager.shared.appearanceMode.appKitAppearance
-        rebuildMenuInPlace()
-    }
-
     /// Close the menu programmatically
     func closeMenu() {
         menu?.cancelTracking()

--- a/Quotio/Services/StatusBarManager.swift
+++ b/Quotio/Services/StatusBarManager.swift
@@ -95,6 +95,7 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
             menu = NSMenu()
             menu?.autoenablesItems = false
             menu?.delegate = self
+            menu?.appearance = AppearanceManager.shared.appearanceMode.appKitAppearance
         }
         
         // Attach menu to status item
@@ -229,6 +230,11 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
         performMenuRebuild(using: menu)
     }
 
+    func refreshMenuAppearance() {
+        menu?.appearance = AppearanceManager.shared.appearanceMode.appKitAppearance
+        rebuildMenuInPlace()
+    }
+
     /// Close the menu programmatically
     func closeMenu() {
         menu?.cancelTracking()
@@ -251,6 +257,7 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
             }
         }
 
+        menu.appearance = AppearanceManager.shared.appearanceMode.appKitAppearance
         menu.removeAllItems()
 
         guard let builder = menuBuilder else { return }

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -38,8 +38,7 @@ final class StatusBarMenuBuilder {
     // MARK: - Build Menu
     
     func buildMenu() -> NSMenu {
-        let menu = NSMenu()
-        menu.autoenablesItems = false
+        let menu = makeMenu()
 
         // 1. Header
         menu.addItem(buildHeaderItem())
@@ -322,8 +321,7 @@ final class StatusBarMenuBuilder {
     }
 
     private func buildCodexAnalyticsSubmenu(analytics: QuotaAnalytics) -> NSMenu {
-        let submenu = NSMenu()
-        submenu.autoenablesItems = false
+        let submenu = makeMenu()
         submenu.addItem(viewItem(for: AnalyticsDetailSection(analytics: analytics), width: 640))
         return submenu
     }
@@ -331,8 +329,7 @@ final class StatusBarMenuBuilder {
     // MARK: - Antigravity Submenu
 
     private func buildAntigravitySubmenu(data: ProviderQuotaData) -> NSMenu {
-        let submenu = NSMenu()
-        submenu.autoenablesItems = false
+        let submenu = makeMenu()
 
         let hasSummary = data.models.contains { $0.name.hasPrefix("antigravity-") }
         let allModels = hasSummary ? data.models : data.models.sorted { $0.name < $1.name }
@@ -390,13 +387,23 @@ final class StatusBarMenuBuilder {
     }
     
     // MARK: - Helpers
+
+    private func makeMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+        menu.appearance = AppearanceManager.shared.appearanceMode.appKitAppearance
+        return menu
+    }
     
     private func viewItem<V: View>(for view: V, width: CGFloat? = nil) -> NSMenuItem {
         let effectiveWidth = width ?? menuWidth
+        let appearanceMode = AppearanceManager.shared.appearanceMode
         let rootView = view
             .frame(width: effectiveWidth)
             .environment(viewModel)
+            .preferredColorScheme(appearanceMode.preferredColorScheme)
         let hostingView = NSHostingView(rootView: rootView)
+        hostingView.appearance = appearanceMode.appKitAppearance
         hostingView.setFrameSize(hostingView.intrinsicContentSize)
         
         let item = NSMenuItem()

--- a/Quotio/Services/StatusBarMenuBuilder.swift
+++ b/Quotio/Services/StatusBarMenuBuilder.swift
@@ -401,7 +401,6 @@ final class StatusBarMenuBuilder {
         let rootView = view
             .frame(width: effectiveWidth)
             .environment(viewModel)
-            .preferredColorScheme(appearanceMode.preferredColorScheme)
         let hostingView = NSHostingView(rootView: rootView)
         hostingView.appearance = appearanceMode.appKitAppearance
         hostingView.setFrameSize(hostingView.intrinsicContentSize)

--- a/QuotioTests/AppearanceModeTests.swift
+++ b/QuotioTests/AppearanceModeTests.swift
@@ -1,0 +1,26 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import Quotio
+
+@MainActor
+final class AppearanceModeTests: XCTestCase {
+    func testSystemAppearanceInheritsFromTheMenuBar() {
+        XCTAssertNil(AppearanceMode.system.appKitAppearance)
+        XCTAssertNil(AppearanceMode.system.preferredColorScheme)
+    }
+
+    func testLightAppearanceUsesAquaAndLightColorScheme() throws {
+        let appearance = try XCTUnwrap(AppearanceMode.light.appKitAppearance)
+
+        XCTAssertEqual(appearance.name, .aqua)
+        XCTAssertEqual(AppearanceMode.light.preferredColorScheme, .light)
+    }
+
+    func testDarkAppearanceUsesDarkAquaAndDarkColorScheme() throws {
+        let appearance = try XCTUnwrap(AppearanceMode.dark.appKitAppearance)
+
+        XCTAssertEqual(appearance.name, .darkAqua)
+        XCTAssertEqual(AppearanceMode.dark.preferredColorScheme, .dark)
+    }
+}

--- a/QuotioTests/AppearanceModeTests.swift
+++ b/QuotioTests/AppearanceModeTests.swift
@@ -1,5 +1,4 @@
 import AppKit
-import SwiftUI
 import XCTest
 @testable import Quotio
 
@@ -7,20 +6,17 @@ import XCTest
 final class AppearanceModeTests: XCTestCase {
     func testSystemAppearanceInheritsFromTheMenuBar() {
         XCTAssertNil(AppearanceMode.system.appKitAppearance)
-        XCTAssertNil(AppearanceMode.system.preferredColorScheme)
     }
 
-    func testLightAppearanceUsesAquaAndLightColorScheme() throws {
+    func testLightAppearanceUsesAqua() throws {
         let appearance = try XCTUnwrap(AppearanceMode.light.appKitAppearance)
 
         XCTAssertEqual(appearance.name, .aqua)
-        XCTAssertEqual(AppearanceMode.light.preferredColorScheme, .light)
     }
 
-    func testDarkAppearanceUsesDarkAquaAndDarkColorScheme() throws {
+    func testDarkAppearanceUsesDarkAqua() throws {
         let appearance = try XCTUnwrap(AppearanceMode.dark.appKitAppearance)
 
         XCTAssertEqual(appearance.name, .darkAqua)
-        XCTAssertEqual(AppearanceMode.dark.preferredColorScheme, .dark)
     }
 }


### PR DESCRIPTION
The menu bar panel inherited the system menu bar appearance even when Quotio was explicitly set to Light or Dark. This applies the selected appearance to the native menu surfaces and embedded SwiftUI content while leaving the status item adaptive to the system menu bar for contrast.

- Centralize the AppKit appearance and SwiftUI color-scheme mapping for each appearance mode.
- Apply the selected appearance to the main menu, submenus, and hosted SwiftUI views.
- Rebuild the menu panel when the appearance setting changes.
- Add regression coverage for System, Light, and Dark appearance mappings.

Closes #511
