### PR TITLE
feat(quota): add optional Fable weekly quota to menu panel

### DIFF
--- a/Packages/QuotioCore/Sources/QuotioDomain/Settings/PreferenceValues.swift
+++ b/Packages/QuotioCore/Sources/QuotioDomain/Settings/PreferenceValues.swift
@@ -93,6 +93,7 @@ public struct MenuBarPreferences: Equatable, Sendable {
     public var colorMode: MenuBarColorMode
     public var quotaDisplayMode: QuotaDisplayMode
     public var quotaDisplayStyle: QuotaDisplayStyle
+    public var showClaudeFableWeekly: Bool
     public var stackPairedQuotaMetrics: Bool
     public var hideSensitiveInfo: Bool
     public var totalUsageMode: TotalUsageMode
@@ -109,6 +110,7 @@ public struct MenuBarPreferences: Equatable, Sendable {
         quotaDisplayMode: QuotaDisplayMode = .used,
         quotaDisplayStyle: QuotaDisplayStyle = .card,
         stackPairedQuotaMetrics: Bool = true,
+        showClaudeFableWeekly: Bool = false,
         hideSensitiveInfo: Bool = false,
         totalUsageMode: TotalUsageMode = .sessionOnly,
         modelAggregationMode: ModelAggregationMode = .lowest,
@@ -123,6 +125,7 @@ public struct MenuBarPreferences: Equatable, Sendable {
         self.quotaDisplayMode = quotaDisplayMode
         self.quotaDisplayStyle = quotaDisplayStyle
         self.stackPairedQuotaMetrics = stackPairedQuotaMetrics
+        self.showClaudeFableWeekly = showClaudeFableWeekly
         self.hideSensitiveInfo = hideSensitiveInfo
         self.totalUsageMode = totalUsageMode
         self.modelAggregationMode = modelAggregationMode

--- a/Packages/QuotioCore/Sources/QuotioInfrastructure/Persistence/UserDefaultsPreferenceRepositories.swift
+++ b/Packages/QuotioCore/Sources/QuotioInfrastructure/Persistence/UserDefaultsPreferenceRepositories.swift
@@ -76,6 +76,7 @@ public final class UserDefaultsMenuBarPreferencesRepository: MenuBarPreferencesR
             quotaDisplayMode: QuotaDisplayMode(rawValue: defaults.string(forKey: "quotaDisplayMode") ?? "") ?? .used,
             quotaDisplayStyle: QuotaDisplayStyle(rawValue: defaults.string(forKey: "quotaDisplayStyle") ?? "") ?? .card,
             stackPairedQuotaMetrics: defaults.bool(forKey: "menuBarStackClaudeQuotaWindows"),
+            showClaudeFableWeekly: defaults.bool(forKey: "menuBarShowClaudeFableWeekly"),
             hideSensitiveInfo: defaults.bool(forKey: "hideSensitiveInfo"),
             totalUsageMode: TotalUsageMode(rawValue: defaults.string(forKey: "totalUsageMode") ?? "") ?? .sessionOnly,
             modelAggregationMode: ModelAggregationMode(rawValue: defaults.string(forKey: "modelAggregationMode") ?? "") ?? .lowest,
@@ -93,6 +94,7 @@ public final class UserDefaultsMenuBarPreferencesRepository: MenuBarPreferencesR
         defaults.set(preferences.quotaDisplayMode.rawValue, forKey: "quotaDisplayMode")
         defaults.set(preferences.quotaDisplayStyle.rawValue, forKey: "quotaDisplayStyle")
         defaults.set(preferences.stackPairedQuotaMetrics, forKey: "menuBarStackClaudeQuotaWindows")
+        defaults.set(preferences.showClaudeFableWeekly, forKey: "menuBarShowClaudeFableWeekly")
         defaults.set(preferences.hideSensitiveInfo, forKey: "hideSensitiveInfo")
         defaults.set(preferences.totalUsageMode.rawValue, forKey: "totalUsageMode")
         defaults.set(preferences.modelAggregationMode.rawValue, forKey: "modelAggregationMode")

--- a/Packages/QuotioCore/Sources/QuotioInfrastructure/Quota/ClaudeQuotaFetcher.swift
+++ b/Packages/QuotioCore/Sources/QuotioInfrastructure/Quota/ClaudeQuotaFetcher.swift
@@ -236,6 +236,19 @@ public actor ClaudeQuotaFetcher: QuotaFetching {
         name: name, percentage: max(0, min(100, 100 - used)),
         resetTime: value["resets_at"] as? String ?? "")
     }
+    if let limits = json["limits"] as? [[String: Any]],
+      let fable = limits.first(where: { limit in
+        let scope = limit["scope"] as? [String: Any]
+        let model = scope?["model"] as? [String: Any]
+        return limit["kind"] as? String == "weekly_scoped"
+          && (model?["display_name"] as? String)?.lowercased() == "fable"
+      }),
+      let used = (fable["percent"] as? NSNumber)?.doubleValue, used.isFinite
+    {
+      metrics.insert(QuotaMetric(
+        name: "seven-day-fable", percentage: max(0, min(100, 100 - used)),
+        resetTime: fable["resets_at"] as? String ?? ""), at: min(2, metrics.count))
+    }
     if let extra = json["extra_usage"] as? [String: Any], extra["is_enabled"] as? Bool == true,
       let usedPercent = (extra["utilization"] as? NSNumber)?.doubleValue
     {

--- a/Packages/QuotioCore/Sources/QuotioPresentation/MenuBar/MenuBarSettingsManager.swift
+++ b/Packages/QuotioCore/Sources/QuotioPresentation/MenuBar/MenuBarSettingsManager.swift
@@ -427,6 +427,11 @@ public final class MenuBarSettingsManager {
         didSet { persist() }
     }
     
+    /// Show the separate Fable weekly limit in the menu panel.
+    public var showClaudeFableWeekly: Bool {
+        didSet { persist() }
+    }
+
     /// Whether to hide sensitive information (emails, account names)
     public var hideSensitiveInfo: Bool {
         didSet { persist() }
@@ -471,6 +476,7 @@ public final class MenuBarSettingsManager {
             quotaDisplayMode: quotaDisplayMode,
             quotaDisplayStyle: quotaDisplayStyle,
             stackPairedQuotaMetrics: stackPairedQuotaMetrics,
+            showClaudeFableWeekly: showClaudeFableWeekly,
             hideSensitiveInfo: hideSensitiveInfo,
             totalUsageMode: totalUsageMode,
             modelAggregationMode: modelAggregationMode,
@@ -490,6 +496,7 @@ public final class MenuBarSettingsManager {
         self.quotaDisplayMode = preferences.quotaDisplayMode
         self.quotaDisplayStyle = preferences.quotaDisplayStyle
         self.stackPairedQuotaMetrics = preferences.stackPairedQuotaMetrics
+        self.showClaudeFableWeekly = preferences.showClaudeFableWeekly
         self.hideSensitiveInfo = preferences.hideSensitiveInfo
         self.totalUsageMode = preferences.totalUsageMode
         self.modelAggregationMode = preferences.modelAggregationMode

--- a/Packages/QuotioCore/Sources/QuotioPresentation/MenuBar/StatusBarMenuRenderer.swift
+++ b/Packages/QuotioCore/Sources/QuotioPresentation/MenuBar/StatusBarMenuRenderer.swift
@@ -862,24 +862,33 @@ private struct MenuAccountCardView: View {
     // MARK: - Quota Content
     
     private var quotaContentSection: some View {
+        let quotaModels = data.models.filter {
+            provider != .claude || settings.showClaudeFableWeekly || $0.name != "seven-day-fable"
+        }
         let isCardStyle = displayStyle == .card
         let models: [ModelBadgeData] = {
             if isAntigravity {
                 return antigravityGroups.map { ModelBadgeData(name: $0.name, percentage: $0.percentage, resetTime: $0.resetTime) }
             } else {
-                let meterModels = data.models.filter { !$0.isStandaloneMetric }.map {
-                    ModelBadgeData(name: $0.displayName, percentage: $0.percentage, resetTime: $0.resetTime)
+                var meterModels = quotaModels.filter { !$0.isStandaloneMetric }.map {
+                    ModelBadgeData(name: provider == .claude && settings.showClaudeFableWeekly && $0.name == "five-hour-session"
+                                   ? "quota.metric.fiveHourCompact".localized() : $0.displayName,
+                                   percentage: $0.percentage, resetTime: $0.resetTime)
+                }
+                if isCardStyle && provider == .claude && settings.showClaudeFableWeekly && !quotaModels.contains(where: { $0.name == "seven-day-fable" }) {
+                    meterModels.insert(ModelBadgeData(name: "quota.metric.fableWeekly".localized(), percentage: -1, resetTime: ""),
+                                       at: min(2, meterModels.count))
                 }
                 guard isCardStyle else { return meterModels }
-                let standaloneModels = data.models.filter(\.isStandaloneMetric).map {
+                let standaloneModels = quotaModels.filter(\.isStandaloneMetric).map {
                     ModelBadgeData(name: $0.displayName, percentage: $0.percentage, resetTime: $0.resetTime, usage: $0.formattedUsage)
                 }
                 return meterModels + standaloneModels
             }
         }()
-        let standaloneModels = isAntigravity || isCardStyle ? [] : data.models.filter(\.isStandaloneMetric)
+        let standaloneModels = isAntigravity || isCardStyle ? [] : quotaModels.filter(\.isStandaloneMetric)
         let factorySections = provider == .factoryDroid
-            ? FactoryDroidQuotaSection.sections(from: data.models.filter { !$0.isStandaloneMetric })
+            ? FactoryDroidQuotaSection.sections(from: quotaModels.filter { !$0.isStandaloneMetric })
             : []
         
         return VStack(spacing: 8) {
@@ -898,6 +907,8 @@ private struct MenuAccountCardView: View {
                         })
                     }
                 }
+            } else if provider == .claude && settings.showClaudeFableWeekly && isCardStyle {
+                CardGridLayout(models: models, displayMode: settings.quotaDisplayMode, columnCount: 3)
             } else if !models.isEmpty {
                 quotaLayout(models: models)
             }
@@ -1965,27 +1976,23 @@ private struct RingGridLayout: View {
 private struct CardGridLayout: View {
     let models: [ModelBadgeData]
     let displayMode: QuotaDisplayMode
+    var columnCount: Int = 2
 
     private var columns: [GridItem] {
-        // Single metric: full width. Multiple: 2 columns
-        if models.count == 1 {
-            return [GridItem(.flexible())]
-        } else {
-            return [GridItem(.flexible()), GridItem(.flexible())]
-        }
+        Array(repeating: GridItem(.flexible()), count: min(max(models.count, 1), columnCount))
     }
-    
+
     var body: some View {
         LazyVGrid(columns: columns, spacing: 8) {
             ForEach(models, id: \.name) { (model: ModelBadgeData) in
                 VStack(alignment: .leading, spacing: 4) {
-                    HStack {
+                    HStack(spacing: columnCount == 3 ? 4 : nil) {
                         Text(model.name)
                             .font(.system(size: 10, weight: .medium, design: .rounded))
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
-                        Spacer()
-                        if let resetTime = model.formattedResetTime {
+                        Spacer(minLength: columnCount == 3 ? 0 : nil)
+                        if columnCount < 3, let resetTime = model.formattedResetTime {
                             Text(resetTime)
                                 .font(.system(size: 9, design: .rounded))
                                 .foregroundStyle(.tertiary)
@@ -2012,6 +2019,7 @@ private struct CardGridLayout: View {
                 .padding(8)
                 .background(Color.secondary.opacity(0.05))
                 .clipShape(RoundedRectangle(cornerRadius: 8))
+                .menuNativeTooltip(model.name + (model.formattedResetTime.map { " · " + $0 } ?? ""))
             }
         }
     }

--- a/Packages/QuotioCore/Sources/QuotioPresentation/MenuBar/StatusBarMenuRenderer.swift
+++ b/Packages/QuotioCore/Sources/QuotioPresentation/MenuBar/StatusBarMenuRenderer.swift
@@ -1996,36 +1996,42 @@ private struct CardGridLayout: View {
     var body: some View {
         LazyVGrid(columns: columns, spacing: 8) {
             ForEach(models, id: \.name) { (model: ModelBadgeData) in
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: columnCount == 3 ? 4 : nil) {
-                        Text(model.name)
-                            .font(.system(size: 10, weight: .medium, design: .rounded))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                        Spacer(minLength: columnCount == 3 ? 0 : nil)
-                        if !showsResetBelow, let resetTime = model.formattedResetTime {
-                            Text(resetTime)
-                                .font(.system(size: 9, design: .rounded))
-                                .foregroundStyle(.tertiary)
+                VStack(alignment: .trailing, spacing: 4) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack(spacing: columnCount == 3 ? 4 : nil) {
+                            Text(model.name)
+                                .font(.system(size: 10, weight: .medium, design: .rounded))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                            Spacer(minLength: columnCount == 3 ? 0 : nil)
+                            if !showsResetBelow, let resetTime = model.formattedResetTime {
+                                Text(resetTime)
+                                    .font(.system(size: 9, design: .rounded))
+                                    .foregroundStyle(.tertiary)
+                            }
+                            if let usage = model.usage {
+                                Text(usage)
+                                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                                    .foregroundStyle(.primary)
+                            } else {
+                                Text(menuPercentText(remainingPercent: model.percentage, displayMode: displayMode))
+                                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                                    .foregroundStyle(menuStatusColor(remainingPercent: model.percentage, displayMode: displayMode))
+                            }
                         }
-                        if let usage = model.usage {
-                            Text(usage)
-                                .font(.system(size: 10, weight: .bold, design: .monospaced))
-                                .foregroundStyle(.primary)
-                        } else {
-                            Text(menuPercentText(remainingPercent: model.percentage, displayMode: displayMode))
-                                .font(.system(size: 10, weight: .bold, design: .monospaced))
-                                .foregroundStyle(menuStatusColor(remainingPercent: model.percentage, displayMode: displayMode))
-                        }
-                    }
 
-                    if model.usage == nil {
-                        ModernProgressBar(
-                            percentage: model.percentage,
-                            height: 4,
-                            displayMode: displayMode
-                        )
+                        if model.usage == nil {
+                            ModernProgressBar(
+                                percentage: model.percentage,
+                                height: 4,
+                                displayMode: displayMode
+                            )
+                        }
                     }
+                    .padding(8)
+                    .background(Color.secondary.opacity(0.05))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .menuNativeTooltip(model.name + (model.formattedResetTime.map { " · " + $0 } ?? ""))
                     if showsResetBelow {
                         Text(model.formattedResetTime ?? "—")
                             .font(.system(size: 9, design: .rounded))
@@ -2034,10 +2040,6 @@ private struct CardGridLayout: View {
                             .frame(maxWidth: .infinity, alignment: .trailing)
                     }
                 }
-                .padding(8)
-                .background(Color.secondary.opacity(0.05))
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-                .menuNativeTooltip(model.name + (model.formattedResetTime.map { " · " + $0 } ?? ""))
             }
         }
     }

--- a/Packages/QuotioCore/Sources/QuotioPresentation/MenuBar/StatusBarMenuRenderer.swift
+++ b/Packages/QuotioCore/Sources/QuotioPresentation/MenuBar/StatusBarMenuRenderer.swift
@@ -756,7 +756,9 @@ private struct MenuAccountCardView: View {
             
             quotaContentSection
             
-            footerSection
+            if provider != .claude {
+                footerSection
+            }
         }
         .padding(12)
         .background(
@@ -784,6 +786,14 @@ private struct MenuAccountCardView: View {
                 .lineLimit(1)
             
             Spacer()
+
+            if provider == .claude {
+                Text(data.lastUpdated.formatted(.relative(presentation: .named)))
+                    .font(.system(size: 9, design: .rounded))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
 
             Button(action: onRefresh) {
                 if isRefreshing {
@@ -908,7 +918,7 @@ private struct MenuAccountCardView: View {
                     }
                 }
             } else if provider == .claude && settings.showClaudeFableWeekly && isCardStyle {
-                CardGridLayout(models: models, displayMode: settings.quotaDisplayMode, columnCount: 3)
+                CardGridLayout(models: models, displayMode: settings.quotaDisplayMode, columnCount: 3, showsResetBelow: true)
             } else if !models.isEmpty {
                 quotaLayout(models: models)
             }
@@ -938,7 +948,7 @@ private struct MenuAccountCardView: View {
         case .ring:
             RingGridLayout(models: models, displayMode: settings.quotaDisplayMode)
         case .card:
-            CardGridLayout(models: models, displayMode: settings.quotaDisplayMode)
+            CardGridLayout(models: models, displayMode: settings.quotaDisplayMode, showsResetBelow: provider == .claude)
         }
     }
     
@@ -1977,6 +1987,7 @@ private struct CardGridLayout: View {
     let models: [ModelBadgeData]
     let displayMode: QuotaDisplayMode
     var columnCount: Int = 2
+    var showsResetBelow: Bool = false
 
     private var columns: [GridItem] {
         Array(repeating: GridItem(.flexible()), count: min(max(models.count, 1), columnCount))
@@ -1992,7 +2003,7 @@ private struct CardGridLayout: View {
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                         Spacer(minLength: columnCount == 3 ? 0 : nil)
-                        if columnCount < 3, let resetTime = model.formattedResetTime {
+                        if !showsResetBelow, let resetTime = model.formattedResetTime {
                             Text(resetTime)
                                 .font(.system(size: 9, design: .rounded))
                                 .foregroundStyle(.tertiary)
@@ -2014,6 +2025,13 @@ private struct CardGridLayout: View {
                             height: 4,
                             displayMode: displayMode
                         )
+                    }
+                    if showsResetBelow {
+                        Text(model.formattedResetTime ?? "—")
+                            .font(.system(size: 9, design: .rounded))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
                     }
                 }
                 .padding(8)

--- a/Packages/QuotioCore/Sources/QuotioPresentation/MenuBar/StatusBarMenuRenderer.swift
+++ b/Packages/QuotioCore/Sources/QuotioPresentation/MenuBar/StatusBarMenuRenderer.swift
@@ -2035,9 +2035,10 @@ private struct CardGridLayout: View {
                     if showsResetBelow {
                         Text(model.formattedResetTime ?? "—")
                             .font(.system(size: 9, design: .rounded))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(.tertiary)
                             .lineLimit(1)
                             .frame(maxWidth: .infinity, alignment: .trailing)
+                            .padding(.trailing, 8)
                     }
                 }
             }

--- a/Packages/QuotioCore/Sources/QuotioPresentation/MenuBar/StatusBarMenuSnapshot.swift
+++ b/Packages/QuotioCore/Sources/QuotioPresentation/MenuBar/StatusBarMenuSnapshot.swift
@@ -22,6 +22,7 @@ struct StatusBarMenuProviderSnapshot: Equatable, Sendable {
 struct StatusBarMenuDisplaySettings: Equatable, Sendable {
     let quotaDisplayMode: QuotaDisplayMode
     let quotaDisplayStyle: QuotaDisplayStyle
+    let showClaudeFableWeekly: Bool
     let hideSensitiveInfo: Bool
     let modelAggregationMode: ModelAggregationMode
 
@@ -117,6 +118,7 @@ public enum StatusBarMenuSnapshotMapper {
             displaySettings: StatusBarMenuDisplaySettings(
                 quotaDisplayMode: menuBarPreferences.quotaDisplayMode,
                 quotaDisplayStyle: menuBarPreferences.quotaDisplayStyle,
+                showClaudeFableWeekly: menuBarPreferences.showClaudeFableWeekly,
                 hideSensitiveInfo: menuBarPreferences.hideSensitiveInfo,
                 modelAggregationMode: menuBarPreferences.modelAggregationMode
             ),

--- a/Packages/QuotioCore/Sources/QuotioPresentation/Quota/QuotaPresentation.swift
+++ b/Packages/QuotioCore/Sources/QuotioPresentation/Quota/QuotaPresentation.swift
@@ -184,6 +184,7 @@ public extension QuotaMetric {
         case "cursor-usage", "trae-usage", "windsurf-usage": "Usage"
         case "five-hour-session": "Session"
         case "seven-day-weekly", "weekly-usage": "Weekly"
+        case "seven-day-fable": "quota.metric.fableWeekly".localizedStatic()
         case "seven-day-sonnet", "sonnet-only": "Sonnet"
         case "seven-day-opus": "Opus"
         case "extra-usage": "Extra"

--- a/Packages/QuotioCore/Sources/QuotioPresentation/Screens/SettingsScreen.swift
+++ b/Packages/QuotioCore/Sources/QuotioPresentation/Screens/SettingsScreen.swift
@@ -1555,6 +1555,12 @@ struct MenuBarSettingsSection: View {
             Toggle("settings.menubar.showIcon".localized(), isOn: showMenuBarIconBinding)
             
             if settings.showMenuBarIcon {
+                Toggle("settings.menubar.showClaudeFableWeekly".localized(), isOn: Binding(
+                    get: { settings.showClaudeFableWeekly },
+                    set: { settings.showClaudeFableWeekly = $0 }
+                ))
+                .help("settings.menubar.showClaudeFableWeekly.help".localized())
+
                 Toggle("settings.menubar.showQuota".localized(), isOn: showQuotaBinding)
                 
                 if settings.showQuotaInMenuBar {

--- a/Packages/QuotioCore/Tests/QuotioInfrastructureTests/ClaudeCodexQuotaFetcherTests.swift
+++ b/Packages/QuotioCore/Tests/QuotioInfrastructureTests/ClaudeCodexQuotaFetcherTests.swift
@@ -6,6 +6,14 @@ import XCTest
 @testable import QuotioInfrastructure
 
 final class ClaudeCodexQuotaFetcherTests: XCTestCase {
+  func testClaudeMapsFableWeeklyScopedLimitIndependently() throws {
+    let data = Data(#"{"five_hour":{"utilization":25},"seven_day":{"utilization":70},"limits":[{"kind":"weekly_scoped","percent":12,"scope":{"model":{"display_name":"Sonnet"}}},{"kind":"weekly_scoped","percent":67,"resets_at":"2030-01-02T00:00:00Z","scope":{"model":{"display_name":"Fable"}}}]}"#.utf8)
+    let quota = try XCTUnwrap(ClaudeQuotaFetcher.mapUsage(data))
+    XCTAssertEqual(quota.models.map(\.name), ["five-hour-session", "seven-day-weekly", "seven-day-fable"])
+    XCTAssertEqual(quota.models.map(\.percentage), [75, 30, 33])
+    XCTAssertEqual(quota.models.last?.resetTime, "2030-01-02T00:00:00Z")
+  }
+
   func testClaudeMapsStableMetricsAndUsesSameRequestInBothModes() async throws {
     let body =
       #"{"five_hour":{"utilization":25,"resets_at":"2030-01-01T00:00:00Z"},"seven_day":{"utilization":70,"resets_at":null},"extra_usage":{"is_enabled":true,"monthly_limit":200,"used_credits":50,"utilization":25}}"#

--- a/Packages/QuotioCore/Tests/QuotioInfrastructureTests/UserDefaultsPreferenceRepositoriesTests.swift
+++ b/Packages/QuotioCore/Tests/QuotioInfrastructureTests/UserDefaultsPreferenceRepositoriesTests.swift
@@ -103,6 +103,7 @@ final class UserDefaultsPreferenceRepositoriesTests: XCTestCase {
         let appShell = UserDefaultsAppShellPreferencesRepository(defaults: defaults).load()
 
         XCTAssertEqual(menu, MenuBarPreferences())
+        XCTAssertFalse(menu.showClaudeFableWeekly)
         XCTAssertEqual(refresh, RefreshPreferences())
         XCTAssertEqual(warmup, WarmupPreferences())
         XCTAssertEqual(appearance, AppearancePreferences())
@@ -131,6 +132,7 @@ final class UserDefaultsPreferenceRepositoriesTests: XCTestCase {
             quotaDisplayMode: .remaining,
             quotaDisplayStyle: .ring,
             stackPairedQuotaMetrics: false,
+            showClaudeFableWeekly: true,
             hideSensitiveInfo: true,
             totalUsageMode: .combined,
             modelAggregationMode: .average,

--- a/Packages/QuotioCore/Tests/QuotioPresentationTests/StatusBarMenuTests.swift
+++ b/Packages/QuotioCore/Tests/QuotioPresentationTests/StatusBarMenuTests.swift
@@ -45,6 +45,7 @@ final class StatusBarMenuSnapshotMapperTests: XCTestCase {
             selectedProvider: .amp,
             quotaDisplayMode: .remaining,
             quotaDisplayStyle: .ring,
+            showClaudeFableWeekly: true,
             hideSensitiveInfo: true,
             modelAggregationMode: .average
         )
@@ -73,6 +74,7 @@ final class StatusBarMenuSnapshotMapperTests: XCTestCase {
         XCTAssertTrue(snapshot.isLoadingQuotas)
         XCTAssertEqual(snapshot.displaySettings.quotaDisplayMode, .remaining)
         XCTAssertEqual(snapshot.displaySettings.quotaDisplayStyle, .ring)
+        XCTAssertTrue(snapshot.displaySettings.showClaudeFableWeekly)
         XCTAssertTrue(snapshot.displaySettings.hideSensitiveInfo)
         XCTAssertEqual(snapshot.displaySettings.modelAggregationMode, .average)
         XCTAssertEqual(snapshot.appearanceMode, .dark)

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -19896,6 +19896,38 @@
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "每日" } }
       }
     },
+    "quota.metric.fiveHourCompact" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "5h" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "5h" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "5 giờ" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "5小时" } }
+      }
+    },
+    "quota.metric.fableWeekly" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Fable 7d" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Fable 7j" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Fable 7 ngày" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Fable 7天" } }
+      }
+    },
+    "settings.menubar.showClaudeFableWeekly" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Show Claude Fable weekly quota in menu" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Afficher le quota hebdomadaire Fable dans le menu" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Hiện hạn mức Fable hàng tuần trong menu" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "在菜单中显示 Claude Fable 每周配额" } }
+      }
+    },
+    "settings.menubar.showClaudeFableWeekly.help" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Adds Fable 7d beside the session and weekly limits. Hover a card to see its reset time." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ajoute Fable 7j aux limites de session et de semaine. Survolez une carte pour voir sa réinitialisation." } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Thêm Fable 7 ngày cạnh hạn mức phiên và tuần. Di chuột lên thẻ để xem thời gian đặt lại." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "在会话和每周配额旁添加 Fable 7天。将鼠标悬停在卡片上可查看重置时间。" } }
+      }
+    },
     "quota.metric.fiveHour" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "5-hour" } },

--- a/Quotio/Localizable.xcstrings
+++ b/Quotio/Localizable.xcstrings
@@ -19922,10 +19922,10 @@
     },
     "settings.menubar.showClaudeFableWeekly.help" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Adds Fable 7d beside the session and weekly limits. Hover a card to see its reset time." } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ajoute Fable 7j aux limites de session et de semaine. Survolez une carte pour voir sa réinitialisation." } },
-        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Thêm Fable 7 ngày cạnh hạn mức phiên và tuần. Di chuột lên thẻ để xem thời gian đặt lại." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "在会话和每周配额旁添加 Fable 7天。将鼠标悬停在卡片上可查看重置时间。" } }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Adds Fable 7d beside the session and weekly limits. Reset times appear below the usage bars." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ajoute Fable 7j aux limites de session et de semaine. Les délais de réinitialisation apparaissent sous les barres." } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Thêm Fable 7 ngày cạnh hạn mức phiên và tuần. Thời gian đặt lại hiển thị bên dưới thanh mức dùng." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "在会话和每周配额旁添加 Fable 7天。重置时间显示在用量条下方。" } }
       }
     },
     "quota.metric.fiveHour" : {


### PR DESCRIPTION
Claude's OAuth usage response can include a separate weekly Fable limit under `limits[]`. Quotio currently ignores it, so the menu panel only shows the session and ordinary weekly limits.

This adds **Settings → Menu Bar → Show Claude Fable weekly quota in menu**, disabled by default. Enabling it shows **5h | Weekly | Fable 7d** using the existing compact Card layout. For Claude only, reset countdowns appear outside each usage card, immediately below and aligned right, and the last-updated timestamp sits beside the refresh button. Other providers keep their existing layout. Ring and Lowest Bar retain their selected layouts, and disabling the toggle restores the existing menu presentation.

- Maps only the `weekly_scoped` limit whose `scope.model.display_name` is `Fable`, using its own `percent` and `resets_at` values.
- Persists the preference through the existing preferences repository and menu snapshot. Other quota metrics are retained; missing Fable data is shown as `—` in Card mode without displacing the real bottleneck in Lowest Bar mode.
- Includes localized labels/help for all four supported languages. The toggle affects menu visibility; fetched Fable data remains available to the normal quota views.

Validation: 539 package tests passed, plus the focused menu-snapshot tests after adding the preference assertion. Parser and preference round-trip coverage use synthetic data. Live Fable data and Settings OFF/ON/relaunch behavior were checked on a local build based on the stable release; this PR is ported to current `master`. The current-master macOS app build passed. The reset-layout follow-up also passed 32 related tests and both app builds; the installed menu was visually checked alongside unchanged Codex cards.
