### PR TITLE
fix(keychain): stop legacy login-keychain prompts for external credentials

### DIFF
--- a/Quotio/Services/KeychainHelper.swift
+++ b/Quotio/Services/KeychainHelper.swift
@@ -188,7 +188,7 @@ enum KeychainHelper {
         let query = externalCredentialQuery(service: service, account: account)
 
         var result: AnyObject?
-        let status = performSecurityCall {
+        let status = performNonInteractiveSecurityCall {
             SecItemCopyMatching(query as CFDictionary, &result)
         }
         if status == errSecSuccess,
@@ -235,7 +235,7 @@ enum KeychainHelper {
             return false
         }
         let query = externalCredentialUpdateQuery(service: service, account: account)
-        let status = performSecurityCall {
+        let status = performNonInteractiveSecurityCall {
             SecItemUpdate(
                 query as CFDictionary,
                 [kSecValueData as String: newData] as CFDictionary
@@ -422,5 +422,32 @@ enum KeychainHelper {
         securityLock.lock()
         defer { securityLock.unlock() }
         return operation()
+    }
+
+    /// Run a keychain call against a credential owned by another app without letting
+    /// securityd show a password dialog.
+    ///
+    /// `LAContext.interactionNotAllowed` only governs the data-protection keychain. Items
+    /// written by other tools (Claude Code, Codex CLI) live in the legacy login keychain,
+    /// where access is enforced by securityd's ACL and partition-list checks. Those checks
+    /// ignore the `LAContext` flag and raise the "wants to access key ... in your keychain"
+    /// prompt whenever this app is not on the item's allow list. The allow list is reset
+    /// every time the owning tool rewrites the item (token refresh, account switch), so
+    /// "Always Allow" cannot stick and the prompt returns on the next background refresh.
+    ///
+    /// The only supported way to make that path fail silently is the process-wide
+    /// `SecKeychainSetUserInteractionAllowed(false)`, which turns the prompt into
+    /// `errSecAuthFailed` / `errSecInteractionNotAllowed`. The flag is global, so it is only
+    /// flipped while `securityLock` is held and is restored before the lock is released.
+    nonisolated private static func performNonInteractiveSecurityCall(
+        _ operation: () -> OSStatus
+    ) -> OSStatus {
+        performSecurityCall {
+            var previous: DarwinBoolean = true
+            SecKeychainGetUserInteractionAllowed(&previous)
+            SecKeychainSetUserInteractionAllowed(false)
+            defer { SecKeychainSetUserInteractionAllowed(previous.boolValue) }
+            return operation()
+        }
     }
 }

--- a/QuotioTests/MonitorRuntimeTests.swift
+++ b/QuotioTests/MonitorRuntimeTests.swift
@@ -186,6 +186,27 @@ final class MonitorRuntimeTests: XCTestCase {
         )
     }
 
+    /// External reads must never reach securityd with user interaction enabled: the legacy
+    /// login keychain ignores `LAContext.interactionNotAllowed` and would otherwise show the
+    /// "wants to access key" password dialog. The flag is process-global, so it must also be
+    /// restored once the call returns or every later keychain operation would fail silently.
+    func testExternalCredentialReadRestoresProcessInteractionFlag() {
+        var before: DarwinBoolean = false
+        XCTAssertEqual(SecKeychainGetUserInteractionAllowed(&before), errSecSuccess)
+
+        XCTAssertNil(KeychainHelper.readExternalCredential(service: "fixture.external.missing.\(UUID().uuidString)"))
+        XCTAssertFalse(KeychainHelper.compareAndSwapExternalCredential(
+            service: "fixture.external.missing.\(UUID().uuidString)",
+            account: "fixture-account",
+            expectedData: Data(),
+            newData: Data("unused".utf8)
+        ))
+
+        var after: DarwinBoolean = false
+        XCTAssertEqual(SecKeychainGetUserInteractionAllowed(&after), errSecSuccess)
+        XCTAssertEqual(after.boolValue, before.boolValue)
+    }
+
     func testMonitorProvidersDoNotRequireInstalledCLI() {
         let providers: Set<AIProvider> = [.codex, .claude, .factoryDroid, .devin, .grok, .openRouter, .amp]
 


### PR DESCRIPTION
## Summary

Quotio 0.30.0 still raises the macOS `login` keychain password dialog for credentials owned by other tools (`Claude Code-credentials`, `Codex Auth`), even after the user picks **Always Allow**. #504 made those reads non-interactive through `LAContext.interactionNotAllowed`, but that flag only governs the data-protection keychain. Items written by Claude Code and the Codex CLI live in the legacy login keychain, where securityd enforces access through the item's ACL and XARA partition list and ignores the `LAContext` flag.

This PR wraps the two external-credential calls (`SecItemCopyMatching` in `readExternalCredentialRecord`, `SecItemUpdate` in `compareAndSwapExternalCredential`) in `SecKeychainSetUserInteractionAllowed(false)`, which is the supported way to make the legacy path fail with `errSecAuthFailed` / `errSecInteractionNotAllowed` instead of prompting. Both statuses are already treated as "silently skip". The flag is process-global, so it is only flipped while `securityLock` is held and restored before the lock is released. The existing `LAContext` handling is kept for data-protection items.

## Why "Always Allow" cannot stick

`securityd` log on macOS 26 (Quotio 0.30.0, Developer ID `C48F8UHK3M`):

```
09:16:57 kcacl      user approved 'always allow' for /Applications/Quotio.app
09:16:57 integrity  adding XARA partition 'teamid:C48F8UHK3M' to list
09:23:27 <Claude Code-credentials rewritten by the owning CLI on token refresh>
09:32:02 integrity  ACL partition mismatch: client teamid:C48F8UHK3M ACL ("apple-tool:")
09:32:02 integrity  asking user about XARA partition for 'teamid:C48F8UHK3M'
09:32:02 kcacl      displaying keychain prompt for /Applications/Quotio.app
```

Every time the owning CLI rewrites the item (OAuth refresh, account switch) the partition list goes back to `apple-tool:` and the next background refresh prompts again. The dialog therefore returns several times a day regardless of what the user answers, and only the app can stop it by never asking interactively.

## Verification

- Ad-hoc signed probe binary reading `Claude Code-credentials` with `SecKeychainSetUserInteractionAllowed(false)`: returns `-25293 errSecAuthFailed`, no `SecurityAgent` process, no `asking user about XARA partition` line in `securityd`. The same read without the flag is what produced the dialog above.
- `xcodebuild test -scheme Quotio -destination 'platform=macOS'`: `** TEST SUCCEEDED **` (all existing tests plus the new one, macOS 26, Xcode 26.6)
- New test `testExternalCredentialReadRestoresProcessInteractionFlag` covers the flag being restored after read and compare-and-swap.

`SecKeychainSetUserInteractionAllowed` is marked deprecated with the rest of `SecKeychain`, but there is no data-protection equivalent for items other apps store in the login keychain, so the two calls are isolated in one helper with the rationale documented inline.

Fixes the remaining path from #447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147q2FhEeHqjGTvEusGBZSk
