### PR TITLE
fix(proxy): wait for delayed dry-run startup

### DIFF
--- a/Quotio/Services/CompatibilityChecker.swift
+++ b/Quotio/Services/CompatibilityChecker.swift
@@ -44,10 +44,19 @@ actor CompatibilityChecker {
     ///   - port: The port to check
     ///   - host: The host (defaults to 127.0.0.1)
     /// - Returns: true if the proxy responds
-    func isHealthy(port: UInt16, host: String = "127.0.0.1", managementKey: String) async -> Bool {
+    func isHealthy(
+        port: UInt16,
+        host: String = "127.0.0.1",
+        managementKey: String,
+        requestTimeout: TimeInterval = 3
+    ) async -> Bool {
         let baseURL = "http://\(host):\(port)"
         
-        guard let request = makeManagementRequest(baseURL: baseURL, managementKey: managementKey) else {
+        guard let request = makeManagementRequest(
+            baseURL: baseURL,
+            managementKey: managementKey,
+            timeoutInterval: requestTimeout
+        ) else {
             return false
         }
         
@@ -81,14 +90,18 @@ actor CompatibilityChecker {
     
     // MARK: - Private Helpers
     
-    private func makeManagementRequest(baseURL: String, managementKey: String) -> URLRequest? {
+    private func makeManagementRequest(
+        baseURL: String,
+        managementKey: String,
+        timeoutInterval: TimeInterval = 3
+    ) -> URLRequest? {
         guard let url = URL(string: "\(baseURL)/v0/management/debug") else {
             return nil
         }
         
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
-        request.timeoutInterval = 3
+        request.timeoutInterval = timeoutInterval
         request.addValue("Bearer \(managementKey)", forHTTPHeaderField: "Authorization")
         request.addValue("application/json", forHTTPHeaderField: "Accept")
         return request

--- a/Quotio/Services/Proxy/CLIProxyManager.swift
+++ b/Quotio/Services/Proxy/CLIProxyManager.swift
@@ -1735,18 +1735,27 @@ extension CLIProxyManager {
         
         testProcess = process
         
-        // Wait for startup
-        try await Task.sleep(nanoseconds: 2_000_000_000)
-        
-        // Check if process is still running
-        guard process.isRunning else {
-            throw ProxyUpgradeError.dryRunFailed("Test proxy exited immediately")
-        }
-        
-        // Verify health
-        let isHealthy = await compatibilityChecker.isHealthy(port: port, managementKey: managementKey)
-        guard isHealthy else {
-            throw ProxyUpgradeError.dryRunFailed("Test proxy health check failed")
+        // Slow machines can take longer than a fixed startup delay to bind the
+        // management endpoint. Poll with a bounded request timeout instead of
+        // rejecting an otherwise healthy proxy after one early connection.
+        let startupOutcome = try await ProxyStartupHealthPoller().waitUntilReady(
+            isProcessRunning: { process.isRunning },
+            checkHealth: {
+                await self.compatibilityChecker.isHealthy(
+                    port: port,
+                    managementKey: managementKey,
+                    requestTimeout: 1
+                )
+            }
+        )
+
+        switch startupOutcome {
+        case .ready:
+            break
+        case .processExited:
+            throw ProxyUpgradeError.dryRunFailed("Test proxy exited before becoming healthy")
+        case .timedOut:
+            throw ProxyUpgradeError.dryRunFailed("Test proxy did not become healthy before startup timeout")
         }
         
         // Mark success - defer block will not cleanup

--- a/Quotio/Services/Proxy/ProxyStartupHealthPoller.swift
+++ b/Quotio/Services/Proxy/ProxyStartupHealthPoller.swift
@@ -1,0 +1,67 @@
+//
+//  ProxyStartupHealthPoller.swift
+//  Quotio - CLIProxyAPI GUI Wrapper
+//
+
+import Foundation
+
+/// Polls a newly launched proxy without assuming that every machine reaches
+/// the management endpoint within a fixed startup delay.
+@MainActor
+struct ProxyStartupHealthPoller {
+    enum Outcome: Equatable {
+        case ready
+        case processExited
+        case timedOut
+    }
+
+    nonisolated static let defaultTimeoutNanoseconds: UInt64 = 10_000_000_000
+    nonisolated static let defaultRetryDelayNanoseconds: UInt64 = 250_000_000
+
+    let timeoutNanoseconds: UInt64
+    let retryDelayNanoseconds: UInt64
+
+    init(
+        timeoutNanoseconds: UInt64 = Self.defaultTimeoutNanoseconds,
+        retryDelayNanoseconds: UInt64 = Self.defaultRetryDelayNanoseconds
+    ) {
+        self.timeoutNanoseconds = timeoutNanoseconds
+        self.retryDelayNanoseconds = max(1, retryDelayNanoseconds)
+    }
+
+    func waitUntilReady(
+        isProcessRunning: () -> Bool,
+        checkHealth: () async -> Bool,
+        sleep: (UInt64) async throws -> Void = { nanoseconds in
+            try await Task.sleep(nanoseconds: nanoseconds)
+        },
+        now: () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }
+    ) async throws -> Outcome {
+        let startedAt = now()
+        let (candidateDeadline, overflowed) = startedAt.addingReportingOverflow(timeoutNanoseconds)
+        let deadline = overflowed ? UInt64.max : candidateDeadline
+        var isFirstAttempt = true
+
+        while true {
+            guard isProcessRunning() else {
+                return .processExited
+            }
+
+            if !isFirstAttempt, now() >= deadline {
+                return .timedOut
+            }
+
+            if await checkHealth() {
+                return .ready
+            }
+
+            let currentTime = now()
+            guard currentTime < deadline else {
+                return .timedOut
+            }
+
+            try await sleep(min(retryDelayNanoseconds, deadline - currentTime))
+            isFirstAttempt = false
+        }
+    }
+}

--- a/QuotioTests/ProxyStartupHealthPollerTests.swift
+++ b/QuotioTests/ProxyStartupHealthPollerTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import Quotio
+
+@MainActor
+final class ProxyStartupHealthPollerTests: XCTestCase {
+    func testRetriesUntilDelayedProxyBecomesHealthy() async throws {
+        let poller = ProxyStartupHealthPoller(timeoutNanoseconds: 100, retryDelayNanoseconds: 25)
+        var healthChecks = 0
+        var sleeps: [UInt64] = []
+        var currentTime: UInt64 = 0
+
+        let outcome = try await poller.waitUntilReady(
+            isProcessRunning: { true },
+            checkHealth: {
+                healthChecks += 1
+                return healthChecks == 3
+            },
+            sleep: {
+                sleeps.append($0)
+                currentTime += $0
+            },
+            now: { currentTime }
+        )
+
+        XCTAssertEqual(outcome, .ready)
+        XCTAssertEqual(healthChecks, 3)
+        XCTAssertEqual(sleeps, [25, 25])
+    }
+
+    func testStopsBeforeAnotherHealthCheckWhenProcessExits() async throws {
+        let poller = ProxyStartupHealthPoller(timeoutNanoseconds: 100, retryDelayNanoseconds: 25)
+        var processChecks = 0
+        var healthChecks = 0
+        var sleeps = 0
+        var currentTime: UInt64 = 0
+
+        let outcome = try await poller.waitUntilReady(
+            isProcessRunning: {
+                processChecks += 1
+                return processChecks == 1
+            },
+            checkHealth: {
+                healthChecks += 1
+                return false
+            },
+            sleep: {
+                sleeps += 1
+                currentTime += $0
+            },
+            now: { currentTime }
+        )
+
+        XCTAssertEqual(outcome, .processExited)
+        XCTAssertEqual(healthChecks, 1)
+        XCTAssertEqual(sleeps, 1)
+    }
+
+    func testTimesOutAtDeadlineAndTruncatesFinalSleep() async throws {
+        let poller = ProxyStartupHealthPoller(timeoutNanoseconds: 60, retryDelayNanoseconds: 25)
+        var healthChecks = 0
+        var sleeps: [UInt64] = []
+        var currentTime: UInt64 = 0
+
+        let outcome = try await poller.waitUntilReady(
+            isProcessRunning: { true },
+            checkHealth: {
+                healthChecks += 1
+                return false
+            },
+            sleep: {
+                sleeps.append($0)
+                currentTime += $0
+            },
+            now: { currentTime }
+        )
+
+        XCTAssertEqual(outcome, .timedOut)
+        XCTAssertEqual(healthChecks, 3)
+        XCTAssertEqual(sleeps, [25, 25, 10])
+        XCTAssertEqual(currentTime, 60)
+    }
+
+    func testCancellationFromRetryDelayPropagates() async {
+        let poller = ProxyStartupHealthPoller(timeoutNanoseconds: 100, retryDelayNanoseconds: 25)
+
+        do {
+            _ = try await poller.waitUntilReady(
+                isProcessRunning: { true },
+                checkHealth: { false },
+                sleep: { _ in throw CancellationError() },
+                now: { 0 }
+            )
+            XCTFail("Expected cancellation to propagate")
+        } catch is CancellationError {
+            // Expected: CLIProxyManager's existing defer cleanup handles it.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testZeroTimeoutStillPerformsInitialProbe() async throws {
+        let poller = ProxyStartupHealthPoller(timeoutNanoseconds: 0, retryDelayNanoseconds: 25)
+        var healthChecks = 0
+
+        let outcome = try await poller.waitUntilReady(
+            isProcessRunning: { true },
+            checkHealth: {
+                healthChecks += 1
+                return true
+            },
+            sleep: { _ in XCTFail("A successful first probe must not sleep") },
+            now: { 0 }
+        )
+
+        XCTAssertEqual(outcome, .ready)
+        XCTAssertEqual(healthChecks, 1)
+    }
+
+    func testZeroRetryDelayIsClampedToAvoidBusyLoop() async throws {
+        let poller = ProxyStartupHealthPoller(timeoutNanoseconds: 2, retryDelayNanoseconds: 0)
+        var currentTime: UInt64 = 0
+        var sleeps: [UInt64] = []
+
+        let outcome = try await poller.waitUntilReady(
+            isProcessRunning: { true },
+            checkHealth: { false },
+            sleep: {
+                sleeps.append($0)
+                currentTime += $0
+            },
+            now: { currentTime }
+        )
+
+        XCTAssertEqual(outcome, .timedOut)
+        XCTAssertEqual(sleeps, [1, 1])
+    }
+}


### PR DESCRIPTION
## Summary

- replace the dry-run's fixed two-second delay and single health request with bounded polling
- use a monotonic ten-second startup deadline and a one-second timeout per localhost probe
- stop immediately when the child exits and distinguish process-exit from startup-timeout failures
- add deterministic coverage for delayed readiness, early exit, deadline handling, cancellation, and invalid timing inputs

## Root cause

In #510, the downloaded test proxy was still running, but Quotio reported `Test proxy health check failed`. The dry-run path waited exactly two seconds and made only one request to the management endpoint. A proxy that bound the endpoint shortly after that request was rejected and deleted even though it would have become healthy.

The new poller probes immediately and retries until a monotonic deadline. The one-second request timeout keeps the overall wait bounded to roughly eleven seconds even if a localhost connection accepts but does not respond.

## Safety

- affects only the temporary dry-run process used before promoting a downloaded version
- leaves active-proxy start, stop, port, configuration, promotion, rollback, and cleanup behavior unchanged
- preserves task cancellation so the existing deferred cleanup still runs

## Validation

- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test` — 309 tests passed, including 6 new startup-poller tests
- `xcodebuild -project Quotio.xcodeproj -scheme Quotio -configuration Debug CODE_SIGNING_ALLOWED=NO build` — succeeded
- Swift 6 standalone compile and behavior harness for the poller — passed
- isolated macOS/Xcode 26.1 run: https://github.com/Adkid-Zephyr/quotio/actions/runs/33256346347

Addresses #510.
