### PR TITLE
fix(antigravity): reject malformed protobuf lengths

### DIFF
--- a/Quotio/Services/Antigravity/AntigravityProtobufHandler.swift
+++ b/Quotio/Services/Antigravity/AntigravityProtobufHandler.swift
@@ -50,23 +50,47 @@ nonisolated enum AntigravityProtobufHandler {
     /// Read a varint from data at offset, returns (value, newOffset)
     static func readVarint(_ data: Data, offset: Int) throws -> (UInt64, Int) {
         var result: UInt64 = 0
-        var shift: UInt64 = 0
         var pos = offset
         
-        while true {
-            guard pos < data.count else {
+        for byteIndex in 0..<10 {
+            guard pos >= 0, pos < data.count else {
                 throw ProtobufError.incompleteData
             }
             let byte = data[pos]
-            result |= UInt64(byte & 0x7F) << shift
+            let value = byte & 0x7F
+
+            guard byteIndex < 9 || value <= 1 else {
+                throw ProtobufError.incompleteData
+            }
+
+            result |= UInt64(value) << UInt64(byteIndex * 7)
             pos += 1
             if byte & 0x80 == 0 {
-                break
+                return (result, pos)
             }
-            shift += 7
         }
         
-        return (result, pos)
+        throw ProtobufError.incompleteData
+    }
+
+    /// Return a range only when its length fits entirely within the available data.
+    private static func lengthDelimitedRange(_ data: Data, offset: Int) throws -> Range<Int> {
+        let (length, contentOffset) = try readVarint(data, offset: offset)
+        let remainingCount = data.count - contentOffset
+
+        guard length <= UInt64(remainingCount) else {
+            throw ProtobufError.incompleteData
+        }
+
+        return contentOffset..<(contentOffset + Int(length))
+    }
+
+    private static func endOffset(_ data: Data, offset: Int, byteCount: Int) throws -> Int {
+        guard offset >= 0, offset <= data.count, byteCount <= data.count - offset else {
+            throw ProtobufError.incompleteData
+        }
+
+        return offset + byteCount
     }
     
     // MARK: - Field Operations
@@ -78,12 +102,11 @@ nonisolated enum AntigravityProtobufHandler {
             let (_, newOffset) = try readVarint(data, offset: offset)
             return newOffset
         case 1: // 64-bit
-            return offset + 8
+            return try endOffset(data, offset: offset, byteCount: 8)
         case 2: // Length-delimited
-            let (length, contentOffset) = try readVarint(data, offset: offset)
-            return contentOffset + Int(length)
+            return try lengthDelimitedRange(data, offset: offset).upperBound
         case 5: // 32-bit
-            return offset + 4
+            return try endOffset(data, offset: offset, byteCount: 4)
         default:
             throw ProtobufError.unknownWireType(wireType)
         }
@@ -127,8 +150,8 @@ nonisolated enum AntigravityProtobufHandler {
             let fieldNum = UInt32(tag >> 3)
             
             if fieldNum == targetField && wireType == 2 {
-                let (length, contentOffset) = try readVarint(data, offset: newOffset)
-                return Data(data[contentOffset..<(contentOffset + Int(length))])
+                let range = try lengthDelimitedRange(data, offset: newOffset)
+                return Data(data[range])
             }
             
             offset = try skipField(data, offset: newOffset, wireType: wireType)
@@ -341,16 +364,14 @@ nonisolated enum AntigravityProtobufHandler {
         // Field 6 contains: field 1 (access_token), field 2 (token_type "Bearer"), field 3 (refresh_token), field 4 (expiry)
         var offset = 0
         
-        while offset < data.count - 10 {
+        while offset + 10 < data.count {
             // Look for field 6 tag (0x32 = (6 << 3) | 2)
             if data[offset] == 0x32 {
                 // Try to read length
-                if let (length, contentOffset) = try? readVarint(data, offset: offset + 1) {
-                    let endOffset = contentOffset + Int(length)
-                    
+                if let range = try? lengthDelimitedRange(data, offset: offset + 1) {
                     // Sanity check
-                    if endOffset <= data.count && length > 100 && length < 2000 {
-                        let potentialOAuth = Data(data[contentOffset..<endOffset])
+                    if range.count > 100 && range.count < 2000 {
+                        let potentialOAuth = Data(data[range])
                         
                         // Check if this looks like OAuth data (should have field 1 with access_token)
                         if let tokenData = try? findField(potentialOAuth, targetField: 1),

--- a/QuotioTests/AntigravityProtobufHandlerTests.swift
+++ b/QuotioTests/AntigravityProtobufHandlerTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import Quotio
+
+final class AntigravityProtobufHandlerTests: XCTestCase {
+    func testExtractOAuthInfoRejectsOverflowingCandidateLengthWithoutCrashing() throws {
+        let data = Data([0x32] + Array(repeating: 0xFF, count: 9) + [0x01, 0x00])
+
+        let result = try AntigravityProtobufHandler.extractOAuthInfo(base64Data: data.base64EncodedString())
+
+        XCTAssertNil(result.accessToken)
+        XCTAssertNil(result.refreshToken)
+        XCTAssertNil(result.expiry)
+    }
+
+    func testFindFieldRejectsLengthBeyondRemainingData() {
+        let data = Data([0x0A, 0x05, 0x01])
+
+        XCTAssertThrowsError(try AntigravityProtobufHandler.findField(data, targetField: 1))
+    }
+
+    func testReadVarintRejectsMoreThanTenBytes() {
+        let data = Data(repeating: 0x80, count: 11)
+
+        XCTAssertThrowsError(try AntigravityProtobufHandler.readVarint(data, offset: 0))
+    }
+
+    func testExtractOAuthInfoHandlesShortInput() throws {
+        let data = Data([0x32, 0x01, 0x00])
+
+        let result = try AntigravityProtobufHandler.extractOAuthInfo(base64Data: data.base64EncodedString())
+
+        XCTAssertNil(result.accessToken)
+        XCTAssertNil(result.refreshToken)
+        XCTAssertNil(result.expiry)
+    }
+
+    func testExtractOAuthInfoPreservesValidOldFormatPayload() throws {
+        let accessToken = "ya29." + String(repeating: "a", count: 120)
+        let refreshToken = "refresh-token"
+        let expiry: Int64 = 1_800_000_000
+        let data = AntigravityProtobufHandler.createOAuthField(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            expiry: expiry
+        )
+
+        let result = try AntigravityProtobufHandler.extractOAuthInfo(base64Data: data.base64EncodedString())
+
+        XCTAssertEqual(result.accessToken, accessToken)
+        XCTAssertEqual(result.refreshToken, refreshToken)
+        XCTAssertEqual(result.expiry, expiry)
+    }
+}


### PR DESCRIPTION
Quotio can crash during startup when Antigravity IDE state contains a byte sequence that the OAuth parser reads as an overflowing protobuf length. Validate varints and field bounds before integer conversion or data slicing so malformed or unsupported state is rejected instead of triggering a Swift trap.

- Reject overflowing and overlong protobuf varints
- Bounds-check length-delimited and fixed-width fields before advancing or slicing
- Handle short OAuth payloads safely while preserving valid old-format extraction
- Add regression coverage for the reported crash payload and malformed field lengths

Tests:
- `xcodebuild test -project Quotio.xcodeproj -scheme Quotio -configuration Debug -only-testing:QuotioTests/AntigravityProtobufHandlerTests`
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build`

Fixes #514
