### PR TITLE
fix(codex): reconcile menu bar account quotas

### DIFF
--- a/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
@@ -488,13 +488,16 @@ actor CodexCLIQuotaFetcher {
         let currentByKey = Dictionary(grouping: current, by: \.key)
 
         for (key, quota) in quotas {
-            let accountIDs = Set(currentByKey[key, default: []].compactMap { identity -> String? in
+            let identities = currentByKey[key, default: []]
+            let accountIDs = identities.compactMap { identity -> String? in
                 guard let accountID = identity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
                       !accountID.isEmpty else { return nil }
                 return accountID
-            })
-            guard accountIDs.count == 1,
-                  let accountID = accountIDs.first,
+            }
+            let distinctAccountIDs = Set(accountIDs)
+            guard accountIDs.count == identities.count,
+                  distinctAccountIDs.count == 1,
+                  let accountID = distinctAccountIDs.first,
                   let legacyIdentity = uniqueLegacyByAccountID[accountID],
                   legacyIdentity.key != key else { continue }
             if promoted[legacyIdentity.key].map({ $0.lastUpdated <= quota.lastUpdated }) ?? true {

--- a/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
@@ -504,8 +504,6 @@ actor CodexCLIQuotaFetcher {
 
         for (email, entries) in legacyByEmail {
             let legacyAccounts = entries.map(\.1)
-            guard legacyAccounts.contains(where: { reconciled[$0.key] != nil }) else { continue }
-
             let legacyAccountIDs = Set(legacyAccounts.compactMap { identity -> String? in
                 guard let accountID = identity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
                       !accountID.isEmpty else { return nil }
@@ -514,13 +512,25 @@ actor CodexCLIQuotaFetcher {
             let matchingCurrent = current.filter {
                 $0.email?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == email
             }
-            for currentIdentity in matchingCurrent {
-                guard let freshQuota = reconciled[currentIdentity.key],
+            let promotableCurrent = matchingCurrent.filter { currentIdentity in
+                guard reconciled[currentIdentity.key] != nil,
                       let currentAccountID = currentIdentity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
                       !currentAccountID.isEmpty,
-                      matchingCurrent.filter({ $0.key == currentIdentity.key }).allSatisfy({
+                      legacyAccounts.contains(where: {
                           $0.accountID?.trimmingCharacters(in: .whitespacesAndNewlines) == currentAccountID
-                      }) else { continue }
+                      }) else { return false }
+                return matchingCurrent.filter({ $0.key == currentIdentity.key }).allSatisfy {
+                    $0.accountID?.trimmingCharacters(in: .whitespacesAndNewlines) == currentAccountID
+                }
+            }
+            guard legacyAccounts.contains(where: { reconciled[$0.key] != nil })
+                    || !promotableCurrent.isEmpty else { continue }
+
+            for currentIdentity in promotableCurrent {
+                guard let freshQuota = reconciled[currentIdentity.key],
+                      let currentAccountID = currentIdentity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines) else {
+                    continue
+                }
                 for legacyAccount in legacyAccounts where
                     legacyAccount.accountID?.trimmingCharacters(in: .whitespacesAndNewlines) == currentAccountID {
                     guard reconciled[legacyAccount.key].map({ $0.lastUpdated <= freshQuota.lastUpdated }) ?? true else {

--- a/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
+++ b/Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift
@@ -365,7 +365,7 @@ actor CodexCLIQuotaFetcher {
         for (key, quota) in await fetchLegacyQuotas() where results[key] == nil {
             results[key] = quota
         }
-        return results
+        return await promoteFreshLegacyAliases(in: results)
     }
 
     /// Fetches only the credential represented by the canonical account key.
@@ -453,6 +453,59 @@ actor CodexCLIQuotaFetcher {
     func reconcileLegacyAliases(
         in quotas: [String: ProviderQuotaData]
     ) async -> [String: ProviderQuotaData] {
+        Self.reconcileLegacyAliases(
+            in: quotas,
+            legacy: readLegacyIdentities(),
+            current: await currentAccountIdentities()
+        )
+    }
+
+    func promoteFreshLegacyAliases(
+        in quotas: [String: ProviderQuotaData]
+    ) async -> [String: ProviderQuotaData] {
+        Self.promoteFreshLegacyAliases(
+            in: quotas,
+            legacy: readLegacyIdentities(),
+            current: await currentAccountIdentities()
+        )
+    }
+
+    nonisolated static func promoteFreshLegacyAliases(
+        in quotas: [String: ProviderQuotaData],
+        legacy: [CodexQuotaAccountIdentity],
+        current: [CodexQuotaAccountIdentity]
+    ) -> [String: ProviderQuotaData] {
+        var promoted = quotas
+        let uniqueLegacyByAccountID = Dictionary(grouping: legacy.compactMap { identity -> (String, CodexQuotaAccountIdentity)? in
+            guard let accountID = identity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !accountID.isEmpty else { return nil }
+            return (accountID, identity)
+        }, by: \.0).compactMapValues { entries -> CodexQuotaAccountIdentity? in
+            let identities = entries.map(\.1)
+            guard Set(identities.map(\.key)).count == 1 else { return nil }
+            return identities.first
+        }
+        let currentByKey = Dictionary(grouping: current, by: \.key)
+
+        for (key, quota) in quotas {
+            let accountIDs = Set(currentByKey[key, default: []].compactMap { identity -> String? in
+                guard let accountID = identity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !accountID.isEmpty else { return nil }
+                return accountID
+            })
+            guard accountIDs.count == 1,
+                  let accountID = accountIDs.first,
+                  let legacyIdentity = uniqueLegacyByAccountID[accountID],
+                  legacyIdentity.key != key else { continue }
+            if promoted[legacyIdentity.key].map({ $0.lastUpdated <= quota.lastUpdated }) ?? true {
+                promoted[legacyIdentity.key] = quota
+            }
+            promoted.removeValue(forKey: key)
+        }
+        return promoted
+    }
+
+    private func currentAccountIdentities() async -> [CodexQuotaAccountIdentity] {
         var current = readAuthSources().map { source in
             let claims = source.auth.tokens?.idToken.flatMap(decodeJWT)
             return CodexQuotaAccountIdentity(
@@ -482,12 +535,7 @@ actor CodexCLIQuotaFetcher {
                 accountID: credential.accountID ?? claims?.accountId
             ))
         }
-
-        return Self.reconcileLegacyAliases(
-            in: quotas,
-            legacy: readLegacyIdentities(),
-            current: current
-        )
+        return current
     }
 
     nonisolated static func reconcileLegacyAliases(
@@ -504,6 +552,8 @@ actor CodexCLIQuotaFetcher {
 
         for (email, entries) in legacyByEmail {
             let legacyAccounts = entries.map(\.1)
+            guard legacyAccounts.contains(where: { reconciled[$0.key] != nil }) else { continue }
+
             let legacyAccountIDs = Set(legacyAccounts.compactMap { identity -> String? in
                 guard let accountID = identity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
                       !accountID.isEmpty else { return nil }
@@ -512,25 +562,13 @@ actor CodexCLIQuotaFetcher {
             let matchingCurrent = current.filter {
                 $0.email?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == email
             }
-            let promotableCurrent = matchingCurrent.filter { currentIdentity in
-                guard reconciled[currentIdentity.key] != nil,
+            for currentIdentity in matchingCurrent {
+                guard let freshQuota = reconciled[currentIdentity.key],
                       let currentAccountID = currentIdentity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
                       !currentAccountID.isEmpty,
-                      legacyAccounts.contains(where: {
-                          $0.accountID?.trimmingCharacters(in: .whitespacesAndNewlines) == currentAccountID
-                      }) else { return false }
-                return matchingCurrent.filter({ $0.key == currentIdentity.key }).allSatisfy {
+                      matchingCurrent.filter({ $0.key == currentIdentity.key }).allSatisfy({
                     $0.accountID?.trimmingCharacters(in: .whitespacesAndNewlines) == currentAccountID
-                }
-            }
-            guard legacyAccounts.contains(where: { reconciled[$0.key] != nil })
-                    || !promotableCurrent.isEmpty else { continue }
-
-            for currentIdentity in promotableCurrent {
-                guard let freshQuota = reconciled[currentIdentity.key],
-                      let currentAccountID = currentIdentity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines) else {
-                    continue
-                }
+                }) else { continue }
                 for legacyAccount in legacyAccounts where
                     legacyAccount.accountID?.trimmingCharacters(in: .whitespacesAndNewlines) == currentAccountID {
                     guard reconciled[legacyAccount.key].map({ $0.lastUpdated <= freshQuota.lastUpdated }) ?? true else {

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -1877,6 +1877,9 @@ final class QuotaViewModel {
             return
         }
         providerQuotas[account.provider, default: [:]][account.accountKey] = quota
+        if account.provider == .codex, let quotas = providerQuotas[.codex] {
+            providerQuotas[.codex] = await codexCLIFetcher.reconcileLegacyAliases(in: quotas)
+        }
         if let subscription {
             subscriptionInfos[account.provider, default: [:]][account.accountKey] = subscription
         }

--- a/Quotio/ViewModels/QuotaViewModel.swift
+++ b/Quotio/ViewModels/QuotaViewModel.swift
@@ -1876,9 +1876,14 @@ final class QuotaViewModel {
             }
             return
         }
-        providerQuotas[account.provider, default: [:]][account.accountKey] = quota
-        if account.provider == .codex, let quotas = providerQuotas[.codex] {
+        if account.provider == .codex {
+            let fresh = await codexCLIFetcher.promoteFreshLegacyAliases(in: [account.accountKey: quota])
+            var quotas = providerQuotas[.codex, default: [:]]
+            quotas.removeValue(forKey: account.accountKey)
+            quotas.merge(fresh) { _, fresh in fresh }
             providerQuotas[.codex] = await codexCLIFetcher.reconcileLegacyAliases(in: quotas)
+        } else {
+            providerQuotas[account.provider, default: [:]][account.accountKey] = quota
         }
         if let subscription {
             subscriptionInfos[account.provider, default: [:]][account.accountKey] = subscription

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -349,6 +349,32 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertEqual(reconciled["same@example.com-pro"]?.lastUpdated, freshDate)
     }
 
+    func testCodexQuotaReconciliationCreatesMissingMatchingLegacyAlias() {
+        let freshDate = Date(timeIntervalSince1970: 2_000)
+        let reconciled = CodexCLIQuotaFetcher.reconcileLegacyAliases(
+            in: [
+                "same@example.com": ProviderQuotaData(models: [], lastUpdated: freshDate),
+            ],
+            legacy: [
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com-pro",
+                    email: "same@example.com",
+                    accountID: "account-1"
+                ),
+            ],
+            current: [
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com",
+                    email: "same@example.com",
+                    accountID: "account-1"
+                ),
+            ]
+        )
+
+        XCTAssertEqual(Set(reconciled.keys), ["same@example.com-pro"])
+        XCTAssertEqual(reconciled["same@example.com-pro"]?.lastUpdated, freshDate)
+    }
+
     func testCodexQuotaReconciliationPreservesNewerLegacyQuota() {
         let staleDate = Date(timeIntervalSince1970: 1_000)
         let freshDate = Date(timeIntervalSince1970: 2_000)

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -407,6 +407,37 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertNil(promoted["same@example.com-team"])
     }
 
+    func testCodexFreshQuotaPromotionRejectsIdentityWithoutAccountID() {
+        let freshDate = Date(timeIntervalSince1970: 2_000)
+        let promoted = CodexCLIQuotaFetcher.promoteFreshLegacyAliases(
+            in: [
+                "same@example.com": ProviderQuotaData(models: [], lastUpdated: freshDate),
+            ],
+            legacy: [
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com-pro",
+                    email: "same@example.com",
+                    accountID: "account-1"
+                ),
+            ],
+            current: [
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com",
+                    email: "same@example.com",
+                    accountID: nil
+                ),
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com",
+                    email: "same@example.com",
+                    accountID: "account-1"
+                ),
+            ]
+        )
+
+        XCTAssertEqual(Set(promoted.keys), ["same@example.com"])
+        XCTAssertNil(promoted["same@example.com-pro"])
+    }
+
     func testCodexFailedRefreshDoesNotPromoteStaleQuotaToCurrentIdentity() {
         let staleDate = Date(timeIntervalSince1970: 1_000)
         let staleSnapshot = [

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -349,9 +349,9 @@ final class MonitorRuntimeTests: XCTestCase {
         XCTAssertEqual(reconciled["same@example.com-pro"]?.lastUpdated, freshDate)
     }
 
-    func testCodexQuotaReconciliationCreatesMissingMatchingLegacyAlias() {
+    func testCodexFreshQuotaPromotionCreatesMissingMatchingLegacyAlias() {
         let freshDate = Date(timeIntervalSince1970: 2_000)
-        let reconciled = CodexCLIQuotaFetcher.reconcileLegacyAliases(
+        let promoted = CodexCLIQuotaFetcher.promoteFreshLegacyAliases(
             in: [
                 "same@example.com": ProviderQuotaData(models: [], lastUpdated: freshDate),
             ],
@@ -371,8 +371,83 @@ final class MonitorRuntimeTests: XCTestCase {
             ]
         )
 
-        XCTAssertEqual(Set(reconciled.keys), ["same@example.com-pro"])
-        XCTAssertEqual(reconciled["same@example.com-pro"]?.lastUpdated, freshDate)
+        XCTAssertEqual(Set(promoted.keys), ["same@example.com-pro"])
+        XCTAssertEqual(promoted["same@example.com-pro"]?.lastUpdated, freshDate)
+    }
+
+    func testCodexFreshQuotaPromotionRequiresUniqueLegacyAlias() {
+        let freshDate = Date(timeIntervalSince1970: 2_000)
+        let promoted = CodexCLIQuotaFetcher.promoteFreshLegacyAliases(
+            in: [
+                "same@example.com": ProviderQuotaData(models: [], lastUpdated: freshDate),
+            ],
+            legacy: [
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com-pro",
+                    email: "same@example.com",
+                    accountID: "account-1"
+                ),
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com-team",
+                    email: "same@example.com",
+                    accountID: "account-1"
+                ),
+            ],
+            current: [
+                CodexQuotaAccountIdentity(
+                    key: "same@example.com",
+                    email: "same@example.com",
+                    accountID: "account-1"
+                ),
+            ]
+        )
+
+        XCTAssertEqual(Set(promoted.keys), ["same@example.com"])
+        XCTAssertNil(promoted["same@example.com-pro"])
+        XCTAssertNil(promoted["same@example.com-team"])
+    }
+
+    func testCodexFailedRefreshDoesNotPromoteStaleQuotaToCurrentIdentity() {
+        let staleDate = Date(timeIntervalSince1970: 1_000)
+        let staleSnapshot = [
+            "same@example.com": ProviderQuotaData(models: [], lastUpdated: staleDate),
+        ]
+        let current = [
+            CodexQuotaAccountIdentity(
+                key: "same@example.com",
+                email: "same@example.com",
+                accountID: "account-2"
+            ),
+        ]
+        let legacy = [
+            CodexQuotaAccountIdentity(
+                key: "same@example.com-pro",
+                email: "same@example.com",
+                accountID: "account-1"
+            ),
+            CodexQuotaAccountIdentity(
+                key: "same@example.com-team",
+                email: "same@example.com",
+                accountID: "account-2"
+            ),
+        ]
+
+        let failedRefresh = CodexCLIQuotaFetcher.promoteFreshLegacyAliases(
+            in: [:],
+            legacy: legacy,
+            current: current
+        )
+        var merged = staleSnapshot
+        merged.merge(failedRefresh) { _, fresh in fresh }
+        let reconciled = CodexCLIQuotaFetcher.reconcileLegacyAliases(
+            in: merged,
+            legacy: legacy,
+            current: current
+        )
+
+        XCTAssertEqual(Set(reconciled.keys), ["same@example.com"])
+        XCTAssertEqual(reconciled["same@example.com"]?.lastUpdated, staleDate)
+        XCTAssertNil(reconciled["same@example.com-team"])
     }
 
     func testCodexQuotaReconciliationPreservesNewerLegacyQuota() {


### PR DESCRIPTION
Codex Monitor credentials can produce email-keyed quota snapshots while menu bar selections use filename-based keys such as `email-pro`. This change reconciles fresh quota data by matching the stable Codex account ID even when no stale canonical snapshot exists, so every selected account keeps its quota visible in the menu bar.

- Promote fresh email-keyed quota data to the matching filename-based alias without requiring a pre-existing alias entry
- Reconcile Codex aliases after scoped account refreshes before snapshots and menu bar updates are persisted
- Add a regression test for the missing-canonical-snapshot case

## Verification

- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug -only-testing:QuotioTests/MonitorRuntimeTests test -quiet`
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug build -quiet`
- Reproduced with two real Codex accounts on macOS: persisted keys normalized to both `-pro` aliases and the menu bar rendered both stacked quota pairs (`100% / 97%` and `100% / 100%`)
